### PR TITLE
Remove JetBrains.Annotations reference from nuget package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -39,7 +39,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 


### PR DESCRIPTION
I would like to remove the reference to JetBrains.Annotations reference from the JsonPatch.Net nuget package.

According to https://blog.jetbrains.com/dotnet/2015/08/12/how-to-use-jetbrains-annotations-to-improve-resharper-inspections/, this is not the best practice, but I don't know, if you want to have the annotation source code in the repository. This change does not change with regards to the nuget package, as the annotations are not compiled into the assembly by default.