### PR TITLE
Vocab data v2

### DIFF
--- a/JsonSchema.Data.Tests/Tests.cs
+++ b/JsonSchema.Data.Tests/Tests.cs
@@ -7,17 +7,17 @@ namespace Json.Schema.Data.Tests;
 public class Tests
 {
 	private static JsonSchema InstanceRef { get; } = new JsonSchemaBuilder()
-		.Schema("https://gregsdennis.github.io/json-everything/meta/data")
+		.Schema("https://json-everything.net/meta/data-2022")
 		.Type(SchemaValueType.Object)
 		.Properties(
 			("foo", new JsonSchemaBuilder()
 				.Type(SchemaValueType.Integer)
-				.Data(("minimum", "#/minValue"))
+				.Data(("minimum", "/minValue"))
 			)
 		);
 
 	private static JsonSchema ExternalRef { get; } = new JsonSchemaBuilder()
-		.Schema("https://gregsdennis.github.io/json-everything/meta/data")
+		.Schema("https://json-everything.net/meta/data-2022")
 		.Type(SchemaValueType.Object)
 		.Properties(
 			("foo", new JsonSchemaBuilder()

--- a/JsonSchema.Data.Tests/Tests.cs
+++ b/JsonSchema.Data.Tests/Tests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Json.Schema.Tests;
 using NUnit.Framework;
 
@@ -62,9 +63,7 @@ public class Tests
 		var instanceData = "{\"minValue\":true,\"foo\":10}";
 		var instance = JsonDocument.Parse(instanceData).RootElement;
 
-		var result = InstanceRef.Validate(instance);
-
-		result.AssertInvalid();
+		Assert.Throws<JsonException>(() => InstanceRef.Validate(instance));
 	}
 
 	[Test]
@@ -73,9 +72,7 @@ public class Tests
 		var instanceData = "{\"minValu\":5,\"foo\":10}";
 		var instance = JsonDocument.Parse(instanceData).RootElement;
 
-		var result = InstanceRef.Validate(instance);
-
-		result.AssertInvalid();
+		Assert.Throws<RefResolutionException>(() => InstanceRef.Validate(instance));
 	}
 
 	[Test]
@@ -83,7 +80,7 @@ public class Tests
 	{
 		try
 		{
-			DataKeyword.Fetch = _ => "{\"minValue\":5}";
+			DataKeyword.Fetch = _ => JsonNode.Parse("{\"minValue\":5}");
 
 			var instanceData = "{\"foo\":10}";
 			var instance = JsonDocument.Parse(instanceData).RootElement;
@@ -103,7 +100,7 @@ public class Tests
 	{
 		try
 		{
-			DataKeyword.Fetch = _ => "{\"minValue\":15}";
+			DataKeyword.Fetch = _ => JsonNode.Parse("{\"minValue\":15}");
 
 			var instanceData = "{\"foo\":10}";
 			var instance = JsonDocument.Parse(instanceData).RootElement;

--- a/JsonSchema.Data.Tests/Tests.cs
+++ b/JsonSchema.Data.Tests/Tests.cs
@@ -83,7 +83,7 @@ public class Tests
 	{
 		try
 		{
-			DataKeyword.Get = _ => "{\"minValue\":5}";
+			DataKeyword.Fetch = _ => "{\"minValue\":5}";
 
 			var instanceData = "{\"foo\":10}";
 			var instance = JsonDocument.Parse(instanceData).RootElement;
@@ -94,7 +94,7 @@ public class Tests
 		}
 		finally
 		{
-			DataKeyword.Get = null!;
+			DataKeyword.Fetch = null!;
 		}
 	}
 
@@ -103,7 +103,7 @@ public class Tests
 	{
 		try
 		{
-			DataKeyword.Get = _ => "{\"minValue\":15}";
+			DataKeyword.Fetch = _ => "{\"minValue\":15}";
 
 			var instanceData = "{\"foo\":10}";
 			var instance = JsonDocument.Parse(instanceData).RootElement;
@@ -114,7 +114,7 @@ public class Tests
 		}
 		finally
 		{
-			DataKeyword.Get = null!;
+			DataKeyword.Fetch = null!;
 		}
 	}
 }

--- a/JsonSchema.Data.Tests/Tests.cs
+++ b/JsonSchema.Data.Tests/Tests.cs
@@ -17,6 +17,21 @@ public class Tests
 			)
 		);
 
+	private static JsonSchema InstanceRelativeRef { get; } = new JsonSchemaBuilder()
+		.Schema("https://json-everything.net/meta/data-2022")
+		.Type(SchemaValueType.Object)
+		.Properties(
+			("foo", new JsonSchemaBuilder()
+				.Type(SchemaValueType.Object)
+				.Properties(
+					("bar", new JsonSchemaBuilder()
+						.Type(SchemaValueType.Integer)
+						.Data(("minimum", "2/minValue"))
+					)
+				)
+			)
+		);
+
 	private static JsonSchema ExternalRef { get; } = new JsonSchemaBuilder()
 		.Schema("https://json-everything.net/meta/data-2022")
 		.Type(SchemaValueType.Object)
@@ -53,6 +68,28 @@ public class Tests
 		var instance = JsonDocument.Parse(instanceData).RootElement;
 
 		var result = InstanceRef.Validate(instance);
+
+		result.AssertInvalid();
+	}
+
+	[Test]
+	public void InstanceRelativeRef_Passing()
+	{
+		var instanceData = "{\"minValue\":5,\"foo\":{\"bar\":10}}";
+		var instance = JsonDocument.Parse(instanceData).RootElement;
+
+		var result = InstanceRelativeRef.Validate(instance);
+
+		result.AssertValid();
+	}
+
+	[Test]
+	public void InstanceRelativeRef_Failing()
+	{
+		var instanceData = "{\"minValue\":15,\"foo\":{\"bar\":10}}";
+		var instance = JsonDocument.Parse(instanceData).RootElement;
+
+		var result = InstanceRelativeRef.Validate(instance);
 
 		result.AssertInvalid();
 	}

--- a/JsonSchema.Data/DataKeyword.cs
+++ b/JsonSchema.Data/DataKeyword.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
-using Json.Pointer;
 
 namespace Json.Schema.Data;
 

--- a/JsonSchema.Data/IDataResourceIdentifier.cs
+++ b/JsonSchema.Data/IDataResourceIdentifier.cs
@@ -2,7 +2,16 @@
 
 namespace Json.Schema.Data;
 
+/// <summary>
+/// Provides an abstraction for different resource identifier types.
+/// </summary>
 public interface IDataResourceIdentifier
 {
+	/// <summary>
+	/// Attempts to resolve the reference.
+	/// </summary>
+	/// <param name="context">The schema evaluation context.</param>
+	/// <param name="value">If return is true, the value at the indicated location.</param>
+	/// <returns>true if resolution is successful; false otherwise.</returns>
 	bool TryResolve(ValidationContext context, out JsonNode? value);
 }

--- a/JsonSchema.Data/IDataResourceIdentifier.cs
+++ b/JsonSchema.Data/IDataResourceIdentifier.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Nodes;
+
+namespace Json.Schema.Data;
+
+public interface IDataResourceIdentifier
+{
+	bool TryResolve(ValidationContext context, out JsonNode? value);
+}

--- a/JsonSchema.Data/JsonPointerIdentifier.cs
+++ b/JsonSchema.Data/JsonPointerIdentifier.cs
@@ -3,20 +3,38 @@ using Json.Pointer;
 
 namespace Json.Schema.Data;
 
+/// <summary>
+/// Handles data references that are JSON Pointers.
+/// </summary>
 public class JsonPointerIdentifier : IDataResourceIdentifier
 {
+	/// <summary>
+	/// The JSON Pointer target.
+	/// </summary>
 	public JsonPointer Target { get; }
 
+	/// <summary>
+	/// Creates a new instance of <see cref="JsonPointerIdentifier"/>.
+	/// </summary>
+	/// <param name="target">The target.</param>
 	public JsonPointerIdentifier(JsonPointer target)
 	{
 		Target = target;
 	}
 
+	/// <summary>
+	/// Attempts to resolve the reference.
+	/// </summary>
+	/// <param name="context">The schema evaluation context.</param>
+	/// <param name="value">If return is true, the value at the indicated location.</param>
+	/// <returns>true if resolution is successful; false otherwise.</returns>
 	public bool TryResolve(ValidationContext context, out JsonNode? value)
 	{
 		return Target.TryEvaluate(context.InstanceRoot, out value);
 	}
 
+	/// <summary>Returns a string that represents the current object.</summary>
+	/// <returns>A string that represents the current object.</returns>
 	public override string ToString()
 	{
 		return Target.ToString();

--- a/JsonSchema.Data/JsonPointerIdentifier.cs
+++ b/JsonSchema.Data/JsonPointerIdentifier.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Nodes;
+using Json.Pointer;
+
+namespace Json.Schema.Data;
+
+public class JsonPointerIdentifier : IDataResourceIdentifier
+{
+	public JsonPointer Target { get; }
+
+	public JsonPointerIdentifier(JsonPointer target)
+	{
+		Target = target;
+	}
+
+	public bool TryResolve(ValidationContext context, out JsonNode? value)
+	{
+		return Target.TryEvaluate(context.InstanceRoot, out value);
+	}
+
+	public override string ToString()
+	{
+		return Target.ToString();
+	}
+}

--- a/JsonSchema.Data/JsonSchema.Data.csproj
+++ b/JsonSchema.Data/JsonSchema.Data.csproj
@@ -16,9 +16,9 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonSchema.Net.Data.xml</DocumentationFile>
 		<LangVersion>latest</LangVersion>
-		<Version>2.0.1</Version>
-		<FileVersion>2.0.1.0</FileVersion>
-		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<Version>3.0.0</Version>
+		<FileVersion>3.0.0.0</FileVersion>
+		<AssemblyVersion>3.0.0.0</AssemblyVersion>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
+++ b/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using Json.Pointer;
 
 namespace Json.Schema.Data;
 
@@ -17,7 +19,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Data(this JsonSchemaBuilder builder, IReadOnlyDictionary<string, string> data)
 	{
-		builder.Add(new DataKeyword(data.ToDictionary(x => x.Key, x => new Uri(x.Value, UriKind.RelativeOrAbsolute))));
+		builder.Add(new DataKeyword(data.ToDictionary(x => x.Key, x => CreateResourceIdentifier(x.Value))));
 		return builder;
 	}
 
@@ -29,7 +31,16 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Data(this JsonSchemaBuilder builder, params (string name, string reference)[] data)
 	{
-		builder.Add(new DataKeyword(data.ToDictionary(x => x.name, x => new Uri(x.reference, UriKind.RelativeOrAbsolute))));
+		builder.Add(new DataKeyword(data.ToDictionary(x => x.name, x => CreateResourceIdentifier(x.reference))));
 		return builder;
+	}
+
+	internal static IDataResourceIdentifier CreateResourceIdentifier(string identifier)
+	{
+		if (JsonPointer.TryParse(identifier, out var jp)) return new JsonPointerIdentifier(jp);
+		if (RelativeJsonPointer.TryParse(identifier, out var rjp)) return new RelativeJsonPointerIdentifier(rjp);
+		if (Uri.TryCreate(identifier, UriKind.RelativeOrAbsolute, out var uri)) return new UriIdentifier(uri);
+
+		throw new JsonException($"Cannot identify type of resource identifier for '{identifier}'");
 	}
 }

--- a/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
+++ b/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
@@ -15,33 +15,9 @@ public static class JsonSchemaBuilderExtensions
 	/// <param name="builder">The builder.</param>
 	/// <param name="data">The collection of keywords and references.</param>
 	/// <returns>The builder.</returns>
-	public static JsonSchemaBuilder Data(this JsonSchemaBuilder builder, IReadOnlyDictionary<string, Uri> data)
-	{
-		builder.Add(new DataKeyword(data));
-		return builder;
-	}
-
-	/// <summary>
-	/// Adds a `data` keyword.
-	/// </summary>
-	/// <param name="builder">The builder.</param>
-	/// <param name="data">The collection of keywords and references.</param>
-	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Data(this JsonSchemaBuilder builder, IReadOnlyDictionary<string, string> data)
 	{
 		builder.Add(new DataKeyword(data.ToDictionary(x => x.Key, x => new Uri(x.Value, UriKind.RelativeOrAbsolute))));
-		return builder;
-	}
-
-	/// <summary>
-	/// Adds a `data` keyword.
-	/// </summary>
-	/// <param name="builder">The builder.</param>
-	/// <param name="data">The collection of keywords and references.</param>
-	/// <returns>The builder.</returns>
-	public static JsonSchemaBuilder Data(this JsonSchemaBuilder builder, params (string name, Uri reference)[] data)
-	{
-		builder.Add(new DataKeyword(data.ToDictionary(x => x.name, x => x.reference)));
 		return builder;
 	}
 

--- a/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
+++ b/JsonSchema.Data/JsonSchemaBuilderExtensions.cs
@@ -37,8 +37,8 @@ public static class JsonSchemaBuilderExtensions
 
 	internal static IDataResourceIdentifier CreateResourceIdentifier(string identifier)
 	{
-		if (JsonPointer.TryParse(identifier, out var jp)) return new JsonPointerIdentifier(jp);
-		if (RelativeJsonPointer.TryParse(identifier, out var rjp)) return new RelativeJsonPointerIdentifier(rjp);
+		if (JsonPointer.TryParse(identifier, out var jp)) return new JsonPointerIdentifier(jp!);
+		if (RelativeJsonPointer.TryParse(identifier, out var rjp)) return new RelativeJsonPointerIdentifier(rjp!);
 		if (Uri.TryCreate(identifier, UriKind.RelativeOrAbsolute, out var uri)) return new UriIdentifier(uri);
 
 		throw new JsonException($"Cannot identify type of resource identifier for '{identifier}'");

--- a/JsonSchema.Data/MetaSchemas.cs
+++ b/JsonSchema.Data/MetaSchemas.cs
@@ -11,7 +11,7 @@ public static class MetaSchemas
 	/// <summary>
 	/// The data vocabulary meta-schema ID.
 	/// </summary>
-	public static readonly Uri DataId = new("https://gregsdennis.github.io/json-everything/meta/data");
+	public static readonly Uri DataId = new("https://json-everything.net/meta/data-2022");
 
 	/// <summary>
 	/// The data vocabulary meta-schema.
@@ -35,7 +35,12 @@ public static class MetaSchemas
 				(DataKeyword.Name, new JsonSchemaBuilder()
 					.AdditionalProperties(new JsonSchemaBuilder()
 						.Type(SchemaValueType.String)
-						.Format(Formats.UriReference))
+						.OneOf(
+							new JsonSchemaBuilder().Format(Formats.UriReference),
+							new JsonSchemaBuilder().Format(Formats.JsonPointer),
+							new JsonSchemaBuilder().Format(Formats.RelativeJsonPointer)
+						)
+					)
 					.Default(new JsonObject())
 				)
 			);

--- a/JsonSchema.Data/MetaSchemas.cs
+++ b/JsonSchema.Data/MetaSchemas.cs
@@ -36,9 +36,9 @@ public static class MetaSchemas
 					.AdditionalProperties(new JsonSchemaBuilder()
 						.Type(SchemaValueType.String)
 						.OneOf(
-							new JsonSchemaBuilder().Format(Formats.UriReference),
 							new JsonSchemaBuilder().Format(Formats.JsonPointer),
-							new JsonSchemaBuilder().Format(Formats.RelativeJsonPointer)
+							new JsonSchemaBuilder().Format(Formats.RelativeJsonPointer),
+							new JsonSchemaBuilder().Format(Formats.UriReference)
 						)
 					)
 					.Default(new JsonObject())

--- a/JsonSchema.Data/RefResolutionException.cs
+++ b/JsonSchema.Data/RefResolutionException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Json.Schema.Data;
 
 // ReSharper disable once CheckNamespace
 namespace Json.Schema;

--- a/JsonSchema.Data/RefResolutionException.cs
+++ b/JsonSchema.Data/RefResolutionException.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Json.Schema.Data;
 
 // ReSharper disable once CheckNamespace
 namespace Json.Schema;
@@ -14,16 +16,15 @@ public class RefResolutionException : Exception
 	/// <summary>
 	/// The URI that could not be resolved.
 	/// </summary>
-	public Uri Uri { get; }
+	public IEnumerable<string> References { get; }
 
 	/// <summary>
 	/// Thrown when a reference cannot be resolved.
 	/// </summary>
-	/// <param name="uri">The URI that could not be resolved.</param>
-	/// <param name="inner">The inner exception.</param>
-	public RefResolutionException(Uri uri, Exception inner)
-		: base($"An error occurred attempting to resolve URI `{uri}`", inner)
+	/// <param name="references">The references that could not be resolved.</param>
+	public RefResolutionException(IEnumerable<string> references)
+		: base("An error occurred attempting to resolve one or more references")
 	{
-		Uri = uri;
+		References = references;
 	}
 }

--- a/JsonSchema.Data/RefResolutionException.cs
+++ b/JsonSchema.Data/RefResolutionException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace Json.Schema;
+
+/// <summary>
+/// Thrown when a reference cannot be resolved.
+/// </summary>
+/// <remarks>
+/// This class will be moved into a future version of JsonSchema.Net.
+/// </remarks>
+public class RefResolutionException : Exception
+{
+	/// <summary>
+	/// The URI that could not be resolved.
+	/// </summary>
+	public Uri Uri { get; }
+
+	/// <summary>
+	/// Thrown when a reference cannot be resolved.
+	/// </summary>
+	/// <param name="uri">The URI that could not be resolved.</param>
+	/// <param name="inner">The inner exception.</param>
+	public RefResolutionException(Uri uri, Exception inner)
+		: base($"An error occurred attempting to resolve URI `{uri}`", inner)
+	{
+		Uri = uri;
+	}
+}

--- a/JsonSchema.Data/RelativeJsonPointerIdentifier.cs
+++ b/JsonSchema.Data/RelativeJsonPointerIdentifier.cs
@@ -3,20 +3,43 @@ using Json.Pointer;
 
 namespace Json.Schema.Data;
 
+/// <summary>
+/// Handles data references that are Relative JSON Pointers.
+/// </summary>
 public class RelativeJsonPointerIdentifier : IDataResourceIdentifier
 {
+	/// <summary>
+	/// The Relative JSON Pointer target.
+	/// </summary>
 	public RelativeJsonPointer Target { get; }
 
+	/// <summary>
+	/// Creates a new instance of <see cref="RelativeJsonPointerIdentifier"/>.
+	/// </summary>
+	/// <param name="target">The target.</param>
 	public RelativeJsonPointerIdentifier(RelativeJsonPointer target)
 	{
 		Target = target;
 	}
 
+	/// <summary>
+	/// Attempts to resolve the reference.
+	/// </summary>
+	/// <param name="context">The schema evaluation context.</param>
+	/// <param name="value">If return is true, the value at the indicated location.</param>
+	/// <returns>true if resolution is successful; false otherwise.</returns>
 	public bool TryResolve(ValidationContext context, out JsonNode? value)
 	{
+		if (context.LocalInstance == null)
+		{
+			value = null;
+			return false;
+		}
 		return Target.TryEvaluate(context.LocalInstance, out value);
 	}
 
+	/// <summary>Returns a string that represents the current object.</summary>
+	/// <returns>A string that represents the current object.</returns>
 	public override string ToString()
 	{
 		return Target.ToString();

--- a/JsonSchema.Data/RelativeJsonPointerIdentifier.cs
+++ b/JsonSchema.Data/RelativeJsonPointerIdentifier.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Nodes;
+using Json.Pointer;
+
+namespace Json.Schema.Data;
+
+public class RelativeJsonPointerIdentifier : IDataResourceIdentifier
+{
+	public RelativeJsonPointer Target { get; }
+
+	public RelativeJsonPointerIdentifier(RelativeJsonPointer target)
+	{
+		Target = target;
+	}
+
+	public bool TryResolve(ValidationContext context, out JsonNode? value)
+	{
+		return Target.TryEvaluate(context.LocalInstance, out value);
+	}
+
+	public override string ToString()
+	{
+		return Target.ToString();
+	}
+}

--- a/JsonSchema.Data/UriIdentifier.cs
+++ b/JsonSchema.Data/UriIdentifier.cs
@@ -5,16 +5,32 @@ using Json.Pointer;
 
 namespace Json.Schema.Data;
 
+/// <summary>
+/// Handles data references that are URIs.
+/// </summary>
 public class UriIdentifier : IDataResourceIdentifier
 {
+	/// <summary>
+	/// The URI target.
+	/// </summary>
 	public Uri Target { get; }
 
+	/// <summary>
+	/// Creates a new instance of <see cref="UriIdentifier"/>.
+	/// </summary>
+	/// <param name="target">The target.</param>
 	public UriIdentifier(Uri target)
 	{
 		Target = target;
 	}
 
-	public bool TryResolve(ValidationContext context, out JsonNode? node)
+	/// <summary>
+	/// Attempts to resolve the reference.
+	/// </summary>
+	/// <param name="context">The schema evaluation context.</param>
+	/// <param name="value">If return is true, the value at the indicated location.</param>
+	/// <returns>true if resolution is successful; false otherwise.</returns>
+	public bool TryResolve(ValidationContext context, out JsonNode? value)
 	{
 		var parts = Target.OriginalString.Split(new[] { '#' }, StringSplitOptions.None);
 		var baseUri = parts[0];
@@ -38,7 +54,7 @@ public class UriIdentifier : IDataResourceIdentifier
 			if (!wasResolved)
 			{
 				context.LocalResult.Fail(ErrorMessages.BaseUriResolution, ("uri", baseUri));
-				node = null;
+				value = null;
 				return false;
 			}
 		}
@@ -51,20 +67,20 @@ public class UriIdentifier : IDataResourceIdentifier
 			if (!JsonPointer.TryParse(fragment, out var pointer))
 			{
 				context.LocalResult.Fail(ErrorMessages.PointerParse, ("fragment", fragment));
-				node = null;
+				value = null;
 				return false;
 			}
 
 			if (!pointer!.TryEvaluate(data, out var resolved))
 			{
 				context.LocalResult.Fail(ErrorMessages.RefResolution, ("uri", fragment));
-				node = null;
+				value = null;
 				return false;
 			}
 			data = resolved;
 		}
 
-		node = data;
+		value = data;
 		return true;
 	}
 
@@ -80,6 +96,8 @@ public class UriIdentifier : IDataResourceIdentifier
 		return true;
 	}
 
+	/// <summary>Returns a string that represents the current object.</summary>
+	/// <returns>A string that represents the current object.</returns>
 	public override string ToString()
 	{
 		return Target.ToString();

--- a/JsonSchema.Data/UriIdentifier.cs
+++ b/JsonSchema.Data/UriIdentifier.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Pointer;
+
+namespace Json.Schema.Data;
+
+public class UriIdentifier : IDataResourceIdentifier
+{
+	public Uri Target { get; }
+
+	public UriIdentifier(Uri target)
+	{
+		Target = target;
+	}
+
+	public bool TryResolve(ValidationContext context, out JsonNode? node)
+	{
+		var parts = Target.OriginalString.Split(new[] { '#' }, StringSplitOptions.None);
+		var baseUri = parts[0];
+		var fragment = parts.Length > 1 ? parts[1] : null;
+
+		JsonNode? data;
+		if (!string.IsNullOrEmpty(baseUri))
+		{
+			bool wasResolved;
+			if (Uri.TryCreate(baseUri, UriKind.Absolute, out var newUri))
+				wasResolved = Download(newUri, out data);
+			else
+			{
+				var uriFolder = context.CurrentUri.OriginalString.EndsWith("/")
+					? context.CurrentUri
+					: context.CurrentUri.GetParentUri();
+				var newBaseUri = new Uri(uriFolder, baseUri);
+				wasResolved = Download(newBaseUri, out data);
+			}
+
+			if (!wasResolved)
+			{
+				context.LocalResult.Fail(ErrorMessages.BaseUriResolution, ("uri", baseUri));
+				node = null;
+				return false;
+			}
+		}
+		else
+			data = JsonSerializer.SerializeToNode(context.SchemaRoot);
+
+		if (!string.IsNullOrEmpty(fragment))
+		{
+			fragment = $"#{fragment}";
+			if (!JsonPointer.TryParse(fragment, out var pointer))
+			{
+				context.LocalResult.Fail(ErrorMessages.PointerParse, ("fragment", fragment));
+				node = null;
+				return false;
+			}
+
+			if (!pointer!.TryEvaluate(data, out var resolved))
+			{
+				context.LocalResult.Fail(ErrorMessages.RefResolution, ("uri", fragment));
+				node = null;
+				return false;
+			}
+			data = resolved;
+		}
+
+		node = data;
+		return true;
+	}
+
+	private static bool Download(Uri uri, out JsonNode? node)
+	{
+		if (DataKeyword.Fetch == null)
+		{
+			node = null;
+			return false;
+		}
+
+		node = DataKeyword.Fetch(uri);
+		return true;
+	}
+
+	public override string ToString()
+	{
+		return Target.ToString();
+	}
+}

--- a/JsonSchema.Data/Vocabularies.cs
+++ b/JsonSchema.Data/Vocabularies.cs
@@ -8,7 +8,7 @@ public static class Vocabularies
 	/// <summary>
 	/// The data vocabulary ID.
 	/// </summary>
-	public const string DataId = "https://gregsdennis.github.io/json-everything/vocabs-data";
+	public const string DataId = "https://json-everything.net/vocabs-data-2022";
 
 	/// <summary>
 	/// The data vocabulary.

--- a/json-everything.net/Pages/Schema.razor
+++ b/json-everything.net/Pages/Schema.razor
@@ -30,7 +30,7 @@
 			<RadzenPanelMenuItem Text="Vocabularies" Value="@("schema-vocabs")"/>
 			<RadzenPanelMenuItem Text="Schema Generation" Value="@("schema-generation")"/>
 			<RadzenPanelMenuItem Text="Data Generation" Value="@("schema-datagen")"/>
-			<RadzenPanelMenuItem Text="Vocabulary: data" Value="@("vocabs-data")"/>
+			<RadzenPanelMenuItem Text="Vocabulary: data" Value="@("vocabs-data-2022")"/>
 			<RadzenPanelMenuItem Text="Vocabulary: uniqueKeys" Value="@("vocabs-unique-keys")"/>
 		</RadzenPanelMenuItem>
 		<RadzenPanelMenuItem Text="Examples (work in progress)" Icon="format_list_numbered" Expanded="true">

--- a/json-everything.net/Services/AnchorRegistry.cs
+++ b/json-everything.net/Services/AnchorRegistry.cs
@@ -28,7 +28,7 @@ namespace JsonEverythingNet.Services
 				RegisterAnchors(client, "schema-datagen"),
 				RegisterAnchors(client, "schema-generation"),
 				RegisterAnchors(client, "schema-vocabs"),
-				RegisterAnchors(client, "vocabs-data"),
+				RegisterAnchors(client, "vocabs-data-2022"),
 				RegisterAnchors(client, "vocabs-unique-keys")
 			);
 		}

--- a/json-everything.net/wwwroot/md/release-notes/json-schema-data.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-schema-data.md
@@ -1,3 +1,39 @@
+# 3.0.0 (https://github.com/gregsdennis/json-everything/pull/316)
+
+Supports the 2022 version of the vocabulary.  This is a breaking change from the previous version.
+
+## Changes
+
+References no longer just support URIs.  Instead several formats are used to indicate the source document:
+
+- JSON Pointers (not URI fragments) and Relative JSON Pointers indicate locations within the instance
+- Fragment-only URI-encoded JSON Pointers indicate locations within the host schema (just like a `$ref` would)
+- Absolute URIs (optionally with URI-encoded JSON Pointer fragments) are used to access external data
+
+The first point is the primary change.
+
+## Migration
+
+URI-encoded JSON Pointer fragments used to resolve to the instance first.  These will need to be changed to plain JSON Pointers.
+
+```
+From
+#/foo/1/bar
+
+To
+/foo/1/bar
+```
+
+Absolute URIs that indicate the host schema may be changed to URI-encoded JSON Pointer fragments.  This is not strictly necessary as the resolution of the full URI will still occur.
+
+```
+From
+https://example.com/schema#/$defs/somedef
+
+To
+#/$defs/somedef
+```
+
 # 2.0.1 (no PR)
 
 [#288](https://github.com/gregsdennis/json-everything/issues/288) - Just bumping version to pick up the latest Json.More.Net by default.  This package pull Json.More.Net transitively via JsonPointer.Net which wasn't updated with the move to `JsonNode`.

--- a/json-everything.net/wwwroot/md/vocabs-data-2022.md
+++ b/json-everything.net/wwwroot/md/vocabs-data-2022.md
@@ -36,8 +36,8 @@ The value of `data` must be an object.  The keys of the object are interpreted a
 
 - JSON Pointers per [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901) 
 - [Relative JSON Pointers](https://json-schema.org/draft/2019-09/relative-json-pointer.html)
-- URI-encoded JSON Pointer identifier per [RFC 6901, §6](https://www.rfc-editor.org/rfc/rfc6901#section-6)
-- Absolute URIs per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), optionally with a JSON Pointer fragment identifier
+- fragment-only IRI using IRI-encoded JSON Pointer identifier per [RFC 6901, §6](https://www.rfc-editor.org/rfc/rfc6901#section-6)
+- Absolute IRIs per [RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987), optionally including an additional IRI-encoded JSON Pointer fragment identifier
 
 `data` MUST NOT contain any keys which are defined by the JSON Schema Core Vocabulary.
 
@@ -52,12 +52,14 @@ The validation and annotation results of `data` are those of the formed schema. 
 
 `data` MUST be processed contextually in the same manner as the host schema.  Specifically,
 
-- URI resolution MUST be performed in the same manner as `$ref` (per section 3.3).
+- IRI resolution MUST be performed in the same manner as `$ref` (per section 3.3).
 - Keys that are ignored by the host schema MUST also be ignored by the formed schema.
 
-Implementations SHOULD validate the formed schema against the host schema's meta-schema (as specified by `$schema`) to ensure that it is a syntactically valid schema object.
+Implementations SHOULD validate that the resolved data forms a valid schema against the host schema's meta-schema (as specified by `$schema`).
 
-### 4.3 URI Resolution
+***NOTE** It is not necessary for an implementation to validate using the meta-schema.  Other mechanisms internal to the implementation (such as deserialization) may suffice to perform this task.*
+
+### 4.3 IRI Resolution
 
 The values of `data` are dereferenced in different ways depending on the format of the value.
 
@@ -67,7 +69,7 @@ If the value is a Relative JSON Pointer, it is resolved against the instance at 
 
 Otherwise, it must be resolved in accordance with the rules of `$ref` resolution for the relevant JSON Schema specification (e.g. [draft 2020-12, §8.2](https://json-schema.org/draft/2020-12/json-schema-core.html#name-base-uri-anchors-and-derefe)).  However, unlike `$ref` which requires that the indicated data must represent a valid schema object, a `data` reference can identify any value which is valid for the associated keyword.
 
-Because JSON Pointers and Relative JSON Pointers are syntactically valid URIs, the value MUST be checked in the sequence indicated above in order to properly identify the pointer types from other URIs.
+Because JSON Pointers and Relative JSON Pointers are syntactically valid IRIs, the value MUST be checked in the sequence indicated above in order to properly identify the pointer types from other IRIs.
 
 For each successfully resolved reference, the full value at the specified location MUST be returned.
 
@@ -75,7 +77,7 @@ If a reference cannot be resolved, or if a resolved value is not valid for the a
 
 #### 4.3.1 External Data Access
 
-Implementations SHOULD provide a means to pre-load and cache any external references prior to evaluation but MAY be configured to fetch external documents at evaluation time.  Documents fetched from URIs which contain a JSON Pointer fragment MUST be interpreted using a media type that allows resolution of such fragments.
+Implementations SHOULD provide a means to pre-load and cache any external references prior to evaluation but MAY be configured to fetch external documents at evaluation time.  Documents fetched from IRIs which contain a JSON Pointer fragment MUST be interpreted using a media type, such as `application/schema-instance+json`, that allows resolution of such fragments.
 
 Users should be aware that fetching data from external locations may carry certain security risks not covered by this document.
 

--- a/json-everything.net/wwwroot/md/vocabs-data-2022.md
+++ b/json-everything.net/wwwroot/md/vocabs-data-2022.md
@@ -77,7 +77,7 @@ If a reference cannot be resolved, or if a resolved value is not valid for the a
 
 Implementations SHOULD provide a means to pre-load and cache any external references prior to evaluation but MAY be configured to fetch external documents at evaluation time.  Documents fetched from URIs which contain a JSON Pointer fragment MUST be interpreted using a media type that allows resolution of such fragments.
 
-Users should be aware that fetching data from external location may carry certain security risks not covered by this document.
+Users should be aware that fetching data from external locations may carry certain security risks not covered by this document.
 
 ### 4.4 Output
 

--- a/json-everything.net/wwwroot/md/vocabs-data-2022.md
+++ b/json-everything.net/wwwroot/md/vocabs-data-2022.md
@@ -1,0 +1,123 @@
+# A Vocabulary for Accessing Data Stored in JSON
+
+## 1. Purpose
+
+This document describes a vocabulary defining keywords that can be used to reference values stored in
+
+- the instance data
+- external JSON data
+- the schema data
+
+and use the dereferenced values as input for other keywords.
+
+The intent for this keyword is to cover the use cases discussed across several issues in the JSON Schema specification GitHub repositories.  (A quick search for `"$data"` can readily summon these issues.)
+
+## 2. Declarations
+
+The ID for this vocabulary is `https://json-everything.net/vocabs-data-2022` (the URI to this document).
+
+A draft 2020-12 meta-schema which includes this vocabulary has been defined for convenience.  The ID for the meta-schema is `https://json-everything.net/meta/data-2022`, and it can also be found at this address.
+
+## 3. The `data` Keyword
+
+### 3.1 Syntax and Semantics
+
+The value of `data` must be an object.  The keys of the object correspond to valid JSON Schema keywords, and the values MUST be one of
+
+- JSON Pointers per [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901)
+- [Relative JSON Pointers](https://json-schema.org/draft/2019-09/relative-json-pointer.html)
+- URI references per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), potentially with JSON Pointer fragments
+
+The set of keywords in the schema or subschema containing `data` SHOULD be distinct from the set of keys defined within `data`.  Behavior in the event of an overlap is not defined.
+
+`data` operates in two phases:
+
+1. All of the values are dereferenced per sections 3.2 and 3.3.
+2. The keywords and values then form a schema which is applied to the instance at the current location.
+
+The validation and annotation results of `data` are those of the formed schema.  More detail regarding output can be found in section 3.4.
+
+### 3.2 Contextual Behavior
+
+`data` MUST be processed contextually in accordance with the draft of the schema in which it is used.  For example, if `data` is used in a schema that declares draft 2019-09, then
+
+- the keys SHOULD be recognized by draft 2019-09 or defined in other referenced vocabularies, and
+- the URI references MUST be resolved following the same rules as `$ref` as defined by draft 2019-09.
+
+If a key is not a recognized keyword in the schema's draft (e.g. `$dynamicAnchor` in a draft 2019-09 schema), then this key is ignored just as it would be ignored if it were in the schema or subschema containing `data`.
+
+### 3.3 URI Resolution
+
+The values of `data` are dereferenced in different ways depending on the format of the value.
+
+If the value is a JSON Pointer, it is resolved against the instance root.
+
+If the value is a Relative JSON Pointer, it is resolved against the instance at the location currently being evaluated.
+
+If the value is a URI reference, it must be resolved in accordance with the rules of `$ref` resolution for the containing spec, as per section 3.2.  The primary different between resolving URIs for `data` and resolving URIs for `$ref` is that `$ref` requires that the indicated data must represent a valid schema object whereas `data` can reference any valid JSON value.
+
+External document data can be referenced using an absolute URI base identifier along with a JSON Pointer fragment.
+
+Implementations SHOULD be able to download external JSON documents, but MAY provide means to pre-load and cache such documents against the identifiers by which they will be referenced.  Documents downloaded from URIs which contain a JSON Pointer fragment MUST be interpreted using a media type that allows resolution of such fragments.
+
+If any single reference cannot be resolved, validation MUST fail; otherwise the full value at the specified location is returned.
+
+If the resolved value is not valid for the associated keyword, validation MUST fail.
+
+### 3.4 Errors
+
+The output formatting specified by the JSON Schema Core specification can only indicate that something failed at the `data` node, but there is no provision for providing further detail.
+
+In summary, the `data` keyword can generate two validation failure states as specified by this document:
+
+- a URI reference cannot be resolved, and
+- a URI reference can be resolved but the returned value is invalid for the associated keyword.
+
+To make debugging `data` simpler, implementations SHOULD provide an error message indicating what the failure was and for which key it occurred.
+
+If both of these succeed, the validation output of the resulting subschema is reported into the overall schema output as if the subschema were actually a child of the `data` keyword.
+
+## 4. A Short Example
+
+The following defines a schema to validate an object instance with a `foo` property that must contain an integer value less than or equal to the value in the instance's `minValue` property.
+
+```json
+{
+  "$schema": "https://json-everything.net/meta/data-2022",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "integer",
+      "data": {
+        "minimum": "/minValue"
+      }
+    },
+    "minValue": {
+      "type": "integer"
+    }
+  },
+  "dependentRequired": {
+    "foo": [ "minValue" ]
+  }
+}
+```
+
+The `data` property declares that its parent subschema should validate a `minimum` keyword whose value is the value in the `minValue` property of the instance.
+
+Note also the use of `dependentRequired` to ensure that when `foo` is present in the instance, `minValue` is also present.  While this not explicitly required of schema authors, this type of insurance mechanism is recommended.
+
+The following shows how a change in the `minValue` property can affect the validation result of the `foo` property and thus the entire instance.
+
+```json
+// passing
+{
+  "minValue": 5,
+  "foo": 10
+}
+
+// failing
+{
+  "minValue": 15,
+  "foo": 10
+}
+```

--- a/json-everything.net/wwwroot/md/vocabs-data-2022.md
+++ b/json-everything.net/wwwroot/md/vocabs-data-2022.md
@@ -5,10 +5,10 @@
 This document describes a vocabulary defining keywords that can be used to reference values stored in
 
 - the instance data
-- external JSON data
 - the schema data
+- external JSON data
 
-and use the dereferenced values as input for other keywords.
+where the dereferenced values serve as input for keywords in a derived subschema.
 
 The intent for this keyword is to cover the use cases discussed across several issues in the JSON Schema specification GitHub repositories.  (A quick search for `"$data"` can readily summon these issues.)
 
@@ -22,29 +22,29 @@ A draft 2020-12 meta-schema which includes this vocabulary has been defined for 
 
 ### 3.1 Syntax and Semantics
 
-The value of `data` must be an object.  The keys of the object correspond to valid JSON Schema keywords, and the values MUST be one of
+The value of `data` must be an object.  The keys of the object are interpreted as JSON Schema keywords, and the values MUST be one of
 
 - JSON Pointers per [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901)
 - [Relative JSON Pointers](https://json-schema.org/draft/2019-09/relative-json-pointer.html)
 - URI references per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986), potentially with JSON Pointer fragments
 
-The set of keywords in the schema or subschema containing `data` SHOULD be distinct from the set of keys defined within `data`.  Behavior in the event of an overlap is not defined.
+`data` MUST NOT contain any keys which are defined by the JSON Schema Core Vocabulary.
 
 `data` operates in two phases:
 
 1. All of the values are dereferenced per sections 3.2 and 3.3.
-2. The keywords and values then form a schema which is applied to the instance at the current location.
+2. The resolved object is then interpreted as a schema (the "formed schema") which is applied to the instance at the current location.
 
 The validation and annotation results of `data` are those of the formed schema.  More detail regarding output can be found in section 3.4.
 
 ### 3.2 Contextual Behavior
 
-`data` MUST be processed contextually in accordance with the draft of the schema in which it is used.  For example, if `data` is used in a schema that declares draft 2019-09, then
+`data` MUST be processed contextually in the same manner as the schema in which it is used.  Specifically,
 
-- the keys SHOULD be recognized by draft 2019-09 or defined in other referenced vocabularies, and
-- the URI references MUST be resolved following the same rules as `$ref` as defined by draft 2019-09.
+- URI resolution MUST be performed in the same manner as `$ref` (per section 3.3).
+- Keys that are ignored by the parent schema MUST also be ignored by the formed subschema.
 
-If a key is not a recognized keyword in the schema's draft (e.g. `$dynamicAnchor` in a draft 2019-09 schema), then this key is ignored just as it would be ignored if it were in the schema or subschema containing `data`.
+Implementations SHOULD validate the formed schema against the containing schema's meta-schema (as specified by `$schema`) to ensure that it is a syntactically valid schema object.
 
 ### 3.3 URI Resolution
 
@@ -54,11 +54,9 @@ If the value is a JSON Pointer, it is resolved against the instance root.
 
 If the value is a Relative JSON Pointer, it is resolved against the instance at the location currently being evaluated.
 
-If the value is a URI reference, it must be resolved in accordance with the rules of `$ref` resolution for the containing spec, as per section 3.2.  The primary different between resolving URIs for `data` and resolving URIs for `$ref` is that `$ref` requires that the indicated data must represent a valid schema object whereas `data` can reference any valid JSON value.
+If the value is a URI reference, it must be resolved in accordance with the rules of `$ref` resolution for the relevant JSON Schema specification (e.g. [draft 2020-12, §8.2](https://json-schema.org/draft/2020-12/json-schema-core.html#name-base-uri-anchors-and-derefe)).  However, unlike `$ref` which requires that the indicated data must represent a valid schema object, a `data` reference can identify any value which is valid for the associated keyword.
 
-External document data can be referenced using an absolute URI base identifier along with a JSON Pointer fragment.
-
-Implementations SHOULD be able to download external JSON documents, but MAY provide means to pre-load and cache such documents against the identifiers by which they will be referenced.  Documents downloaded from URIs which contain a JSON Pointer fragment MUST be interpreted using a media type that allows resolution of such fragments.
+Implementations SHOULD provide a means to pre-load and cache any external reference but MAY be configured to fetch external documents at evaluation time.  Documents fetched from URIs which contain a JSON Pointer fragment MUST be interpreted using a media type that allows resolution of such fragments.
 
 If any single reference cannot be resolved, validation MUST fail; otherwise the full value at the specified location is returned.
 
@@ -66,16 +64,16 @@ If the resolved value is not valid for the associated keyword, validation MUST f
 
 ### 3.4 Errors
 
-The output formatting specified by the JSON Schema Core specification can only indicate that something failed at the `data` node, but there is no provision for providing further detail.
-
-In summary, the `data` keyword can generate two validation failure states as specified by this document:
+The `data` keyword can generate two validation failure states as specified by this document:
 
 - a URI reference cannot be resolved, and
 - a URI reference can be resolved but the returned value is invalid for the associated keyword.
 
 To make debugging `data` simpler, implementations SHOULD provide an error message indicating what the failure was and for which key it occurred.
 
-If both of these succeed, the validation output of the resulting subschema is reported into the overall schema output as if the subschema were actually a child of the `data` keyword.
+If both of these succeed, the evaluation output of the formed schema is reported into the overall schema output incorporating "data" into the evaluation path and following on with additional pointer segments as navigable within the formed schema.
+
+Annotation results of the formed schema are retained so that they can be processed by other keywords such as `unevaluatedItems` and `unevaluatedProperties`.
 
 ## 4. A Short Example
 

--- a/json-everything.net/wwwroot/meta/data-2022
+++ b/json-everything.net/wwwroot/meta/data-2022
@@ -7,6 +7,8 @@
         "https://json-schema.org/draft/2020-12/vocab/validation": true,
         "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
         "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
         "https://json-everything.net/vocabs-data-2022": true
     },
     "$dynamicAnchor": "meta",
@@ -24,6 +26,21 @@
                     { "format": "json-pointer" },
                     { "format": "relative-json-pointer" }
                 ]
+            },
+            "propertyNames": {
+                "not": {
+                    "anyOf": [
+                        { "const": "$id" },
+                        { "const": "$schema" },
+                        { "const": "$ref" },
+                        { "const": "$anchor" },
+                        { "const": "$dynamicRef" },
+                        { "const": "$dynamicAnchor" },
+                        { "const": "$vocabulary" },
+                        { "const": "$comment" },
+                        { "const": "$defs" }
+                    ]
+                }
             },
             "default": {}
         }

--- a/json-everything.net/wwwroot/meta/data-2022
+++ b/json-everything.net/wwwroot/meta/data-2022
@@ -22,9 +22,9 @@
             "additionalProperties": {
                 "type": "string",
                 "oneOf": [
-                    { "format": "uri-reference" },
                     { "format": "json-pointer" },
-                    { "format": "relative-json-pointer" }
+                    { "format": "relative-json-pointer" },
+                    { "format": "uri-reference" }
                 ]
             },
             "propertyNames": {

--- a/json-everything.net/wwwroot/meta/data-2022
+++ b/json-everything.net/wwwroot/meta/data-2022
@@ -1,48 +1,52 @@
 {
-    "$id": "https://json-everything.net/meta/data-2022",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$vocabulary": {
-        "https://json-schema.org/draft/2020-12/vocab/core": true,
-        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-        "https://json-schema.org/draft/2020-12/vocab/validation": true,
-        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-        "https://json-schema.org/draft/2020-12/vocab/content": true,
-        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-        "https://json-everything.net/vocabs-data-2022": true
-    },
-    "$dynamicAnchor": "meta",
+  "$id": "https://json-everything.net/meta/data-2022",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-everything.net/vocabs-data-2022": true
+  },
+  "$dynamicAnchor": "meta",
 
-    "title": "Referenced data meta-schema",
-    "allOf": [
-        { "$ref": "https://json-schema.org/draft/2020-12/schema" }
-    ],
-    "properties": {
-        "data": {
-            "additionalProperties": {
-                "type": "string",
-                "oneOf": [
-                    { "format": "json-pointer" },
-                    { "format": "relative-json-pointer" },
-                    { "format": "uri-reference" }
-                ]
-            },
-            "propertyNames": {
-                "not": {
-                    "anyOf": [
-                        { "const": "$id" },
-                        { "const": "$schema" },
-                        { "const": "$ref" },
-                        { "const": "$anchor" },
-                        { "const": "$dynamicRef" },
-                        { "const": "$dynamicAnchor" },
-                        { "const": "$vocabulary" },
-                        { "const": "$comment" },
-                        { "const": "$defs" }
-                    ]
-                }
-            },
-            "default": {}
+  "title": "Referenced data meta-schema",
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/schema" }
+  ],
+  "properties": {
+    "data": {
+      "additionalProperties": {
+        "type": "string",
+        "oneOf": [
+          { "format": "json-pointer" },
+          { "format": "relative-json-pointer" },
+          {
+            "format": "iri-reference",
+            "pattern": "^#"
+          },
+          { "format": "iri" }
+        ]
+      },
+      "propertyNames": {
+        "not": {
+          "anyOf": [
+            { "const": "$id" },
+            { "const": "$schema" },
+            { "const": "$ref" },
+            { "const": "$anchor" },
+            { "const": "$dynamicRef" },
+            { "const": "$dynamicAnchor" },
+            { "const": "$vocabulary" },
+            { "const": "$comment" },
+            { "const": "$defs" }
+          ]
         }
+      },
+      "default": {}
     }
+  }
 }

--- a/json-everything.net/wwwroot/meta/data-2022
+++ b/json-everything.net/wwwroot/meta/data-2022
@@ -1,0 +1,31 @@
+{
+    "$id": "https://json-everything.net/meta/data-2022",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-everything.net/vocabs-data-2022": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Referenced data meta-schema",
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/2020-12/schema" }
+    ],
+    "properties": {
+        "data": {
+            "additionalProperties": {
+                "type": "string",
+                "oneOf": [
+                    { "format": "uri-reference" },
+                    { "format": "json-pointer" },
+                    { "format": "relative-json-pointer" }
+                ]
+            },
+            "default": {}
+        }
+    }
+}


### PR DESCRIPTION
Resolves some conversations with @handrews in the JSON Schema Slack workspace.

Change summary:

- instances are now referenced using either plain or relative JSON Pointers
- schema data is now referenced using JSON Pointer fragments without needing to specify the full URI

This brings `data` resolution in closer alignment with `$ref` (and potentially solves some other issues.