### PR TITLE
Fix race condition in EnumStringConverter, fix name that is added to required list in ObjectSchemaGenerator

### DIFF
--- a/Json.More.Tests/Json.More.Tests.csproj
+++ b/Json.More.Tests/Json.More.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+	  <RootNamespace>Json.More.Tests</RootNamespace>
+	  <SignAssembly>true</SignAssembly>
+	  <AssemblyOriginatorKeyFile>../json-everything.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+	  <PackageReference Include="JunitXml.TestLogger" Version="2.1.32" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Json.More\Json.More.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Json.More.Tests/UnitTest1.cs
+++ b/Json.More.Tests/UnitTest1.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NUnit.Framework;
+
+namespace Json.More.Tests
+{
+	public class EnumStringConverterTests
+	{
+		class ConversionTest
+		{
+			[JsonConverter(typeof(EnumStringConverter<DayOfWeek>))]
+			public DayOfWeek Day { get; set; }
+		}
+
+		[Test]
+		public void DayOfWeekAsPropertyIsConverted()
+		{
+			var expected = "{\"Day\":\"Wednesday\"}";
+			var actual = JsonSerializer.Serialize(new ConversionTest {Day = DayOfWeek.Wednesday});
+
+			Assert.AreEqual(expected, actual);
+		}
+
+		[JsonConverter(typeof(EnumStringConverter<CustomEnum>))]
+		public enum CustomEnum
+		{
+			Zero,
+			[System.ComponentModel.Description("one")]
+			One,
+			Two
+		}
+
+		[TestCase(CustomEnum.Zero, "Zero")]
+		[TestCase(CustomEnum.One, "one")]
+		[TestCase(CustomEnum.Two, "Two")]
+		public void CustomEnumIsConverted(CustomEnum value, string serializedValue)
+		{
+			var expected = $"\"{serializedValue}\"";
+			var actual = JsonSerializer.Serialize(value);
+
+			Assert.AreEqual(expected, actual);
+		}
+	}
+}

--- a/Json.More/EnumStringConverter.cs
+++ b/Json.More/EnumStringConverter.cs
@@ -151,10 +151,10 @@ namespace Json.More
 
 		private static void EnsureMap()
 		{
-			if (_writeValues != null) return;
+			if (_readValues != null && _writeValues != null) return;
 			lock (_lock)
 			{
-				if (_writeValues != null) return;
+				if (_readValues != null && _writeValues != null) return;
 
 				var map = typeof(T).GetFields()
 					.Where(f => !f.IsSpecialName)

--- a/Json.More/EnumStringConverter.cs
+++ b/Json.More/EnumStringConverter.cs
@@ -151,10 +151,10 @@ namespace Json.More
 
 		private static void EnsureMap()
 		{
-			if (_readValues != null) return;
+			if (_writeValues != null) return;
 			lock (_lock)
 			{
-				if (_readValues != null) return;
+				if (_writeValues != null) return;
 
 				var map = typeof(T).GetFields()
 					.Where(f => !f.IsSpecialName)

--- a/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
+++ b/JsonSchema.Generation.Tests/SchemaGenerationTests.cs
@@ -146,6 +146,13 @@ namespace Json.Schema.Generation.Tests
 			[Pattern("^[a-z0-9_]$")]
 			public string String { get; set; }
 
+			[Required]
+			public string RequiredString { get; set; }
+
+			[JsonPropertyName("rename-this-required-string")]
+			[Required]
+			public string RenameThisRequiredString { get; set; }
+
 			[MinItems(5)]
 			[MaxItems(10)]
 			public List<bool> ListOfBool { get; set; }
@@ -165,6 +172,7 @@ namespace Json.Schema.Generation.Tests
 
 			[JsonIgnore]
 			public int IgnoreThis { get; set; }
+
 			[JsonPropertyName("rename-this")]
 			public string RenameThis { get; set; }
 
@@ -206,6 +214,12 @@ namespace Json.Schema.Generation.Tests
 						.Type(SchemaValueType.String)
 						.MaxLength(10)
 						.Pattern("^[a-z0-9_]$")
+					),
+					("RequiredString", new JsonSchemaBuilder()
+						.Type(SchemaValueType.String)
+					),
+					("rename-this-required-string", new JsonSchemaBuilder()
+						.Type(SchemaValueType.String)
 					),
 					("ListOfBool", new JsonSchemaBuilder()
 						.Type(SchemaValueType.Array)
@@ -251,7 +265,7 @@ namespace Json.Schema.Generation.Tests
 						)
 					)
 				)
-				.Required(nameof(GenerationTarget.Integer))
+				.Required(nameof(GenerationTarget.Integer), "RequiredString", "rename-this-required-string")
 				.Defs(
 					("integer", new JsonSchemaBuilder()
 						.Type(SchemaValueType.Integer)

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -52,7 +52,7 @@ namespace Json.Schema.Generation.Generators
 				props.Add(name, memberContext);
 
 				if (memberAttributes.OfType<RequiredAttribute>().Any())
-					required.Add(member.Name);
+					required.Add(name);
 			}
 
 			context.Intents.Add(new PropertiesIntent(props)); 

--- a/json-everything.sln
+++ b/json-everything.sln
@@ -61,9 +61,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "schema2020-12", "schema2020
 		Meta-Schemas\2020-12\validation.json = Meta-Schemas\2020-12\validation.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonSchema.Data", "JsonSchema.Data\JsonSchema.Data.csproj", "{435FA9F1-496D-454C-85EA-A98029C54A10}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonSchema.Data", "JsonSchema.Data\JsonSchema.Data.csproj", "{435FA9F1-496D-454C-85EA-A98029C54A10}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonSchema.Data.Tests", "JsonSchema.Data.Tests\JsonSchema.Data.Tests.csproj", "{E42C6093-9763-4246-8D10-EB835B7FA932}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonSchema.Data.Tests", "JsonSchema.Data.Tests\JsonSchema.Data.Tests.csproj", "{E42C6093-9763-4246-8D10-EB835B7FA932}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Json.More.Tests", "Json.More.Tests\Json.More.Tests.csproj", "{D6E10FBB-8BF4-4ECF-90B4-3C4EE6418496}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -135,6 +137,10 @@ Global
 		{E42C6093-9763-4246-8D10-EB835B7FA932}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E42C6093-9763-4246-8D10-EB835B7FA932}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E42C6093-9763-4246-8D10-EB835B7FA932}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6E10FBB-8BF4-4ECF-90B4-3C4EE6418496}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6E10FBB-8BF4-4ECF-90B4-3C4EE6418496}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6E10FBB-8BF4-4ECF-90B4-3C4EE6418496}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6E10FBB-8BF4-4ECF-90B4-3C4EE6418496}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Bug 1:

There is a race condition in `EnumStringConverter` that was found when running unit tests in parallel. Multiple tests serializing distinct `JsonSchema` objects at the same time can cause this race condition to be hit.

**Example stack trace:**
```
Error Message:
 System.NullReferenceException : Object reference not set to an instance of an object.
Stack Trace:
   at Json.More.EnumStringConverter`1.Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
 at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](JsonConverter jsonConverter, Utf8JsonWriter writer, TValue& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](Utf8JsonWriter writer, TValue& value, Type inputType, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize[TValue](Utf8JsonWriter writer, TValue& value, Type type, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize[TValue](Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
 at Json.Schema.TypeKeywordJsonConverter.Write(Utf8JsonWriter writer, TypeKeyword value, JsonSerializerOptions options)
 at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.Serialization.JsonConverter`1.WriteCoreAsObject(Utf8JsonWriter writer, Object value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](JsonConverter jsonConverter, Utf8JsonWriter writer, TValue& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](Utf8JsonWriter writer, TValue& value, Type inputType, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize[TValue](Utf8JsonWriter writer, TValue& value, Type type, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize(Utf8JsonWriter writer, Object value, Type inputType, JsonSerializerOptions options)
 at Json.Schema.SchemaJsonConverter.Write(Utf8JsonWriter writer, JsonSchema value, JsonSerializerOptions options)
 at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](JsonConverter jsonConverter, Utf8JsonWriter writer, TValue& value, JsonSerializerOptions options, WriteStack& state)
 at System.Text.Json.JsonSerializer.WriteCore[TValue](Utf8JsonWriter writer, TValue& value, Type inputType, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize[TValue](TValue& value, Type inputType, JsonSerializerOptions options)
 at System.Text.Json.JsonSerializer.Serialize[TValue](TValue value, JsonSerializerOptions options)
```

### Bug 2:

Names added to the `required` list will not respect the value set in the `JsonPropertyNameAttribute`.

**Actual JSON schema:**
```
{
  "type": "object",
  "properties": {
    "exampleProperty": {
      "type": "string"
    }
  },
  "required": [
    "ExampleProperty"
  ]
}
```

**Expected JSON schema:**
```
{
  "type": "object",
  "properties": {
    "exampleProperty": {
      "type": "string"
    }
  },
  "required": [
    "exampleProperty"
  ]
}
```