### PR TITLE
Order properties by type and then declaration order

### DIFF
--- a/JsonSchema.Generation.Tests/PropertyOrderTests.cs
+++ b/JsonSchema.Generation.Tests/PropertyOrderTests.cs
@@ -14,6 +14,12 @@ namespace Json.Schema.Generation.Tests
 			public int First { get; set; }
 		}
 
+		private class SpecifiedOrderDerived : SpecifiedOrder
+		{
+			public int Third { get; set; }
+		}
+
+
 		[Test]
 		public void PropertiesAsDeclared()
 		{
@@ -31,6 +37,26 @@ namespace Json.Schema.Generation.Tests
 			Assert.AreEqual(nameof(SpecifiedOrder.First), properties.Properties.Keys.Last());
 		}
 
+
+		[Test]
+		public void PropertiesAsDeclaredByType()
+		{
+			var config = new SchemaGeneratorConfiguration
+			{
+				PropertyOrder = PropertyOrder.AsDeclared
+			};
+
+			JsonSchema schema = new JsonSchemaBuilder()
+				.FromType<SpecifiedOrderDerived>(config);
+
+			var properties = schema.Keywords.OfType<PropertiesKeyword>().Single();
+
+			Assert.AreEqual(nameof(SpecifiedOrder.Second), properties.Properties.Keys.ElementAt(0));
+			Assert.AreEqual(nameof(SpecifiedOrder.First), properties.Properties.Keys.ElementAt(1));
+			Assert.AreEqual(nameof(SpecifiedOrderDerived.Third), properties.Properties.Keys.ElementAt(2));
+		}
+
+
 		[Test]
 		public void PropertiesByName()
 		{
@@ -47,5 +73,6 @@ namespace Json.Schema.Generation.Tests
 			Assert.AreEqual(nameof(SpecifiedOrder.First), properties.Properties.Keys.First());
 			Assert.AreEqual(nameof(SpecifiedOrder.Second), properties.Properties.Keys.Last());
 		}
+
 	}
 }

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -34,7 +34,7 @@ namespace Json.Schema.Generation.Generators
 
 			membersToGenerate = context.Configuration.PropertyOrder switch
 			{
-				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, context.AsDeclaredMemberInfoComparer.Value),
+				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, context.DeclarationOrderComparer.Value),
 				PropertyOrder.ByName => membersToGenerate.OrderBy(m => m.Name),
 				_ => membersToGenerate
 			};

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -97,16 +97,19 @@ namespace Json.Schema.Generation.Generators
 
 			private static bool HasMetadataToken(MemberInfo? member)
 			{
-				if (member == null)
-				{
-					return false;
-				}
+				if (member == null) return false;
 
 #if NET5_0_OR_GREATER
 				return member.HasMetadataToken();
 #else
-				try { var token = member.MetadataToken; return true; }
-				catch (InvalidOperationException) { return false; }
+				try 
+				{ 
+					var token = member.MetadataToken; return true; 
+				}
+				catch (InvalidOperationException) 
+				{ 
+					return false; 
+				}
 #endif
 			}
 
@@ -117,20 +120,11 @@ namespace Json.Schema.Generation.Generators
 
 			public override int Compare(MemberInfo? x, MemberInfo? y)
 			{
-				if (x == y)
-				{
-					return 0;
-				}
+				if (x == y) return 0;
+				
+				if (x == null) return 1;
 
-				if (x == null)
-				{
-					return 1;
-				}
-
-				if (y == null)
-				{
-					return -1;
-				}
+				if (y == null) return -1;
 
 				// Get metadata tokens for the types that declared the members.
 				var xTypeToken = GetMetadataToken(x.DeclaringType);
@@ -144,20 +138,11 @@ namespace Json.Schema.Generation.Generators
 					var xIndex = Array.IndexOf(_typeOrder, xTypeToken);
 					var yIndex = Array.IndexOf(_typeOrder, yTypeToken);
 
-					if (xIndex < 0 && yIndex < 0)
-					{
-						return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
-					}
+					if (xIndex < 0 && yIndex < 0) return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
 
-					if (xIndex < 0)
-					{
-						return 1;
-					}
+					if (xIndex < 0) return 1;
 
-					if (yIndex < 0)
-					{
-						return -1;
-					}
+					if (yIndex < 0) return -1;
 
 					return Comparer<int>.Default.Compare(xIndex, yIndex);
 				}

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -34,7 +34,7 @@ namespace Json.Schema.Generation.Generators
 
 			membersToGenerate = context.Configuration.PropertyOrder switch
 			{
-				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(GetMemberSequenceValue),
+				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, MemberInfoMetadataTokenComparer.ForType(context.Type)),
 				PropertyOrder.ByName => membersToGenerate.OrderBy(m => m.Name),
 				_ => membersToGenerate
 			};
@@ -71,9 +71,106 @@ namespace Json.Schema.Generation.Generators
 			}
 		}
 
-		private static int GetMemberSequenceValue(MemberInfo member)
+
+		private class MemberInfoMetadataTokenComparer : Comparer<MemberInfo>
 		{
-			return member.MetadataToken;
+
+			private readonly int[] _typeOrder;
+
+			private MemberInfoMetadataTokenComparer(Type type)
+			{
+				var typeStack = new Stack<Type>();
+
+				do
+				{
+					typeStack.Push(type);
+					type = type.BaseType!;
+				} while (type != null);
+
+				_typeOrder = typeStack.Select(GetMetadataToken).ToArray();
+			}
+
+			public static MemberInfoMetadataTokenComparer ForType(Type type)
+			{
+				return new MemberInfoMetadataTokenComparer(type ?? throw new ArgumentNullException(nameof(type)));
+			}
+
+			private static bool HasMetadataToken(MemberInfo? member)
+			{
+				if (member == null)
+				{
+					return false;
+				}
+
+#if NET5_0_OR_GREATER
+				return member.HasMetadataToken();
+#else
+				try { var token = member.MetadataToken; return true; }
+				catch (InvalidOperationException) { return false; }
+#endif
+			}
+
+			private static int GetMetadataToken(MemberInfo? member)
+			{
+				return HasMetadataToken(member) ? member!.MetadataToken : int.MaxValue;
+			}
+
+			public override int Compare(MemberInfo? x, MemberInfo? y)
+			{
+				if (x == y)
+				{
+					return 0;
+				}
+
+				if (x == null)
+				{
+					return 1;
+				}
+
+				if (y == null)
+				{
+					return -1;
+				}
+
+				// Get metadata tokens for the types that declared the members.
+				var xTypeToken = GetMetadataToken(x.DeclaringType);
+				var yTypeToken = GetMetadataToken(y.DeclaringType);
+
+				if (xTypeToken != yTypeToken)
+				{
+					// Members were declared in different types. Find the _typeOrder indices for
+					// the types so that we can identify which one we consider to be the
+					// least-derived type.
+					var xIndex = Array.IndexOf(_typeOrder, xTypeToken);
+					var yIndex = Array.IndexOf(_typeOrder, yTypeToken);
+
+					if (xIndex < 0 && yIndex < 0)
+					{
+						return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
+					}
+
+					if (xIndex < 0)
+					{
+						return 1;
+					}
+
+					if (yIndex < 0)
+					{
+						return -1;
+					}
+
+					return Comparer<int>.Default.Compare(xIndex, yIndex);
+				}
+
+				// Members were declared in the same type. Use the metadata tokens for the members
+				// to determine the sort order.
+				var xToken = GetMetadataToken(x);
+				var yToken = GetMetadataToken(y);
+
+				return Comparer<int>.Default.Compare(xToken, yToken);
+			}
+
 		}
+
 	}
 }

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -34,7 +34,7 @@ namespace Json.Schema.Generation.Generators
 
 			membersToGenerate = context.Configuration.PropertyOrder switch
 			{
-				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, MemberInfoMetadataTokenComparer.ForType(context.Type)),
+				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, context.AsDeclaredMemberInfoComparer.Value),
 				PropertyOrder.ByName => membersToGenerate.OrderBy(m => m.Name),
 				_ => membersToGenerate
 			};
@@ -69,92 +69,6 @@ namespace Json.Schema.Generation.Generators
 				if (required.Count > 0)
 					context.Intents.Add(new RequiredIntent(required));
 			}
-		}
-
-
-		private class MemberInfoMetadataTokenComparer : Comparer<MemberInfo>
-		{
-
-			private readonly int[] _typeOrder;
-
-			private MemberInfoMetadataTokenComparer(Type type)
-			{
-				var typeStack = new Stack<Type>();
-
-				do
-				{
-					typeStack.Push(type);
-					type = type.BaseType!;
-				} while (type != null);
-
-				_typeOrder = typeStack.Select(GetMetadataToken).ToArray();
-			}
-
-			public static MemberInfoMetadataTokenComparer ForType(Type type)
-			{
-				return new MemberInfoMetadataTokenComparer(type ?? throw new ArgumentNullException(nameof(type)));
-			}
-
-			private static bool HasMetadataToken(MemberInfo? member)
-			{
-				if (member == null) return false;
-
-#if NET5_0_OR_GREATER
-				return member.HasMetadataToken();
-#else
-				try 
-				{ 
-					var token = member.MetadataToken; return true; 
-				}
-				catch (InvalidOperationException) 
-				{ 
-					return false; 
-				}
-#endif
-			}
-
-			private static int GetMetadataToken(MemberInfo? member)
-			{
-				return HasMetadataToken(member) ? member!.MetadataToken : int.MaxValue;
-			}
-
-			public override int Compare(MemberInfo? x, MemberInfo? y)
-			{
-				if (x == y) return 0;
-				
-				if (x == null) return 1;
-
-				if (y == null) return -1;
-
-				// Get metadata tokens for the types that declared the members.
-				var xTypeToken = GetMetadataToken(x.DeclaringType);
-				var yTypeToken = GetMetadataToken(y.DeclaringType);
-
-				if (xTypeToken != yTypeToken)
-				{
-					// Members were declared in different types. Find the _typeOrder indices for
-					// the types so that we can identify which one we consider to be the
-					// least-derived type.
-					var xIndex = Array.IndexOf(_typeOrder, xTypeToken);
-					var yIndex = Array.IndexOf(_typeOrder, yTypeToken);
-
-					if (xIndex < 0 && yIndex < 0) return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
-
-					if (xIndex < 0) return 1;
-
-					if (yIndex < 0) return -1;
-
-					return Comparer<int>.Default.Compare(xIndex, yIndex);
-				}
-
-				// Members were declared in the same type. Use the metadata tokens for the members
-				// to determine the sort order.
-				var xToken = GetMetadataToken(x);
-				var yToken = GetMetadataToken(y);
-
-				return Comparer<int>.Default.Compare(xToken, yToken);
-			}
-
 		}
 
 	}

--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -34,7 +34,7 @@ namespace Json.Schema.Generation.Generators
 
 			membersToGenerate = context.Configuration.PropertyOrder switch
 			{
-				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, context.DeclarationOrderComparer.Value),
+				PropertyOrder.AsDeclared => membersToGenerate.OrderBy(m => m, context.DeclarationOrderComparer),
 				PropertyOrder.ByName => membersToGenerate.OrderBy(m => m.Name),
 				_ => membersToGenerate
 			};

--- a/JsonSchema.Generation/JsonSchema.Net.Generation.xml
+++ b/JsonSchema.Generation/JsonSchema.Net.Generation.xml
@@ -1443,6 +1443,11 @@
             The generator configuration.
             </summary>
         </member>
+        <member name="P:Json.Schema.Generation.SchemaGeneratorContext.AsDeclaredMemberInfoComparer">
+            <summary>
+            <see cref="T:System.Collections.Generic.IComparer`1"/> for ordering members when generating a schema with <see cref="F:Json.Schema.Generation.PropertyOrder.AsDeclared"/> ordering enabled.
+            </summary>
+        </member>
         <member name="M:Json.Schema.Generation.SchemaGeneratorContext.Apply(Json.Schema.JsonSchemaBuilder)">
             <summary>
             Applies the keyword to the <see cref="T:Json.Schema.JsonSchemaBuilder"/>.

--- a/JsonSchema.Generation/MemberInfoMetadataComparer.cs
+++ b/JsonSchema.Generation/MemberInfoMetadataComparer.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Json.Schema.Generation
+{
+	internal class MemberInfoMetadataTokenComparer : Comparer<MemberInfo>
+	{
+
+		private readonly int[] _typeOrder;
+
+		internal MemberInfoMetadataTokenComparer(Type type)
+		{
+			var typeStack = new Stack<Type>();
+
+			do
+			{
+				typeStack.Push(type);
+				type = type.BaseType!;
+			} while (type != null);
+
+			_typeOrder = typeStack.Select(GetMetadataToken).ToArray();
+		}
+
+
+		private static bool HasMetadataToken(MemberInfo? member)
+		{
+			if (member == null) return false;
+
+#if NET5_0_OR_GREATER
+				return member.HasMetadataToken();
+#else
+			try
+			{
+				var token = member.MetadataToken; return true;
+			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
+#endif
+		}
+
+		private static int GetMetadataToken(MemberInfo? member)
+		{
+			return HasMetadataToken(member) ? member!.MetadataToken : int.MaxValue;
+		}
+
+		public override int Compare(MemberInfo? x, MemberInfo? y)
+		{
+			if (x == y) return 0;
+
+			if (x == null) return 1;
+
+			if (y == null) return -1;
+
+			// Get metadata tokens for the types that declared the members.
+			var xTypeToken = GetMetadataToken(x.DeclaringType);
+			var yTypeToken = GetMetadataToken(y.DeclaringType);
+
+			if (xTypeToken != yTypeToken)
+			{
+				// Members were declared in different types. Find the _typeOrder indices for
+				// the types so that we can identify which one we consider to be the
+				// least-derived type.
+				var xIndex = Array.IndexOf(_typeOrder, xTypeToken);
+				var yIndex = Array.IndexOf(_typeOrder, yTypeToken);
+
+				if (xIndex < 0 && yIndex < 0) return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
+
+				if (xIndex < 0) return 1;
+
+				if (yIndex < 0) return -1;
+
+				return Comparer<int>.Default.Compare(xIndex, yIndex);
+			}
+
+			// Members were declared in the same type. Use the metadata tokens for the members
+			// to determine the sort order.
+			var xToken = GetMetadataToken(x);
+			var yToken = GetMetadataToken(y);
+
+			return Comparer<int>.Default.Compare(xToken, yToken);
+		}
+
+	}
+}

--- a/JsonSchema.Generation/SchemaGeneratorContext.cs
+++ b/JsonSchema.Generation/SchemaGeneratorContext.cs
@@ -1,6 +1,7 @@
 ﻿ using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Json.Schema.Generation.Intents;
  using Json.Schema.Generation.Refiners;
@@ -24,6 +25,91 @@ using Json.Schema.Generation.Intents;
 			}
 		}
 
+		private class MemberInfoMetadataTokenComparer : Comparer<MemberInfo>
+		{
+
+			private readonly int[] _typeOrder;
+
+			private MemberInfoMetadataTokenComparer(Type type)
+			{
+				var typeStack = new Stack<Type>();
+
+				do
+				{
+					typeStack.Push(type);
+					type = type.BaseType!;
+				} while (type != null);
+
+				_typeOrder = typeStack.Select(GetMetadataToken).ToArray();
+			}
+
+			public static MemberInfoMetadataTokenComparer ForType(Type type)
+			{
+				return new MemberInfoMetadataTokenComparer(type ?? throw new ArgumentNullException(nameof(type)));
+			}
+
+			private static bool HasMetadataToken(MemberInfo? member)
+			{
+				if (member == null) return false;
+
+#if NET5_0_OR_GREATER
+				return member.HasMetadataToken();
+#else
+				try
+				{
+					var token = member.MetadataToken; return true;
+				}
+				catch (InvalidOperationException)
+				{
+					return false;
+				}
+#endif
+			}
+
+			private static int GetMetadataToken(MemberInfo? member)
+			{
+				return HasMetadataToken(member) ? member!.MetadataToken : int.MaxValue;
+			}
+
+			public override int Compare(MemberInfo? x, MemberInfo? y)
+			{
+				if (x == y) return 0;
+
+				if (x == null) return 1;
+
+				if (y == null) return -1;
+
+				// Get metadata tokens for the types that declared the members.
+				var xTypeToken = GetMetadataToken(x.DeclaringType);
+				var yTypeToken = GetMetadataToken(y.DeclaringType);
+
+				if (xTypeToken != yTypeToken)
+				{
+					// Members were declared in different types. Find the _typeOrder indices for
+					// the types so that we can identify which one we consider to be the
+					// least-derived type.
+					var xIndex = Array.IndexOf(_typeOrder, xTypeToken);
+					var yIndex = Array.IndexOf(_typeOrder, yTypeToken);
+
+					if (xIndex < 0 && yIndex < 0) return Comparer<int>.Default.Compare(xTypeToken, yTypeToken);
+
+					if (xIndex < 0) return 1;
+
+					if (yIndex < 0) return -1;
+
+					return Comparer<int>.Default.Compare(xIndex, yIndex);
+				}
+
+				// Members were declared in the same type. Use the metadata tokens for the members
+				// to determine the sort order.
+				var xToken = GetMetadataToken(x);
+				var yToken = GetMetadataToken(y);
+
+				return Comparer<int>.Default.Compare(xToken, yToken);
+			}
+
+		}
+
 		/// <summary>
 		/// The CLR type currently being processed.
 		/// </summary>
@@ -40,12 +126,17 @@ using Json.Schema.Generation.Intents;
 		/// The generator configuration.
 		/// </summary>
 		public SchemaGeneratorConfiguration Configuration { get; }
+		/// <summary>
+		/// <see cref="IComparer{MemberInfo}"/> for ordering members when generating a schema with <see cref="PropertyOrder.AsDeclared"/> ordering enabled.
+		/// </summary>
+		internal Lazy<IComparer<MemberInfo>> AsDeclaredMemberInfoComparer { get; }
 
 		internal SchemaGeneratorContext(Type type, List<Attribute> attributes, SchemaGeneratorConfiguration configuration)
 		{
 			Type = type;
 			Attributes = attributes;
 			Configuration = configuration;
+			AsDeclaredMemberInfoComparer = new Lazy<IComparer<MemberInfo>>(() => MemberInfoMetadataTokenComparer.ForType(Type));
 		}
 
 		internal void GenerateIntents()

--- a/JsonSchema.Generation/SchemaGeneratorContext.cs
+++ b/JsonSchema.Generation/SchemaGeneratorContext.cs
@@ -129,7 +129,8 @@ using Json.Schema.Generation.Intents;
 		/// <summary>
 		/// <see cref="IComparer{MemberInfo}"/> for ordering members when generating a schema with <see cref="PropertyOrder.AsDeclared"/> ordering enabled.
 		/// </summary>
-		internal Lazy<IComparer<MemberInfo>> AsDeclaredMemberInfoComparer { get; }
+		private IComparer<MemberInfo> _memberInfoComparer;
+		internal IComparer<MemberInfo> AsDeclaredMemberInfoComparer => _memberInfoComparer ??= new MemberInfoMetadataTokenComparer(Type);
 
 		internal SchemaGeneratorContext(Type type, List<Attribute> attributes, SchemaGeneratorConfiguration configuration)
 		{


### PR DESCRIPTION
See [this comment](https://github.com/gregsdennis/json-everything/issues/112#issuecomment-845935019) in #112 for more details.

This PR extends the "as declared" property ordering to ensure that members are ordered from least-derived type to most-derived type, and then in declaration order in each individual type.

Consider the following types:

```csharp
public class BaseClass {
  public int First { get; set; }
  public int Second { get; set; }
}

public class DerivedClass : BaseClass {
  public int Third { get; set; }
  public int Fourth { get; set; }
}
```

When generating a schema for `DerivedClass` using `PropertyOrder.AsDeclared`, the order of properties in the schema is currently:

- `Third`
- `Fourth`
- `First`
- `Second`

This PR ensures that the properties from `BaseClass` are listed before `DerivedClass` i.e.

- `First`
- `Second`
- `Third`
- `Fourth`

The issue linked above mentions that a refiner could be used to accomplish the same task, but a general-purpose solution for any given type would effectively need to follow the same logic as the PR adds, but without the benefit of access to the `MemberInfo.MetadataToken` that `ObjectSchemaGenerator` already uses to determine the order at present, so would be more efficient to do this in `ObjectSchemaGenerator` instead.

Currently, a new comparer object is created for each call to `AddConstraints` using the `SchemaGeneratorContext.Type` property, but a cache of instantiated comparers could be stored in e.g. a `ConcurrentDictionary` is preferred for performance reasons.