### PR TITLE
Fix #109

### DIFF
--- a/JsonSchema.Generation.Tests/AttributeHandlerTests.cs
+++ b/JsonSchema.Generation.Tests/AttributeHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+namespace Json.Schema.Generation.Tests {
+    public class AttributeHandlerTests {
+
+        [Test]
+        public void DirectAttributeHandler() {
+            JsonSchema expected = new JsonSchemaBuilder()
+                .Type(SchemaValueType.Object)
+                .Properties(
+                    ("MyProperty", new JsonSchemaBuilder().Type(SchemaValueType.String).MaxLength(AttributeWithDirectHandler.MaxLength))
+                );
+
+            JsonSchema actual = new JsonSchemaBuilder().FromType<TypeWithCustomAttribute1>();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [Test]
+        public void IndirectAttributeHandler() {
+            AttributeHandler.RemoveHandler<CustomAttributeHandler>();
+            AttributeHandler.AddHandler<CustomAttributeHandler>();
+
+            JsonSchema expected = new JsonSchemaBuilder()
+                .Type(SchemaValueType.Object)
+                .Properties(
+                    ("MyProperty", new JsonSchemaBuilder().Type(SchemaValueType.String).MaxLength(AttributeWithIndirectHandler.MaxLength))
+                );
+
+            JsonSchema actual = new JsonSchemaBuilder().FromType<TypeWithCustomAttribute2>();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [AttributeUsage(AttributeTargets.Property)]
+        public class AttributeWithDirectHandler : Attribute, IAttributeHandler {
+
+            public const uint MaxLength = 100;
+            
+            void IAttributeHandler.AddConstraints(SchemaGeneratorContext context) {
+                if (context.Attributes.Any(x => x.GetType() == typeof(AttributeWithDirectHandler))) {
+                    context.Intents.Add(new Intents.MaxLengthIntent(MaxLength));
+                }
+            }
+
+        }
+
+
+        [AttributeUsage(AttributeTargets.Property)]
+        public class AttributeWithIndirectHandler : Attribute {
+
+            public const uint MaxLength = 200;
+
+        }
+
+
+        public class CustomAttributeHandler : IAttributeHandler {
+            void IAttributeHandler.AddConstraints(SchemaGeneratorContext context) {
+                if (context.Attributes.Any(x => x.GetType() == typeof(AttributeWithIndirectHandler))) {
+                    context.Intents.Add(new Intents.MaxLengthIntent(AttributeWithIndirectHandler.MaxLength));
+                }
+            }
+        }
+
+
+        public class TypeWithCustomAttribute1 {
+
+            [AttributeWithDirectHandler]
+            public string MyProperty { get; set; }
+
+        }
+
+
+        public class TypeWithCustomAttribute2 {
+
+            [AttributeWithIndirectHandler]
+            public string MyProperty { get; set; }
+
+        }
+
+    }
+}

--- a/JsonSchema.Generation/AttributeHandler.cs
+++ b/JsonSchema.Generation/AttributeHandler.cs
@@ -27,7 +27,7 @@ namespace Json.Schema.Generation
 		public static void AddHandler<T>()
 			where T : IAttributeHandler, new()
 		{
-			if (_handlers.Any(h => h.GetType() != typeof(T))) return;
+			if (_handlers.Any(h => h.GetType() == typeof(T))) return;
 
 			_handlers.Add(new T());
 		}
@@ -39,7 +39,7 @@ namespace Json.Schema.Generation
 		public static void AddHandler(IAttributeHandler handler)
 		{
 			var handlerType = handler.GetType();
-			if (_handlers.Any(h => h.GetType() != handlerType)) return;
+			if (_handlers.Any(h => h.GetType() == handlerType)) return;
 
 			_handlers.Add(handler);
 		}


### PR DESCRIPTION
Fixes #109 by ensuring that the check for an existing attribute handler registration is performed correctly.