### PR TITLE
Make initialization of the static classes thread-safe

### DIFF
--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -98,7 +98,6 @@ namespace Json.Schema
 		public ValidationResults Validate(JsonElement root, ValidationOptions? options = null)
 		{
 			options = ValidationOptions.From(options ?? ValidationOptions.Default);
-			SchemaRegistry.Initialize();
 
 			var context = new ValidationContext(options)
 				{

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -32,7 +32,7 @@ namespace Json.Schema
 		private Dictionary<Uri, Registration>? _registered;
 		private Func<Uri, JsonSchema?>? _fetch;
 		private Stack<Uri>? _scopes;
-		private ValidationOptions? _options;
+		private readonly ValidationOptions _options;
 
 		/// <summary>
 		/// The global registry.
@@ -48,7 +48,7 @@ namespace Json.Schema
 			set => _fetch = value;
 		}
 
-		internal Draft ValidatingAs => _options!.ValidatingAs;
+		internal Draft ValidatingAs => _options.ValidatingAs;
 
 		internal SchemaRegistry(ValidationOptions options)
 		{

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -37,7 +37,7 @@ namespace Json.Schema
 		/// <summary>
 		/// The global registry.
 		/// </summary>
-		public static SchemaRegistry Global { get; }
+		public static SchemaRegistry Global => ValidationOptions.Default.SchemaRegistry;
 
 		/// <summary>
 		/// Gets or sets a method to enable automatic download of schemas by `$id` URI.
@@ -50,48 +50,34 @@ namespace Json.Schema
 
 		internal Draft ValidatingAs => _options!.ValidatingAs;
 
-		static SchemaRegistry()
-		{
-			Global = new SchemaRegistry();
-		}
-
 		internal SchemaRegistry(ValidationOptions options)
 		{
 			_options = options;
 		}
-		private SchemaRegistry(){}
 
-		internal static void Initialize()
+		internal void InitializeMetaSchemas()
 		{
-			if (Global._options != null) return;
+			MetaSchemas.Draft6.RegisterSubschemas(this, MetaSchemas.Draft6Id);
 
-			lock (Global)
-			{
-				if (Global._options != null) return;
-				Global._options = ValidationOptions.Default;
+			MetaSchemas.Draft7.RegisterSubschemas(this, MetaSchemas.Draft7Id);
 
-				MetaSchemas.Draft6.RegisterSubschemas(Global, MetaSchemas.Draft6Id);
+			MetaSchemas.Draft201909.RegisterSubschemas(this, MetaSchemas.Draft201909Id);
+			MetaSchemas.Core201909.RegisterSubschemas(this, MetaSchemas.Core201909Id);
+			MetaSchemas.Applicator201909.RegisterSubschemas(this, MetaSchemas.Applicator201909Id);
+			MetaSchemas.Validation201909.RegisterSubschemas(this, MetaSchemas.Validation201909Id);
+			MetaSchemas.Metadata201909.RegisterSubschemas(this, MetaSchemas.Metadata201909Id);
+			MetaSchemas.Format201909.RegisterSubschemas(this, MetaSchemas.Format201909Id);
+			MetaSchemas.Content201909.RegisterSubschemas(this, MetaSchemas.Content201909Id);
 
-				MetaSchemas.Draft7.RegisterSubschemas(Global, MetaSchemas.Draft7Id);
-
-				MetaSchemas.Draft201909.RegisterSubschemas(Global, MetaSchemas.Draft201909Id);
-				MetaSchemas.Core201909.RegisterSubschemas(Global, MetaSchemas.Core201909Id);
-				MetaSchemas.Applicator201909.RegisterSubschemas(Global, MetaSchemas.Applicator201909Id);
-				MetaSchemas.Validation201909.RegisterSubschemas(Global, MetaSchemas.Validation201909Id);
-				MetaSchemas.Metadata201909.RegisterSubschemas(Global, MetaSchemas.Metadata201909Id);
-				MetaSchemas.Format201909.RegisterSubschemas(Global, MetaSchemas.Format201909Id);
-				MetaSchemas.Content201909.RegisterSubschemas(Global, MetaSchemas.Content201909Id);
-
-				MetaSchemas.Draft202012.RegisterSubschemas(Global, MetaSchemas.Draft202012Id);
-				MetaSchemas.Core202012.RegisterSubschemas(Global, MetaSchemas.Core202012Id);
-				MetaSchemas.Applicator202012.RegisterSubschemas(Global, MetaSchemas.Applicator202012Id);
-				MetaSchemas.Validation202012.RegisterSubschemas(Global, MetaSchemas.Validation202012Id);
-				MetaSchemas.Metadata202012.RegisterSubschemas(Global, MetaSchemas.Metadata202012Id);
-				MetaSchemas.Unevaluated202012.RegisterSubschemas(Global, MetaSchemas.Unevaluated202012Id);
-				MetaSchemas.FormatAnnotation202012.RegisterSubschemas(Global, MetaSchemas.FormatAnnotation202012Id);
-				MetaSchemas.FormatAssertion202012.RegisterSubschemas(Global, MetaSchemas.FormatAssertion202012Id);
-				MetaSchemas.Content202012.RegisterSubschemas(Global, MetaSchemas.Content202012Id);
-			}
+			MetaSchemas.Draft202012.RegisterSubschemas(this, MetaSchemas.Draft202012Id);
+			MetaSchemas.Core202012.RegisterSubschemas(this, MetaSchemas.Core202012Id);
+			MetaSchemas.Applicator202012.RegisterSubschemas(this, MetaSchemas.Applicator202012Id);
+			MetaSchemas.Validation202012.RegisterSubschemas(this, MetaSchemas.Validation202012Id);
+			MetaSchemas.Metadata202012.RegisterSubschemas(this, MetaSchemas.Metadata202012Id);
+			MetaSchemas.Unevaluated202012.RegisterSubschemas(this, MetaSchemas.Unevaluated202012Id);
+			MetaSchemas.FormatAnnotation202012.RegisterSubschemas(this, MetaSchemas.FormatAnnotation202012Id);
+			MetaSchemas.FormatAssertion202012.RegisterSubschemas(this, MetaSchemas.FormatAssertion202012Id);
+			MetaSchemas.Content202012.RegisterSubschemas(this, MetaSchemas.Content202012Id);
 		}
 
 		/// <summary>

--- a/JsonSchema/ValidationOptions.cs
+++ b/JsonSchema/ValidationOptions.cs
@@ -100,6 +100,11 @@ namespace Json.Schema
 			SchemaRegistry = new SchemaRegistry(this);
 		}
 
+		static ValidationOptions()
+		{
+			Default.SchemaRegistry.InitializeMetaSchemas();
+		}
+
 		internal static ValidationOptions From(ValidationOptions other)
 		{
 			var options = new ValidationOptions


### PR DESCRIPTION
While using your library in an asp.net core project I hit some unexpected failures. The only reproducer I managed to find out required concurrent validations, which pointed in the direction of some issue in the thread-safety of the library.

I am quite confident that the issue stems from

https://github.com/gregsdennis/json-everything/blob/f52854937a06afa87794345cb8e66bb1d2d45ee8/JsonSchema/SchemaRegistry.cs#L66-L73

as this makes it possible for two threads A & B to perform the following:
 - A proceeds up to line 72, yields;
 - B finds `Global._options != null` at line 66, `return`s and performs the validation (without the MetaSchemas registrations)
 - A finally continues with line 73 and beyond

A fix for this race condition could be implemented by moving line `71` to the very bottom of the `lock` block, but I believe that a (minor) refactoring of the code allows for a cleaner initialization of both `SchemaRegistry` and `ValidationOptions`.

The approach followed in this branch involves:
 - removing all of the static initialization/construction from `SchemaRegistry`
 - adding a static constructor to `ValidationOptions` that performs the metaschema initialization on the registry associated to the default validation options (aka the global registry)
 - making the global registry available through a getter

As a (minor) nice side effect, this branch makes it possible to flag `SchemaRegistry._options` as `readonly` and make it non-nullable :)