### PR TITLE
Add missing options argument to serializer during apply

### DIFF
--- a/JsonPatch.Tests/PatchExtensionTests.cs
+++ b/JsonPatch.Tests/PatchExtensionTests.cs
@@ -309,6 +309,23 @@ public class PatchExtensionTests
 		Assert.AreEqual(model.InnerObjects[1].Id, final.InnerObjects[0].Id);
 	}
 
+	[Test]
+	public void ApplyPatch_Respect_SerializationOptions()
+	{
+		var model = new TestModel
+		{
+			Numbers = new int[0],
+		};
+
+		var patchStr = "[{\"op\":\"add\",\"path\":\"/numbers/-\",\"value\":5}]";
+		var patch = JsonSerializer.Deserialize<JsonPatch>(patchStr)!;
+
+		var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+		var final = patch.Apply(model, options);
+
+		Assert.AreEqual(5, final?.Numbers?[0]);
+	}
+
 	private static void OutputPatch(JsonPatch patch)
 	{
 		Console.WriteLine(JsonSerializer.Serialize(patch, new JsonSerializerOptions { WriteIndented = true }));

--- a/JsonPatch/PatchExtensions.cs
+++ b/JsonPatch/PatchExtensions.cs
@@ -39,7 +39,7 @@ public static class PatchExtensions
 	/// <exception cref="InvalidOperationException">Thrown when the patch cannot be applied.</exception>
 	public static TTarget? Apply<TOriginal, TTarget>(this JsonPatch patch, TOriginal obj, JsonSerializerOptions? options = null)
 	{
-		var node = JsonSerializer.SerializeToNode(obj);
+		var node = JsonSerializer.SerializeToNode(obj, options);
 		var patchResult = patch.Apply(node);
 		if (!patchResult.IsSuccess)
 			throw new InvalidOperationException($"{patchResult.Error} Operation: {patchResult.Operation}");


### PR DESCRIPTION
Hello there!

I've noticed that in the `Apply<T1, T2>()` `JsonPatch` extension method the given `JsonSerializerOptions` argument is not passed forward to the `JsonSerializer.SerializeToNode()` function. This caused some issues that I've reproduced in a unit test.

Thanks!