### PR TITLE
fix error condition in ReadOnlyKeywordJsonConverter

### DIFF
--- a/JsonSchema.Tests/SerializationTests.cs
+++ b/JsonSchema.Tests/SerializationTests.cs
@@ -32,6 +32,8 @@ namespace Json.Schema.Tests
 		[TestCase("{\"additionalItems\":true}")]
 		[TestCase("{\"additionalItems\":false}")]
 		[TestCase("{\"additionalItems\":{\"$id\":\"http://some.site/schema\"}}")]
+		[TestCase("{\"readOnly\":true}")]
+		[TestCase("{\"readOnly\":false}")]
 		public void RoundTrip(string text)
 		{
 			var schema = JsonSchema.FromText(text);

--- a/JsonSchema/ReadOnlyKeyword.cs
+++ b/JsonSchema/ReadOnlyKeyword.cs
@@ -44,7 +44,7 @@ namespace Json.Schema
 	{
 		public override ReadOnlyKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			if (reader.TokenType != JsonTokenType.True || reader.TokenType != JsonTokenType.False)
+			if (reader.TokenType != JsonTokenType.True && reader.TokenType != JsonTokenType.False)
 				throw new JsonException("Expected boolean");
 
 			var str = reader.GetBoolean();


### PR DESCRIPTION
Wasn't quite sure how you'd test this (I wasn't able to load the `Suite` tests - in VS) so I added just one of the most basic ones I could find. Please let me know how to improve if required.