### PR TITLE
private JetBrains.Annotations dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/Json.More/Json.More.csproj
+++ b/Json.More/Json.More.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonLogic/JsonLogic.csproj
+++ b/JsonLogic/JsonLogic.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonPatch/JsonPatch.csproj
+++ b/JsonPatch/JsonPatch.csproj
@@ -43,7 +43,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -40,10 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\JsonPointer\JsonPointer.csproj" />
   </ItemGroup>
 

--- a/JsonPointer/JsonPointer.csproj
+++ b/JsonPointer/JsonPointer.csproj
@@ -31,7 +31,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonSchema.Data/JsonSchema.Data.csproj
+++ b/JsonSchema.Data/JsonSchema.Data.csproj
@@ -32,10 +32,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Include="..\docs_source\release-notes\json-schema-data.md" Link="json-schema-data.md" />
 		<None Include="..\LICENSE">
 			<Pack>True</Pack>

--- a/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.11.10" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonSchema.UniqueKeys/JsonSchema.UniqueKeys.csproj
+++ b/JsonSchema.UniqueKeys/JsonSchema.UniqueKeys.csproj
@@ -32,10 +32,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Include="..\docs_source\release-notes\json-schema-unique-keys.md" Link="json-schema-unique-keys.md" />
 		<None Include="..\LICENSE">
 			<Pack>True</Pack>

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -31,9 +31,7 @@
    </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -31,7 +31,7 @@
    </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Let the `JetBrains.Annotations` dependency be private, it can be private so that won't be an external dependency

https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets