### PR TITLE
Fix memory leaks.

### DIFF
--- a/Json.More/JsonElementExtensions.cs
+++ b/Json.More/JsonElementExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 
@@ -145,8 +146,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this long value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -157,8 +158,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this int value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -169,8 +170,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this short value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -181,8 +182,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this bool value)
 		{
-			var doc = JsonDocument.Parse($"{value.ToString().ToLower()}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value ? "true" : "false");
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -193,8 +194,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this decimal value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -205,8 +206,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this double value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -217,8 +218,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this float value)
 		{
-			var doc = JsonDocument.Parse($"{value}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(value.ToString(CultureInfo.InvariantCulture));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -229,8 +230,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this string? value)
 		{
-			var doc = JsonDocument.Parse(JsonSerializer.Serialize(value));
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse(JsonSerializer.Serialize(value));
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -241,8 +242,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this IEnumerable<JsonElement> values)
 		{
-			var doc = JsonDocument.Parse($"[{string.Join(",", values.Select(v => v.ToJsonString()))}]");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse($"[{string.Join(",", values.Select(v => v.ToJsonString()))}]");
+			return doc.RootElement.Clone();
 		}
 
 		/// <summary>
@@ -253,8 +254,8 @@ namespace Json.More
 		/// <remarks>This is a workaround for lack of native support in the System.Text.Json namespace.</remarks>
 		public static JsonElement AsJsonElement(this IDictionary<string, JsonElement> values)
 		{
-			var doc = JsonDocument.Parse($"{{{string.Join(",", values.Select(v => $"{JsonSerializer.Serialize(v.Key)}:{v.Value.ToJsonString()}"))}}}");
-			return doc.RootElement;
+			using var doc = JsonDocument.Parse($"{{{string.Join(",", values.Select(v => $"{JsonSerializer.Serialize(v.Key)}:{v.Value.ToJsonString()}"))}}}");
+			return doc.RootElement.Clone();
 		}
 	}
 }

--- a/JsonLogic/Rule.cs
+++ b/JsonLogic/Rule.cs
@@ -75,7 +75,10 @@ namespace Json.Logic
 		public override Rule Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
 			if (reader.TokenType != JsonTokenType.StartObject)
-				return new LiteralRule(JsonDocument.ParseValue(ref reader).RootElement);
+			{
+				using var doc = JsonDocument.ParseValue(ref reader);
+				return new LiteralRule(doc.RootElement.Clone());
+			}
 
 			var data = JsonSerializer.Deserialize<Dictionary<string, ArgumentCollection>>(ref reader, options);
 			

--- a/JsonLogic/RuleExtensions.cs
+++ b/JsonLogic/RuleExtensions.cs
@@ -7,6 +7,14 @@ namespace Json.Logic
 	/// </summary>
 	public static class RuleExtensions
 	{
+		private static readonly JsonElement _nullElement;
+
+		static RuleExtensions()
+		{
+			using var doc = JsonDocument.Parse("null");
+			_nullElement = doc.RootElement.Clone();
+		}
+
 		/// <summary>
 		/// Calls <see cref="Rule.Apply(JsonElement)"/> with no data.
 		/// </summary>
@@ -14,7 +22,7 @@ namespace Json.Logic
 		/// <returns>The result.</returns>
 		public static JsonElement Apply(this Rule rule)
 		{
-			return rule.Apply(JsonDocument.Parse("null").RootElement);
+			return rule.Apply(_nullElement);
 		}
 	}
 }

--- a/JsonLogic/Rules/ReduceRule.cs
+++ b/JsonLogic/Rules/ReduceRule.cs
@@ -40,7 +40,8 @@ namespace Json.Logic.Rules
 					Current = element,
 					Accumulator = accumulator
 				};
-				var item = JsonDocument.Parse(JsonSerializer.Serialize(intermediary, _options)).RootElement;
+				using var doc = JsonDocument.Parse(JsonSerializer.Serialize(intermediary, _options));
+				var item = doc.RootElement.Clone();
 				
 				accumulator = _rule.Apply(item);
 			}

--- a/JsonPatch/EditableJsonElement.cs
+++ b/JsonPatch/EditableJsonElement.cs
@@ -42,7 +42,8 @@ namespace Json.Patch
 
 		public JsonElement ToElement()
 		{
-			return JsonDocument.Parse(ToString()).RootElement;
+			using var doc = JsonDocument.Parse(ToString());
+			return doc.RootElement.Clone();
 		}
 
 		public override string ToString()

--- a/JsonPath/PropertyNameIndex.cs
+++ b/JsonPath/PropertyNameIndex.cs
@@ -59,7 +59,8 @@ namespace Json.Path
 			{
 				if (start == '\'') 
 					key = key.Replace("\\'", "'").Replace("\"", "\\\"");
-				key = JsonDocument.Parse($"\"{key}\"").RootElement.GetString();
+				using var doc = JsonDocument.Parse($"\"{key}\"");
+				key = doc.RootElement.GetString();
 			}
 			catch
 			{

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -208,7 +208,8 @@ namespace Json.Path
 				var block = span[i..end];
 				if (block[0] == '\'' && block[^1] == '\'')
 					block = $"\"{block[1..^1].ToString()}\"".AsSpan();
-				element = JsonDocument.Parse(block.ToString()).RootElement.Clone();
+				using var doc = JsonDocument.Parse(block.ToString());
+				element = doc.RootElement.Clone();
 				i = end;
 				return true;
 			}

--- a/JsonSchema/ConstKeyword.cs
+++ b/JsonSchema/ConstKeyword.cs
@@ -77,7 +77,8 @@ namespace Json.Schema
 	{
 		public override ConstKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			var element = JsonDocument.ParseValue(ref reader).RootElement;
+			using var document = JsonDocument.ParseValue(ref reader);
+			var element = document.RootElement;
 
 			return new ConstKeyword(element);
 		}

--- a/JsonSchema/DefaultKeyword.cs
+++ b/JsonSchema/DefaultKeyword.cs
@@ -76,7 +76,8 @@ namespace Json.Schema
 	{
 		public override DefaultKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			var element = JsonDocument.ParseValue(ref reader).RootElement;
+			using var document = JsonDocument.ParseValue(ref reader);
+			var element = document.RootElement;
 
 			return new DefaultKeyword(element);
 		}

--- a/JsonSchema/EnumKeyword.cs
+++ b/JsonSchema/EnumKeyword.cs
@@ -89,7 +89,7 @@ namespace Json.Schema
 	{
 		public override EnumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			var document = JsonDocument.ParseValue(ref reader);
+			using var document = JsonDocument.ParseValue(ref reader);
 
 			if (document.RootElement.ValueKind != JsonValueKind.Array)
 				throw new JsonException("Expected array");

--- a/JsonSchema/ExamplesKeyword.cs
+++ b/JsonSchema/ExamplesKeyword.cs
@@ -88,7 +88,7 @@ namespace Json.Schema
 	{
 		public override ExamplesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			var document = JsonDocument.ParseValue(ref reader);
+			using var document = JsonDocument.ParseValue(ref reader);
 
 			if (document.RootElement.ValueKind != JsonValueKind.Array)
 				throw new JsonException("Expected array");

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -383,7 +383,8 @@ namespace Json.Schema
 						var keywordType = SchemaKeywordRegistry.GetImplementationType(keyword);
 						if (keywordType == null)
 						{
-							var element = JsonDocument.ParseValue(ref reader).RootElement;
+							using var document = JsonDocument.ParseValue(ref reader);
+							var element = document.RootElement;
 							otherData[keyword] = element.Clone();
 							break;
 						}

--- a/JsonSchema/RequiredKeyword.cs
+++ b/JsonSchema/RequiredKeyword.cs
@@ -109,7 +109,7 @@ namespace Json.Schema
 	{
 		public override RequiredKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
-			var document = JsonDocument.ParseValue(ref reader);
+			using var document = JsonDocument.ParseValue(ref reader);
 
 			if (document.RootElement.ValueKind != JsonValueKind.Array)
 				throw new JsonException("Expected array");

--- a/JsonSchema/SchemaKeyword.cs
+++ b/JsonSchema/SchemaKeyword.cs
@@ -64,7 +64,8 @@ namespace Json.Schema
 			}
 
 			context.Log(() => "Validating against meta-schema.");
-			var schemaAsJson = JsonDocument.Parse(JsonSerializer.Serialize(context.LocalSchema)).RootElement;
+			using var document = JsonDocument.Parse(JsonSerializer.Serialize(context.LocalSchema));
+			var schemaAsJson = document.RootElement;
 			var newOptions = ValidationOptions.From(context.Options);
 			newOptions.ValidateMetaSchema = false;
 			var results = metaSchema.Validate(schemaAsJson, newOptions);

--- a/JsonSchema/SchemaKeywordRegistry.cs
+++ b/JsonSchema/SchemaKeywordRegistry.cs
@@ -30,7 +30,8 @@ namespace Json.Schema
 					.Select(t => new {Type = t, Keyword = t.GetCustomAttribute<SchemaKeywordAttribute>().Name})
 					.ToDictionary(k => k.Keyword, k => k.Type));
 
-			var nullElement = JsonDocument.Parse("null").RootElement;
+			using var document = JsonDocument.Parse("null");
+			var nullElement = document.RootElement;
 			_nullKeywords = new ConcurrentDictionary<Type, IJsonSchemaKeyword>
 			{
 				[typeof(ConstKeyword)] = new ConstKeyword(nullElement),


### PR DESCRIPTION
JsonDocument rents from ArrayPool and must be disposed to prevent memory leaks.