### PR TITLE
Fix #138

### DIFF
--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -49,7 +49,10 @@ namespace Json.Schema
 			set => _fetch = value;
 		}
 
-		internal Draft ValidatingAs => _options.ValidatingAs;
+		internal Draft ValidatingAs
+		{
+			get => _options?.ValidatingAs ?? Draft.Unspecified;
+		}
 
 		static SchemaRegistry()
 		{


### PR DESCRIPTION
Fixes #138 by making `SchemaRegistry.ValidatingAs` get its value from `_options` every time and protecting against `_options` being `null`.