### PR TITLE
fixed issue with passed data vs external data

### DIFF
--- a/JsonLogic.Tests/GithubTests.cs
+++ b/JsonLogic.Tests/GithubTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
+using Json.Logic.Rules;
 using Json.More;
 using NUnit.Framework;
 
@@ -85,5 +87,21 @@ public class GithubTests
 		var result = rule.Apply(data.RootElement);
 
 		JsonAssert.AreEquivalent(true, result);
+	}
+
+	[Test]
+	public void Issue263_SomeInTest()
+	{
+		var rule = JsonLogic.Some(
+			JsonLogic.Variable("x"),
+			JsonLogic.In(
+				JsonLogic.Variable(""),
+				JsonLogic.Variable("y")
+			)
+		);
+
+		var data = JsonDocument.Parse("{\"x\":[-1, 0, 1],\"y\":[2, 3, 1]}").RootElement;
+
+		JsonAssert.IsTrue(rule.Apply(data));
 	}
 }

--- a/JsonLogic.Tests/VariableTests.cs
+++ b/JsonLogic.Tests/VariableTests.cs
@@ -41,4 +41,13 @@ public class VariableTests
 
 		JsonAssert.AreEquivalent(11, rule.Apply(data));
 	}
+
+	[Test]
+	public void VariableWithEmptyPathReturnsEntireData()
+	{
+		var rule = new VariableRule("");
+		var data = new { foo = 5, bar = 10 }.ToJsonDocument().RootElement;
+
+		JsonAssert.AreEquivalent(data, rule.Apply(data));
+	}
 }

--- a/JsonLogic/JsonLogic.csproj
+++ b/JsonLogic/JsonLogic.csproj
@@ -15,9 +15,9 @@
 		<PackageTags>json logic json-logic jsonlogic</PackageTags>
 		<PackageReleaseNotes>https://gregsdennis.github.io/json-everything/release-notes/json-logic.html</PackageReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.4.0</Version>
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>1.4.0.0</FileVersion>
+		<Version>2.0.0</Version>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<FileVersion>2.0.0.0</FileVersion>
 		<DocumentationFile>JsonLogic.xml</DocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/JsonLogic/Rule.cs
+++ b/JsonLogic/Rule.cs
@@ -17,8 +17,12 @@ public abstract class Rule
 	/// Applies the rule to the input data.
 	/// </summary>
 	/// <param name="data">The input data.</param>
+	/// <param name="contextData">
+	///     Optional secondary data.  Used by a few operators to pass a secondary
+	///     data context to inner operators.
+	/// </param>
 	/// <returns>The result of the rule.</returns>
-	public abstract JsonElement Apply(JsonElement data);
+	public abstract JsonElement Apply(JsonElement data, JsonElement? contextData = null);
 
 	/// <summary>
 	/// Casts a JSON value to a <see cref="LiteralRule"/>.

--- a/JsonLogic/RuleExtensions.cs
+++ b/JsonLogic/RuleExtensions.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 namespace Json.Logic;
 
 /// <summary>
-/// Calls <see cref="Rule.Apply(JsonElement)"/> with no data.
+/// Calls <see cref="Rule.Apply"/> with no data.
 /// </summary>
 public static class RuleExtensions
 {
@@ -16,7 +16,7 @@ public static class RuleExtensions
 	}
 
 	/// <summary>
-	/// Calls <see cref="Rule.Apply(JsonElement)"/> with no data.
+	/// Calls <see cref="Rule.Apply"/> with no data.
 	/// </summary>
 	/// <param name="rule">The rule.</param>
 	/// <returns>The result.</returns>

--- a/JsonLogic/Rules/AddRule.cs
+++ b/JsonLogic/Rules/AddRule.cs
@@ -15,13 +15,13 @@ internal class AddRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		decimal result = 0;
 
 		foreach (var item in _items)
 		{
-			var value = item.Apply(data);
+			var value = item.Apply(data, contextData);
 
 			var number = value.Numberify();
 

--- a/JsonLogic/Rules/AllRule.cs
+++ b/JsonLogic/Rules/AllRule.cs
@@ -24,7 +24,7 @@ internal class AllRule : Rule
 			throw new JsonLogicException("Input must evaluate to an array.");
 
 		var inputData = input.EnumerateArray();
-		var results = inputData.Select(value => _rule.Apply(value)).ToList();
+		var results = inputData.Select(value => _rule.Apply(data, value)).ToList();
 		return (results.Any() &&
 				results.All(result => result.IsTruthy()))
 			.AsJsonElement();

--- a/JsonLogic/Rules/AllRule.cs
+++ b/JsonLogic/Rules/AllRule.cs
@@ -16,9 +16,9 @@ internal class AllRule : Rule
 		_rule = rule;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
+		var input = _input.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.Array)
 			throw new JsonLogicException("Input must evaluate to an array.");

--- a/JsonLogic/Rules/AndRule.cs
+++ b/JsonLogic/Rules/AndRule.cs
@@ -16,9 +16,9 @@ internal class AndRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data));
+		var items = _items.Select(i => i.Apply(data, contextData));
 		var first = false.AsJsonElement();
 		foreach (var x in items)
 		{

--- a/JsonLogic/Rules/BooleanCastRule.cs
+++ b/JsonLogic/Rules/BooleanCastRule.cs
@@ -13,13 +13,13 @@ internal class BooleanCastRule : Rule
 		_value = value;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var value = _value.Apply(data);
+		var value = _value.Apply(data, contextData);
 
 		if (value.ValueKind == JsonValueKind.Object)
 			throw new JsonLogicException("Cannot cast objects to boolean");
 
-		return _value.Apply(data).IsTruthy().AsJsonElement();
+		return _value.Apply(data, contextData).IsTruthy().AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/CatRule.cs
+++ b/JsonLogic/Rules/CatRule.cs
@@ -15,13 +15,13 @@ internal class CatRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		var result = string.Empty;
 
 		foreach (var item in _items)
 		{
-			var value = item.Apply(data);
+			var value = item.Apply(data, contextData);
 
 			var str = value.Stringify();
 

--- a/JsonLogic/Rules/DivideRule.cs
+++ b/JsonLogic/Rules/DivideRule.cs
@@ -15,10 +15,10 @@ internal class DivideRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();

--- a/JsonLogic/Rules/FilterRule.cs
+++ b/JsonLogic/Rules/FilterRule.cs
@@ -17,13 +17,13 @@ internal class FilterRule : Rule
 		_rule = rule;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
+		var input = _input.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.Array)
 			return Array.Empty<JsonElement>().AsJsonElement();
 
-		return input.EnumerateArray().Where(i => _rule.Apply(i).IsTruthy()).AsJsonElement();
+		return input.EnumerateArray().Where(i => _rule.Apply(data, i).IsTruthy()).AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/IfRule.cs
+++ b/JsonLogic/Rules/IfRule.cs
@@ -16,7 +16,7 @@ internal class IfRule : Rule
 		_components = new List<Rule>(components);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		bool condition;
 		switch (_components.Count)
@@ -24,13 +24,13 @@ internal class IfRule : Rule
 			case 0:
 				return ((string?)null).AsJsonElement();
 			case 1:
-				return _components[0].Apply(data);
+				return _components[0].Apply(data, contextData);
 			case 2:
-				condition = _components[0].Apply(data).IsTruthy();
+				condition = _components[0].Apply(data, contextData).IsTruthy();
 				var thenResult = _components[1];
 
 				return condition
-					? thenResult.Apply(data)
+					? thenResult.Apply(data, contextData)
 					: ((string?)null).AsJsonElement();
 			default:
 				var currentCondition = _components[0];
@@ -39,17 +39,17 @@ internal class IfRule : Rule
 
 				while (currentCondition != null)
 				{
-					condition = currentCondition.Apply(data).IsTruthy();
+					condition = currentCondition.Apply(data, contextData).IsTruthy();
 
 					if (condition)
-						return currentTrueResult.Apply(data);
+						return currentTrueResult.Apply(data, contextData);
 
 					if (elseIndex == _components.Count) return ((string?)null).AsJsonElement();
 
 					currentCondition = _components[elseIndex++];
 
 					if (elseIndex >= _components.Count)
-						return currentCondition.Apply(data);
+						return currentCondition.Apply(data, contextData);
 
 					currentTrueResult = _components[elseIndex++];
 				}

--- a/JsonLogic/Rules/InRule.cs
+++ b/JsonLogic/Rules/InRule.cs
@@ -16,10 +16,10 @@ internal class InRule : Rule
 		_source = source;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var test = _test.Apply(data);
-		var source = _source.Apply(data);
+		var test = _test.Apply(data, contextData);
+		var source = _source.Apply(data, contextData);
 
 		if (source.ValueKind == JsonValueKind.String)
 		{

--- a/JsonLogic/Rules/LessThanEqualRule.cs
+++ b/JsonLogic/Rules/LessThanEqualRule.cs
@@ -22,12 +22,12 @@ internal class LessThanEqualRule : Rule
 		_c = c;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		if (_c == null)
 		{
-			var a = _a.Apply(data);
-			var b = _b.Apply(data);
+			var a = _a.Apply(data, contextData);
+			var b = _b.Apply(data, contextData);
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();
@@ -38,9 +38,9 @@ internal class LessThanEqualRule : Rule
 			return (numberA <= numberB).AsJsonElement();
 		}
 
-		var low = _a.Apply(data);
-		var value = _b.Apply(data);
-		var high = _c.Apply(data);
+		var low = _a.Apply(data, contextData);
+		var value = _b.Apply(data, contextData);
+		var high = _c.Apply(data, contextData);
 
 		if (low.ValueKind != JsonValueKind.Number)
 			throw new JsonLogicException("Lower bound must be a number.");

--- a/JsonLogic/Rules/LessThanRule.cs
+++ b/JsonLogic/Rules/LessThanRule.cs
@@ -23,12 +23,12 @@ internal class LessThanRule : Rule
 		_c = c;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		if (_c == null)
 		{
-			var a = _a.Apply(data);
-			var b = _b.Apply(data);
+			var a = _a.Apply(data, contextData);
+			var b = _b.Apply(data, contextData);
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();
@@ -39,9 +39,9 @@ internal class LessThanRule : Rule
 			return (numberA < numberB).AsJsonElement();
 		}
 
-		var low = _a.Apply(data);
-		var value = _b.Apply(data);
-		var high = _c.Apply(data);
+		var low = _a.Apply(data, contextData);
+		var value = _b.Apply(data, contextData);
+		var high = _c.Apply(data, contextData);
 
 		if (low.ValueKind != JsonValueKind.Number)
 			throw new JsonLogicException("Lower bound must be a number.");

--- a/JsonLogic/Rules/LiteralRule.cs
+++ b/JsonLogic/Rules/LiteralRule.cs
@@ -50,7 +50,7 @@ internal class LiteralRule : Rule
 		_value = value.AsJsonElement();
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		return _value;
 	}

--- a/JsonLogic/Rules/LogRule.cs
+++ b/JsonLogic/Rules/LogRule.cs
@@ -13,9 +13,9 @@ internal class LogRule : Rule
 		_log = log;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var log = _log.Apply(data);
+		var log = _log.Apply(data, contextData);
 
 		Console.WriteLine(log);
 

--- a/JsonLogic/Rules/LooseEqualsRule.cs
+++ b/JsonLogic/Rules/LooseEqualsRule.cs
@@ -15,10 +15,10 @@ internal class LooseEqualsRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		return a.LooseEquals(b).AsJsonElement();
 	}

--- a/JsonLogic/Rules/LooseNotEqualsRule.cs
+++ b/JsonLogic/Rules/LooseNotEqualsRule.cs
@@ -15,10 +15,10 @@ internal class LooseNotEqualsRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		return (!a.LooseEquals(b)).AsJsonElement();
 	}

--- a/JsonLogic/Rules/MapRule.cs
+++ b/JsonLogic/Rules/MapRule.cs
@@ -17,13 +17,13 @@ internal class MapRule : Rule
 		_rule = rule;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
+		var input = _input.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.Array)
 			return Array.Empty<JsonElement>().AsJsonElement();
 
-		return input.EnumerateArray().Select(i => _rule.Apply(i)).AsJsonElement();
+		return input.EnumerateArray().Select(i => _rule.Apply(data, i)).AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/MaxRule.cs
+++ b/JsonLogic/Rules/MaxRule.cs
@@ -17,9 +17,9 @@ internal class MaxRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data)).Select(e => new { e.ValueKind, Value = e.Numberify() }).ToList();
+		var items = _items.Select(i => i.Apply(data, contextData)).Select(e => new { e.ValueKind, Value = e.Numberify() }).ToList();
 		var nulls = items.Where(i => i.Value == null);
 		if (nulls.Any())
 			throw new JsonLogicException($"Cannot find max with {nulls.First().ValueKind}.");

--- a/JsonLogic/Rules/MergeRule.cs
+++ b/JsonLogic/Rules/MergeRule.cs
@@ -15,9 +15,9 @@ internal class MergeRule : Rule
 		_items = items.ToList();
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data)).SelectMany(e => e.Flatten());
+		var items = _items.Select(i => i.Apply(data, contextData)).SelectMany(e => e.Flatten());
 
 		return items.AsJsonElement();
 	}

--- a/JsonLogic/Rules/MinRule.cs
+++ b/JsonLogic/Rules/MinRule.cs
@@ -17,9 +17,9 @@ internal class MinRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data)).Select(e => new { e.ValueKind, Value = e.Numberify() }).ToList();
+		var items = _items.Select(i => i.Apply(data, contextData)).Select(e => new { e.ValueKind, Value = e.Numberify() }).ToList();
 		var nulls = items.Where(i => i.Value == null);
 		if (nulls.Any())
 			throw new JsonLogicException($"Cannot find min with {nulls.First().ValueKind}.");

--- a/JsonLogic/Rules/MissingRule.cs
+++ b/JsonLogic/Rules/MissingRule.cs
@@ -15,9 +15,9 @@ internal class MissingRule : Rule
 		_components = components;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var expected = _components.SelectMany(c => c.Apply(data).Flatten())
+		var expected = _components.SelectMany(c => c.Apply(data, contextData).Flatten())
 			.Where(e => e.ValueKind == JsonValueKind.String);
 
 		if (data.ValueKind != JsonValueKind.Object)

--- a/JsonLogic/Rules/MissingSomeRule.cs
+++ b/JsonLogic/Rules/MissingSomeRule.cs
@@ -18,10 +18,10 @@ internal class MissingSomeRule : Rule
 		_components = components;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var requiredCount = _requiredCount.Apply(data).Numberify();
-		var components = _components.Apply(data);
+		var requiredCount = _requiredCount.Apply(data, contextData).Numberify();
+		var components = _components.Apply(data, contextData);
 		if (components.ValueKind != JsonValueKind.Array)
 			throw new JsonLogicException("Expected array of required paths.");
 

--- a/JsonLogic/Rules/ModRule.cs
+++ b/JsonLogic/Rules/ModRule.cs
@@ -15,10 +15,10 @@ internal class ModRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();

--- a/JsonLogic/Rules/MoreThanEqualRule.cs
+++ b/JsonLogic/Rules/MoreThanEqualRule.cs
@@ -15,10 +15,10 @@ internal class MoreThanEqualRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();

--- a/JsonLogic/Rules/MoreThanRule.cs
+++ b/JsonLogic/Rules/MoreThanRule.cs
@@ -15,10 +15,10 @@ internal class MoreThanRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var a = _a.Apply(data);
-		var b = _b.Apply(data);
+		var a = _a.Apply(data, contextData);
+		var b = _b.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();

--- a/JsonLogic/Rules/MultiplyRule.cs
+++ b/JsonLogic/Rules/MultiplyRule.cs
@@ -15,13 +15,13 @@ internal class MultiplyRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		decimal result = 1;
 
 		foreach (var item in _items)
 		{
-			var value = item.Apply(data);
+			var value = item.Apply(data, contextData);
 
 			var number = value.Numberify();
 

--- a/JsonLogic/Rules/NoneRule.cs
+++ b/JsonLogic/Rules/NoneRule.cs
@@ -16,15 +16,15 @@ internal class NoneRule : Rule
 		_rule = rule;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
+		var input = _input.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.Array)
 			throw new JsonLogicException("Input must evaluate to an array.");
 
 		var inputData = input.EnumerateArray();
-		return (!inputData.Select(value => _rule.Apply(value))
+		return (!inputData.Select(value => _rule.Apply(data, value))
 				.Any(result => result.IsTruthy()))
 			.AsJsonElement();
 	}

--- a/JsonLogic/Rules/NotRule.cs
+++ b/JsonLogic/Rules/NotRule.cs
@@ -13,9 +13,9 @@ internal class NotRule : Rule
 		_value = value;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var value = _value.Apply(data);
+		var value = _value.Apply(data, contextData);
 
 		return (!value.IsTruthy()).AsJsonElement();
 	}

--- a/JsonLogic/Rules/OrRule.cs
+++ b/JsonLogic/Rules/OrRule.cs
@@ -16,9 +16,9 @@ internal class OrRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data));
+		var items = _items.Select(i => i.Apply(data, contextData));
 		var first = false.AsJsonElement();
 		foreach (var x in items)
 		{

--- a/JsonLogic/Rules/ReduceRule.cs
+++ b/JsonLogic/Rules/ReduceRule.cs
@@ -24,10 +24,10 @@ internal class ReduceRule : Rule
 		_initial = initial;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
-		var accumulator = _initial.Apply(data);
+		var input = _input.Apply(data, contextData);
+		var accumulator = _initial.Apply(data, contextData);
 
 		if (input.ValueKind == JsonValueKind.Null) return accumulator;
 		if (input.ValueKind != JsonValueKind.Array)
@@ -43,7 +43,7 @@ internal class ReduceRule : Rule
 			using var doc = JsonDocument.Parse(JsonSerializer.Serialize(intermediary, _options));
 			var item = doc.RootElement.Clone();
 
-			accumulator = _rule.Apply(item);
+			accumulator = _rule.Apply(data, item);
 		}
 
 		return accumulator;

--- a/JsonLogic/Rules/RuleCollection.cs
+++ b/JsonLogic/Rules/RuleCollection.cs
@@ -18,8 +18,8 @@ internal class RuleCollection : Rule
 		_rules = rules;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		return _rules.Select(x => x.Apply(data)).AsJsonElement();
+		return _rules.Select(x => x.Apply(data, contextData)).AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/SomeRule.cs
+++ b/JsonLogic/Rules/SomeRule.cs
@@ -16,15 +16,15 @@ internal class SomeRule : Rule
 		_rule = rule;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
+		var input = _input.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.Array)
 			throw new JsonLogicException("Input must evaluate to an array.");
 
 		var inputData = input.EnumerateArray();
-		return inputData.Select(value => _rule.Apply(value))
+		return inputData.Select(value => _rule.Apply(data, value))
 			.Any(result => result.IsTruthy())
 			.AsJsonElement();
 	}

--- a/JsonLogic/Rules/StrictEqualsRule.cs
+++ b/JsonLogic/Rules/StrictEqualsRule.cs
@@ -15,8 +15,8 @@ internal class StrictEqualsRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		return _a.Apply(data).IsEquivalentTo(_b.Apply(data)).AsJsonElement();
+		return _a.Apply(data, contextData).IsEquivalentTo(_b.Apply(data, contextData)).AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/StrictNotEqualsRule.cs
+++ b/JsonLogic/Rules/StrictNotEqualsRule.cs
@@ -15,8 +15,8 @@ internal class StrictNotEqualsRule : Rule
 		_b = b;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		return (!_a.Apply(data).IsEquivalentTo(_b.Apply(data))).AsJsonElement();
+		return (!_a.Apply(data, contextData).IsEquivalentTo(_b.Apply(data, contextData))).AsJsonElement();
 	}
 }

--- a/JsonLogic/Rules/SubstrRule.cs
+++ b/JsonLogic/Rules/SubstrRule.cs
@@ -23,11 +23,11 @@ internal class SubstrRule : Rule
 		_count = count;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
-		var input = _input.Apply(data);
-		var start = _start.Apply(data);
-		var count = _count?.Apply(data);
+		var input = _input.Apply(data, contextData);
+		var start = _start.Apply(data, contextData);
+		var count = _count?.Apply(data, contextData);
 
 		if (input.ValueKind != JsonValueKind.String)
 			throw new JsonLogicException($"Cannot substring a {input.ValueKind}.");

--- a/JsonLogic/Rules/SubtractRule.cs
+++ b/JsonLogic/Rules/SubtractRule.cs
@@ -16,11 +16,11 @@ internal class SubtractRule : Rule
 		_items.AddRange(more);
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		if (_items.Count == 0) return 0.AsJsonElement();
 
-		var value = _items[0].Apply(data);
+		var value = _items[0].Apply(data, contextData);
 		var number = value.Numberify();
 
 		if (number == null)
@@ -33,7 +33,7 @@ internal class SubtractRule : Rule
 
 		foreach (var item in _items.Skip(1))
 		{
-			value = item.Apply(data);
+			value = item.Apply(data, contextData);
 
 			number = value.Numberify();
 

--- a/JsonLogic/Rules/VariableRule.cs
+++ b/JsonLogic/Rules/VariableRule.cs
@@ -23,16 +23,18 @@ internal class VariableRule : Rule
 		_defaultValue = defaultValue;
 	}
 
-	public override JsonElement Apply(JsonElement data)
+	public override JsonElement Apply(JsonElement data, JsonElement? contextData = null)
 	{
 		if (_path == null) return data;
 
-		var path = _path.Apply(data);
+		var path = _path.Apply(data, contextData);
 		var pathString = path.Stringify()!;
+		if (pathString == string.Empty) return contextData ?? data;
+
 		var pointer = JsonPointer.Parse(pathString == string.Empty ? "" : $"/{pathString.Replace('.', '/')}");
-		var pathEval = pointer.Evaluate(data);
+		var pathEval = pointer.Evaluate(contextData ?? data) ?? pointer.Evaluate(data);
 		if (pathEval != null) return pathEval.Value;
 
-		return _defaultValue?.Apply(data) ?? ((string?)null).AsJsonElement();
+		return _defaultValue?.Apply(data, contextData) ?? ((string?)null).AsJsonElement();
 	}
 }

--- a/json-everything.net/wwwroot/md/release-notes/json-logic.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-logic.md
@@ -1,6 +1,13 @@
-# (coming soon)
+# [2.0.0](https://github.com/gregsdennis/json-everything/pull/265)
 
 [#243](https://github.com/gregsdennis/json-everything/pull/243) - Updated System.Text.Json to version 6.
+
+[#263](https://github.com/gregsdennis/json-everything/issues/263) - `{"var": ""}` is used by some operations to pass context data into inner rules, but the external data is also available.
+
+## Breaking Changes
+
+- Added optional parameter to `Rule.Apply()` in order to supply context data.
+- `"var"` will now prioritize context data over external data.  If the path yields no result for context data, it will search the external data.  This means that if both the context data and the external data have the given path, the context data will be used.
 
 # [1.4.0](https://github.com/gregsdennis/json-everything/pull/205)
 


### PR DESCRIPTION
Resolves #263 

@wangh-trimble I think this addresses the issue.  It basically follows your suggestion of adding the secondary parameter, but I did it without an overload.  Either way would have been a breaking change, I think.  It's fine.

It passes all of the tests, including your new one, so I guess it's fine.

This functionality overall has been... weird... to implement.