### PR TITLE
Check Condition on System.Text.Json.JsonIgnoreAttribute

### DIFF
--- a/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
+++ b/JsonSchema.Generation/Generators/ObjectSchemaGenerator.cs
@@ -43,7 +43,7 @@ internal class ObjectSchemaGenerator : ISchemaGenerator
 			var memberAttributes = member.GetCustomAttributes().ToList();
 #pragma warning disable 8600 // Assigning null to non-null
 			// ReSharper disable once AssignNullToNotNullAttribute
-			var ignoreAttribute = (Attribute)memberAttributes.OfType<JsonIgnoreAttribute>().FirstOrDefault() ??
+			var ignoreAttribute = (Attribute)memberAttributes.OfType<JsonIgnoreAttribute>().Where(a=>a.Condition == JsonIgnoreCondition.Always).FirstOrDefault() ??
 								  memberAttributes.OfType<JsonExcludeAttribute>().FirstOrDefault();
 #pragma warning restore 8600
 			if (ignoreAttribute != null) continue;


### PR DESCRIPTION
I'm typically adding
`[JsonIgnore(Condition = JsonIgnoreCondition.Never)]`
to my classes, to ensure that serialized json has the format I want,
even if someone changes the global `JsonIgnoreCondition`.

This means that the existance of `JsonIgnore` is not enough, but you
need to check that `Condition == JsonIgnoreCondition.Always`.

The Docs for `[JsonIgnore]` states that `Always` is the default condition
and the other conditions does not indicate that the property should be
ignored from schema.
https://docs.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonignoreattribute.condition?view=net-6.0