### PR TITLE
Logic/serialize rules

### DIFF
--- a/Json.More/Json.More.csproj
+++ b/Json.More/Json.More.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Json.More.Net</PackageId>
     <Authors>Greg Dennis</Authors>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.6.0.0</FileVersion>
+    <FileVersion>1.7.0.0</FileVersion>
     <Description>Provides extended functionality for the System.Text.Json namespace.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>

--- a/Json.More/JsonNodeExtensions.cs
+++ b/Json.More/JsonNodeExtensions.cs
@@ -119,10 +119,11 @@ public static class JsonNodeExtensions
 	/// Gets JSON string representation for <see cref="JsonNode"/>, including null support.
 	/// </summary>
 	/// <param name="node">A node.</param>
+	/// <param name="options">Serializer options</param>
 	/// <returns>JSON string representation.</returns>
-	public static string AsJsonString(this JsonNode? node)
+	public static string AsJsonString(this JsonNode? node, JsonSerializerOptions? options = null)
 	{
-		return node?.ToJsonString() ?? "null";
+		return node?.ToJsonString(options) ?? "null";
 	}
 
 	/// <summary>

--- a/JsonLogic.Tests/GithubTests.cs
+++ b/JsonLogic.Tests/GithubTests.cs
@@ -121,7 +121,7 @@ public class GithubTests
 		var rule = JsonSerializer.Deserialize<Rule>("{ \"+\" : [ 1, 2 ] }");
 		
 		Assert.IsInstanceOf<AddRule>(rule);
-		Assert.IsTrue(rule.Apply().IsEquivalentTo(3));
+		Assert.IsTrue(rule!.Apply().IsEquivalentTo(3));
 	}
 
 	[Test]
@@ -135,7 +135,7 @@ public class GithubTests
 }");
 
 		var rule = node.Deserialize<Rule>();
-		var result = rule.Apply(JsonNode.Parse("{\"value\": null}"));
+		var result = rule!.Apply(JsonNode.Parse("{\"value\": null}"));
 
 		Assert.IsTrue(result.IsEquivalentTo(true));
 	}

--- a/JsonLogic.Tests/Suite/SuiteRunner.cs
+++ b/JsonLogic.Tests/Suite/SuiteRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Json.More;
@@ -12,6 +13,8 @@ namespace Json.Logic.Tests.Suite;
 
 public class SuiteRunner
 {
+	private static readonly JsonSerializerOptions _serializerOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
 	public static IEnumerable<TestCaseData> Suite()
 	{
 		return Task.Run(async () =>
@@ -55,5 +58,9 @@ public class SuiteRunner
 		}
 
 		JsonAssert.AreEquivalent(test.Expected, rule.Apply(test.Data));
+
+		var serialized = JsonSerializer.Serialize(rule, _serializerOptions);
+
+		Assert.AreEqual(test.Logic, serialized);
 	}
 }

--- a/JsonLogic/JsonLogic.csproj
+++ b/JsonLogic/JsonLogic.csproj
@@ -15,9 +15,9 @@
 		<PackageTags>json logic json-logic jsonlogic</PackageTags>
 		<PackageReleaseNotes>https://gregsdennis.github.io/json-everything/release-notes/json-logic.html</PackageReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>3.1.2</Version>
+		<Version>3.2.0</Version>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>
-		<FileVersion>3.1.2.0</FileVersion>
+		<FileVersion>3.2.0.0</FileVersion>
 		<DocumentationFile>JsonLogic.xml</DocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/JsonLogic/JsonWriterExtensions.cs
+++ b/JsonLogic/JsonWriterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 namespace Json.Logic;
@@ -14,20 +15,34 @@ public static class JsonWriterExtensions
 	/// <param name="writer">The writer.</param>
 	/// <param name="rule">The rule.</param>
 	/// <param name="options">Serializer options.</param>
-	public static void WriteRule(this Utf8JsonWriter writer, Rule rule, JsonSerializerOptions options)
+	public static void WriteRule(this Utf8JsonWriter writer, Rule? rule, JsonSerializerOptions options)
 	{
+		if (rule == null)
+		{
+			writer.WriteNullValue();
+			return;
+		}
 		JsonSerializer.Serialize(writer, rule, rule.GetType(), options);
 	}
+
 	/// <summary>
 	/// Writes a rule to the stream, taking its specific type into account.
 	/// </summary>
 	/// <param name="writer">The writer.</param>
 	/// <param name="rules">The rules.</param>
 	/// <param name="options">Serializer options.</param>
-	public static void WriteRules(this Utf8JsonWriter writer, IEnumerable<Rule> rules, JsonSerializerOptions options)
+	/// <param name="unwrapSingle">Unwraps single items instead of writing an array.</param>
+	public static void WriteRules(this Utf8JsonWriter writer, IEnumerable<Rule> rules, JsonSerializerOptions options, bool unwrapSingle = true)
 	{
+		var array = rules.ToArray();
+		if (unwrapSingle && array.Length == 1)
+		{
+			writer.WriteRule(array[0], options);
+			return;
+		}
+
 		writer.WriteStartArray();
-		foreach (var rule in rules)
+		foreach (var rule in array)
 		{
 			writer.WriteRule(rule, options);
 		}

--- a/JsonLogic/JsonWriterExtensions.cs
+++ b/JsonLogic/JsonWriterExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Json.Logic;
+
+/// <summary>
+/// Provides extended functionality for serializing rules.
+/// </summary>
+public static class JsonWriterExtensions
+{
+	/// <summary>
+	/// Writes a rule to the stream, taking its specific type into account.
+	/// </summary>
+	/// <param name="writer">The writer.</param>
+	/// <param name="rule">The rule.</param>
+	/// <param name="options">Serializer options.</param>
+	public static void WriteRule(this Utf8JsonWriter writer, Rule rule, JsonSerializerOptions options)
+	{
+		JsonSerializer.Serialize(writer, rule, rule.GetType(), options);
+	}
+	/// <summary>
+	/// Writes a rule to the stream, taking its specific type into account.
+	/// </summary>
+	/// <param name="writer">The writer.</param>
+	/// <param name="rules">The rules.</param>
+	/// <param name="options">Serializer options.</param>
+	public static void WriteRules(this Utf8JsonWriter writer, IEnumerable<Rule> rules, JsonSerializerOptions options)
+	{
+		writer.WriteStartArray();
+		foreach (var rule in rules)
+		{
+			writer.WriteRule(rule, options);
+		}
+		writer.WriteEndArray();
+	}
+}

--- a/JsonLogic/Rule.cs
+++ b/JsonLogic/Rule.cs
@@ -120,7 +120,7 @@ public class LogicComponentConverter : JsonConverter<Rule>
 	/// <param name="options">An object that specifies serialization options to use.</param>
 	public override void Write(Utf8JsonWriter writer, Rule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteRule(value, options);
 	}
 }
 

--- a/JsonLogic/Rules/AddRule.cs
+++ b/JsonLogic/Rules/AddRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(AddRuleJsonConverter))]
 public class AddRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal AddRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class AddRule : Rule
 	{
 		decimal result = 0;
 
-		foreach (var item in _items)
+		foreach (var item in Items)
 		{
 			var value = item.Apply(data, contextData);
 
@@ -69,6 +69,9 @@ internal class AddRuleJsonConverter : JsonConverter<AddRule>
 
 	public override void Write(Utf8JsonWriter writer, AddRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("+");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/AllRule.cs
+++ b/JsonLogic/Rules/AllRule.cs
@@ -13,13 +13,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(AllRuleJsonConverter))]
 public class AllRule : Rule
 {
-	private readonly Rule _input;
-	private readonly Rule _rule;
+	internal Rule Input { get; }
+	internal Rule Rule { get; }
 
 	internal AllRule(Rule input, Rule rule)
 	{
-		_input = input;
-		_rule = rule;
+		Input = input;
+		Rule = rule;
 	}
 
 	/// <summary>
@@ -33,12 +33,12 @@ public class AllRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var input = _input.Apply(data, contextData);
+		var input = Input.Apply(data, contextData);
 
 		if (input is not JsonArray arr)
 			throw new JsonLogicException("Input must evaluate to an array.");
 
-		var results = arr.Select(value => _rule.Apply(data, value)).ToList();
+		var results = arr.Select(value => Rule.Apply(data, value)).ToList();
 		return (results.Any() &&
 				results.All(result => result.IsTruthy()));
 	}
@@ -58,6 +58,12 @@ internal class AllRuleJsonConverter : JsonConverter<AllRule>
 
 	public override void Write(Utf8JsonWriter writer, AllRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("all");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Input, options);
+		writer.WriteRule(value.Rule, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/AndRule.cs
+++ b/JsonLogic/Rules/AndRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(AndRuleJsonConverter))]
 public class AndRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal AndRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class AndRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data, contextData));
+		var items = Items.Select(i => i.Apply(data, contextData));
 		JsonNode? first = false;
 		foreach (var x in items)
 		{
@@ -59,6 +59,9 @@ internal class AndRuleJsonConverter : JsonConverter<AndRule>
 
 	public override void Write(Utf8JsonWriter writer, AndRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("and");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/BooleanCastRule.cs
+++ b/JsonLogic/Rules/BooleanCastRule.cs
@@ -12,11 +12,11 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(BooleanCastRuleJsonConverter))]
 public class BooleanCastRule : Rule
 {
-	private readonly Rule _value;
+	internal Rule Value { get; }
 
 	internal BooleanCastRule(Rule value)
 	{
-		_value = value;
+		Value = value;
 	}
 
 	/// <summary>
@@ -30,9 +30,9 @@ public class BooleanCastRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var value = _value.Apply(data, contextData);
+		var value = Value.Apply(data, contextData);
 
-		return _value.Apply(data, contextData).IsTruthy();
+		return Value.Apply(data, contextData).IsTruthy();
 	}
 }
 
@@ -50,6 +50,11 @@ internal class BooleanCastRuleJsonConverter : JsonConverter<BooleanCastRule>
 
 	public override void Write(Utf8JsonWriter writer, BooleanCastRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("!!");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Value, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/CatRule.cs
+++ b/JsonLogic/Rules/CatRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(CatRuleJsonConverter))]
 public class CatRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal CatRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class CatRule : Rule
 	{
 		var result = string.Empty;
 
-		foreach (var item in _items)
+		foreach (var item in Items)
 		{
 			var value = item.Apply(data, contextData);
 
@@ -66,6 +66,9 @@ internal class CatRuleJsonConverter : JsonConverter<CatRule>
 
 	public override void Write(Utf8JsonWriter writer, CatRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("cat");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/DivideRule.cs
+++ b/JsonLogic/Rules/DivideRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(DivideRuleJsonConverter))]
 public class DivideRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal DivideRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class DivideRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();
@@ -62,6 +62,12 @@ internal class DivideRuleJsonConverter : JsonConverter<DivideRule>
 
 	public override void Write(Utf8JsonWriter writer, DivideRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("/");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/FilterRule.cs
+++ b/JsonLogic/Rules/FilterRule.cs
@@ -14,13 +14,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(FilterRuleJsonConverter))]
 public class FilterRule : Rule
 {
-	private readonly Rule _input;
-	private readonly Rule _rule;
+	internal Rule Input { get; }
+	internal Rule Rule { get; }
 
 	internal FilterRule(Rule input, Rule rule)
 	{
-		_input = input;
-		_rule = rule;
+		Input = input;
+		Rule = rule;
 	}
 
 	/// <summary>
@@ -34,12 +34,12 @@ public class FilterRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var input = _input.Apply(data, contextData);
+		var input = Input.Apply(data, contextData);
 
 		if (input is not JsonArray arr)
 			return new JsonArray();
 
-		return arr.Where(i => _rule.Apply(data, i).IsTruthy()).ToJsonArray();
+		return arr.Where(i => Rule.Apply(data, i).IsTruthy()).ToJsonArray();
 	}
 }
 
@@ -57,6 +57,12 @@ internal class FilterRuleJsonConverter : JsonConverter<FilterRule>
 
 	public override void Write(Utf8JsonWriter writer, FilterRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("filter");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Input, options);
+		writer.WriteRule(value.Rule, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/InRule.cs
+++ b/JsonLogic/Rules/InRule.cs
@@ -14,13 +14,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(InRuleJsonConverter))]
 public class InRule : Rule
 {
-	private readonly Rule _test;
-	private readonly Rule _source;
+	internal Rule Test { get; }
+	internal Rule Source { get; }
 
 	internal InRule(Rule test, Rule source)
 	{
-		_test = test;
-		_source = source;
+		Test = test;
+		Source = source;
 	}
 
 	/// <summary>
@@ -34,8 +34,8 @@ public class InRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var test = _test.Apply(data, contextData);
-		var source = _source.Apply(data, contextData);
+		var test = Test.Apply(data, contextData);
+		var source = Source.Apply(data, contextData);
 
 		if (source is JsonValue value && value.TryGetValue(out string? stringSource))
 		{
@@ -68,6 +68,12 @@ internal class InRuleJsonConverter : JsonConverter<InRule>
 
 	public override void Write(Utf8JsonWriter writer, InRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("in");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Test, options);
+		writer.WriteRule(value.Source, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/LessThanEqualRule.cs
+++ b/JsonLogic/Rules/LessThanEqualRule.cs
@@ -14,20 +14,20 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LessThanEqualRuleJsonConverter))]
 public class LessThanEqualRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
-	private readonly Rule? _c;
+	internal Rule A { get; }
+	internal Rule B { get; }
+	internal Rule? C { get; }
 
 	internal LessThanEqualRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 	internal LessThanEqualRule(Rule a, Rule b, Rule c)
 	{
-		_a = a;
-		_b = b;
-		_c = c;
+		A = a;
+		B = b;
+		C = c;
 	}
 
 	/// <summary>
@@ -41,10 +41,10 @@ public class LessThanEqualRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		if (_c == null)
+		if (C == null)
 		{
-			var a = _a.Apply(data, contextData);
-			var b = _b.Apply(data, contextData);
+			var a = A.Apply(data, contextData);
+			var b = B.Apply(data, contextData);
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();
@@ -55,15 +55,15 @@ public class LessThanEqualRule : Rule
 			return numberA <= numberB;
 		}
 
-		var low = (_a.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var low = (A.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (low == null)
 			throw new JsonLogicException("Lower bound must be a number.");
 
-		var value = (_b.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var value = (B.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (value == null)
 			throw new JsonLogicException("Value must be a number.");
 
-		var high = (_c.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var high = (C.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (high == null)
 			throw new JsonLogicException("Upper bound must be a number.");
 
@@ -87,6 +87,14 @@ internal class LessThanEqualRuleJsonConverter : JsonConverter<LessThanEqualRule>
 
 	public override void Write(Utf8JsonWriter writer, LessThanEqualRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("<=");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		if (value.C != null)
+			writer.WriteRule(value.C, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/LessThanRule.cs
+++ b/JsonLogic/Rules/LessThanRule.cs
@@ -14,21 +14,21 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LessThanRuleJsonConverter))]
 public class LessThanRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
-	private readonly Rule? _c;
+	internal Rule A { get; }
+	internal Rule B { get; }
+	internal Rule? C { get; }
 
 	internal LessThanRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	internal LessThanRule(Rule a, Rule b, Rule c)
 	{
-		_a = a;
-		_b = b;
-		_c = c;
+		A = a;
+		B = b;
+		C = c;
 	}
 
 	/// <summary>
@@ -42,10 +42,10 @@ public class LessThanRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		if (_c == null)
+		if (C == null)
 		{
-			var a = _a.Apply(data, contextData);
-			var b = _b.Apply(data, contextData);
+			var a = A.Apply(data, contextData);
+			var b = B.Apply(data, contextData);
 
 			var numberA = a.Numberify();
 			var numberB = b.Numberify();
@@ -56,15 +56,15 @@ public class LessThanRule : Rule
 			return numberA < numberB;
 		}
 
-		var low = (_a.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var low = (A.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (low == null)
 			throw new JsonLogicException("Lower bound must be a number.");
 
-		var value = (_b.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var value = (B.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (value == null)
 			throw new JsonLogicException("Value must be a number.");
 
-		var high = (_c.Apply(data, contextData) as JsonValue)?.GetNumber();
+		var high = (C.Apply(data, contextData) as JsonValue)?.GetNumber();
 		if (high == null)
 			throw new JsonLogicException("Upper bound must be a number.");
 
@@ -88,6 +88,14 @@ internal class LessThanRuleJsonConverter : JsonConverter<LessThanRule>
 
 	public override void Write(Utf8JsonWriter writer, LessThanRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("<");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		if (value.C != null)
+			writer.WriteRule(value.C, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/LiteralRule.cs
+++ b/JsonLogic/Rules/LiteralRule.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Nodes;
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Json.More;
 
 namespace Json.Logic.Rules;
@@ -8,15 +11,16 @@ namespace Json.Logic.Rules;
 /// </summary>
 /// <remarks>This is not exactly part of the specification, but it helps things in this library.</remarks>
 [Operator("")]
+[JsonConverter(typeof(LiteralRuleJsonConverter))]
 public class LiteralRule : Rule
 {
-	private readonly JsonNode? _value;
+	internal JsonNode? Value { get; }
 
 	internal static readonly LiteralRule Null = new(null);
 
 	internal LiteralRule(JsonNode? value)
 	{
-		_value = ReferenceEquals(JsonNull.SignalNode, value) ? null : value.Copy();
+		Value = ReferenceEquals(JsonNull.SignalNode, value) ? null : value.Copy();
 	}
 
 	/// <summary>
@@ -30,6 +34,20 @@ public class LiteralRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		return _value;
+		return Value;
+	}
+}
+
+internal class LiteralRuleJsonConverter : JsonConverter<LiteralRule>
+{
+	public override LiteralRule? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		// this is handled by Rule
+		throw new NotImplementedException();
+	}
+
+	public override void Write(Utf8JsonWriter writer, LiteralRule value, JsonSerializerOptions options)
+	{
+		JsonSerializer.Serialize(writer, value.Value, options);
 	}
 }

--- a/JsonLogic/Rules/LogRule.cs
+++ b/JsonLogic/Rules/LogRule.cs
@@ -12,11 +12,11 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LogRuleJsonConverter))]
 public class LogRule : Rule
 {
-	private readonly Rule _log;
+	internal Rule Log { get; }
 
 	internal LogRule(Rule log)
 	{
-		_log = log;
+		Log = log;
 	}
 
 	/// <summary>
@@ -30,7 +30,7 @@ public class LogRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var log = _log.Apply(data, contextData);
+		var log = Log.Apply(data, contextData);
 
 		Console.WriteLine(log);
 
@@ -52,6 +52,9 @@ internal class LogRuleJsonConverter : JsonConverter<LogRule>
 
 	public override void Write(Utf8JsonWriter writer, LogRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("log");
+		writer.WriteRule(value.Log, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/LooseEqualsRule.cs
+++ b/JsonLogic/Rules/LooseEqualsRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LooseEqualsRuleJsonConverter))]
 public class LooseEqualsRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal LooseEqualsRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class LooseEqualsRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		return a.LooseEquals(b);
 	}
@@ -53,6 +53,12 @@ internal class LooseEqualsRuleJsonConverter : JsonConverter<LooseEqualsRule>
 
 	public override void Write(Utf8JsonWriter writer, LooseEqualsRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("==");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/LooseNotEqualsRule.cs
+++ b/JsonLogic/Rules/LooseNotEqualsRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LooseNotEqualsRuleJsonConverter))]
 public class LooseNotEqualsRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal LooseNotEqualsRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class LooseNotEqualsRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		return !a.LooseEquals(b);
 	}
@@ -53,6 +53,12 @@ internal class LooseNotEqualsRuleJsonConverter : JsonConverter<LooseNotEqualsRul
 
 	public override void Write(Utf8JsonWriter writer, LooseNotEqualsRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("!=");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MapRule.cs
+++ b/JsonLogic/Rules/MapRule.cs
@@ -14,13 +14,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MapRuleJsonConverter))]
 public class MapRule : Rule
 {
-	private readonly Rule _input;
-	private readonly Rule _rule;
+	internal Rule Input { get; }
+	internal Rule Rule { get; }
 
 	internal MapRule(Rule input, Rule rule)
 	{
-		_input = input;
-		_rule = rule;
+		Input = input;
+		Rule = rule;
 	}
 
 	/// <summary>
@@ -34,12 +34,12 @@ public class MapRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var input = _input.Apply(data, contextData);
+		var input = Input.Apply(data, contextData);
 
 		if (input is not JsonArray arr)
 			return new JsonArray();
 
-		return arr.Select(i => _rule.Apply(data, i)).ToJsonArray();
+		return arr.Select(i => Rule.Apply(data, i)).ToJsonArray();
 	}
 }
 
@@ -57,6 +57,12 @@ internal class MapRuleJsonConverter : JsonConverter<MapRule>
 
 	public override void Write(Utf8JsonWriter writer, MapRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("map");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Input, options);
+		writer.WriteRule(value.Rule, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MaxRule.cs
+++ b/JsonLogic/Rules/MaxRule.cs
@@ -16,12 +16,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MaxRuleJsonConverter))]
 public class MaxRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal MaxRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class MaxRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data, contextData))
+		var items = Items.Select(i => i.Apply(data, contextData))
 			.Select(e => new { Type = e.JsonType(), Value = e.Numberify() })
 			.ToList();
 		var nulls = items.Where(i => i.Value == null);
@@ -60,6 +60,9 @@ internal class MaxRuleJsonConverter : JsonConverter<MaxRule>
 
 	public override void Write(Utf8JsonWriter writer, MaxRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("max");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MergeRule.cs
+++ b/JsonLogic/Rules/MergeRule.cs
@@ -15,11 +15,11 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MergeRuleJsonConverter))]
 public class MergeRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal MergeRule(params Rule[] items)
 	{
-		_items = items.ToList();
+		Items = items.ToList();
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class MergeRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data, contextData)).SelectMany(e => e.Flatten());
+		var items = Items.Select(i => i.Apply(data, contextData)).SelectMany(e => e.Flatten());
 
 		return items.ToJsonArray();
 	}
@@ -57,6 +57,9 @@ internal class MergeRuleJsonConverter : JsonConverter<MergeRule>
 
 	public override void Write(Utf8JsonWriter writer, MergeRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("merge");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MergeRule.cs
+++ b/JsonLogic/Rules/MergeRule.cs
@@ -59,7 +59,7 @@ internal class MergeRuleJsonConverter : JsonConverter<MergeRule>
 	{
 		writer.WriteStartObject();
 		writer.WritePropertyName("merge");
-		writer.WriteRules(value.Items, options);
+		writer.WriteRules(value.Items, options, false);
 		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MinRule.cs
+++ b/JsonLogic/Rules/MinRule.cs
@@ -16,12 +16,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MinRuleJsonConverter))]
 public class MinRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal MinRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class MinRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data, contextData)).Select(e => new { Type = e.JsonType(), Value = e.Numberify() }).ToList();
+		var items = Items.Select(i => i.Apply(data, contextData)).Select(e => new { Type = e.JsonType(), Value = e.Numberify() }).ToList();
 		var nulls = items.Where(i => i.Value == null);
 		if (nulls.Any())
 			throw new JsonLogicException($"Cannot find min with {nulls.First().Type}.");
@@ -58,6 +58,9 @@ internal class MinRuleJsonConverter : JsonConverter<MinRule>
 
 	public override void Write(Utf8JsonWriter writer, MinRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("min");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MissingRule.cs
+++ b/JsonLogic/Rules/MissingRule.cs
@@ -15,11 +15,11 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MissingRuleJsonConverter))]
 public class MissingRule : Rule
 {
-	private readonly Rule[] _components;
+	internal Rule[] Components { get; }
 
 	internal MissingRule(params Rule[] components)
 	{
-		_components = components;
+		Components = components;
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class MissingRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var expected = _components.SelectMany(c => c.Apply(data, contextData).Flatten())
+		var expected = Components.SelectMany(c => c.Apply(data, contextData).Flatten())
 			.OfType<JsonValue>()
 			.Where(v => v.TryGetValue(out string? _));
 
@@ -72,6 +72,9 @@ internal class MissingRuleJsonConverter : JsonConverter<MissingRule>
 
 	public override void Write(Utf8JsonWriter writer, MissingRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("missing");
+		writer.WriteRules(value.Components, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MissingSomeRule.cs
+++ b/JsonLogic/Rules/MissingSomeRule.cs
@@ -15,13 +15,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MissingSomeRuleJsonConverter))]
 public class MissingSomeRule : Rule
 {
-	private readonly Rule _requiredCount;
-	private readonly Rule _components;
+	internal Rule RequiredCount { get; }
+	internal Rule Components { get; }
 
 	internal MissingSomeRule(Rule requiredCount, Rule components)
 	{
-		_requiredCount = requiredCount;
-		_components = components;
+		RequiredCount = requiredCount;
+		Components = components;
 	}
 
 	/// <summary>
@@ -35,8 +35,8 @@ public class MissingSomeRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var requiredCount = _requiredCount.Apply(data, contextData).Numberify();
-		var components = _components.Apply(data, contextData);
+		var requiredCount = RequiredCount.Apply(data, contextData).Numberify();
+		var components = Components.Apply(data, contextData);
 		if (components is not JsonArray arr)
 			throw new JsonLogicException("Expected array of required paths.");
 
@@ -81,6 +81,12 @@ internal class MissingSomeRuleJsonConverter : JsonConverter<MissingSomeRule>
 
 	public override void Write(Utf8JsonWriter writer, MissingSomeRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("missing_some");
+		writer.WriteStartArray();
+		writer.WriteRule(value.RequiredCount, options);
+		writer.WriteRule(value.Components, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/ModRule.cs
+++ b/JsonLogic/Rules/ModRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(ModRuleJsonConverter))]
 public class ModRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal ModRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class ModRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();
@@ -62,6 +62,12 @@ internal class ModRuleJsonConverter : JsonConverter<ModRule>
 
 	public override void Write(Utf8JsonWriter writer, ModRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("%");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MoreThanEqualRule.cs
+++ b/JsonLogic/Rules/MoreThanEqualRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MoreThanEqualRuleJsonConverter))]
 public class MoreThanEqualRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal MoreThanEqualRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class MoreThanEqualRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();
@@ -59,6 +59,12 @@ internal class MoreThanEqualRuleJsonConverter : JsonConverter<MoreThanEqualRule>
 
 	public override void Write(Utf8JsonWriter writer, MoreThanEqualRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName(">=");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MoreThanRule.cs
+++ b/JsonLogic/Rules/MoreThanRule.cs
@@ -12,13 +12,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MoreThanRuleJsonConverter))]
 public class MoreThanRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal MoreThanRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -32,8 +32,8 @@ public class MoreThanRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var a = _a.Apply(data, contextData);
-		var b = _b.Apply(data, contextData);
+		var a = A.Apply(data, contextData);
+		var b = B.Apply(data, contextData);
 
 		var numberA = a.Numberify();
 		var numberB = b.Numberify();
@@ -59,6 +59,12 @@ internal class MoreThanRuleJsonConverter : JsonConverter<MoreThanRule>
 
 	public override void Write(Utf8JsonWriter writer, MoreThanRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName(">");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/MultiplyRule.cs
+++ b/JsonLogic/Rules/MultiplyRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(MultiplyRuleJsonConverter))]
 public class MultiplyRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal MultiplyRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -35,7 +35,7 @@ public class MultiplyRule : Rule
 	{
 		decimal result = 1;
 
-		foreach (var item in _items)
+		foreach (var item in Items)
 		{
 			var value = item.Apply(data, contextData);
 
@@ -65,6 +65,9 @@ internal class MultiplyRuleJsonConverter : JsonConverter<MultiplyRule>
 
 	public override void Write(Utf8JsonWriter writer, MultiplyRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("*");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/NoneRule.cs
+++ b/JsonLogic/Rules/NoneRule.cs
@@ -13,13 +13,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(NoneRuleJsonConverter))]
 public class NoneRule : Rule
 {
-	private readonly Rule _input;
-	private readonly Rule _rule;
+	internal Rule Input { get; }
+	internal Rule Rule { get; }
 
 	internal NoneRule(Rule input, Rule rule)
 	{
-		_input = input;
-		_rule = rule;
+		Input = input;
+		Rule = rule;
 	}
 
 	/// <summary>
@@ -33,12 +33,12 @@ public class NoneRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var input = _input.Apply(data, contextData);
+		var input = Input.Apply(data, contextData);
 
 		if (input is not JsonArray arr)
 			throw new JsonLogicException("Input must evaluate to an array.");
 
-		return !arr.Select(value => _rule.Apply(data, value))
+		return !arr.Select(value => Rule.Apply(data, value))
 			.Any(result => result.IsTruthy());
 	}
 }
@@ -57,6 +57,12 @@ internal class NoneRuleJsonConverter : JsonConverter<NoneRule>
 
 	public override void Write(Utf8JsonWriter writer, NoneRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("none");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Input, options);
+		writer.WriteRule(value.Rule, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/NotRule.cs
+++ b/JsonLogic/Rules/NotRule.cs
@@ -56,9 +56,7 @@ internal class NotRuleJsonConverter : JsonConverter<NotRule>
 	{
 		writer.WriteStartObject();
 		writer.WritePropertyName("!");
-		writer.WriteStartArray();
 		writer.WriteRule(value.Value, options);
-		writer.WriteEndArray();
 		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/NotRule.cs
+++ b/JsonLogic/Rules/NotRule.cs
@@ -12,11 +12,11 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(NotRuleJsonConverter))]
 public class NotRule : Rule
 {
-	private readonly Rule _value;
+	internal Rule Value { get; }
 
 	internal NotRule(Rule value)
 	{
-		_value = value;
+		Value = value;
 	}
 
 	/// <summary>
@@ -30,7 +30,7 @@ public class NotRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var value = _value.Apply(data, contextData);
+		var value = Value.Apply(data, contextData);
 
 		return !value.IsTruthy();
 	}
@@ -54,6 +54,11 @@ internal class NotRuleJsonConverter : JsonConverter<NotRule>
 
 	public override void Write(Utf8JsonWriter writer, NotRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("!");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Value, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/OrRule.cs
+++ b/JsonLogic/Rules/OrRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(OrRuleJsonConverter))]
 public class OrRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items { get; }
 
 	internal OrRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class OrRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var items = _items.Select(i => i.Apply(data, contextData));
+		var items = Items.Select(i => i.Apply(data, contextData));
 		JsonNode? first = false;
 		foreach (var x in items)
 		{
@@ -59,6 +59,9 @@ internal class OrRuleJsonConverter : JsonConverter<OrRule>
 
 	public override void Write(Utf8JsonWriter writer, OrRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("or");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/RuleCollection.cs
+++ b/JsonLogic/Rules/RuleCollection.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Json.More;
 
 namespace Json.Logic.Rules;
@@ -9,17 +12,18 @@ namespace Json.Logic.Rules;
 /// Provides a stand-in "rule" for collections of rules.
 /// </summary>
 /// <remarks>This is not exactly part of the specification, but it helps things in this library.</remarks>
+[JsonConverter(typeof(RuleCollectionJsonConverter))]
 public class RuleCollection : Rule
 {
-	private readonly IEnumerable<Rule> _rules;
+	internal IEnumerable<Rule> Rules { get; }
 
 	internal RuleCollection(params Rule[] rules)
 	{
-		_rules = rules;
+		Rules = rules;
 	}
 	internal RuleCollection(IEnumerable<Rule> rules)
 	{
-		_rules = rules;
+		Rules = rules;
 	}
 
 	/// <summary>
@@ -33,6 +37,20 @@ public class RuleCollection : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		return _rules.Select(x => x.Apply(data, contextData)).ToJsonArray();
+		return Rules.Select(x => x.Apply(data, contextData)).ToJsonArray();
+	}
+}
+
+internal class RuleCollectionJsonConverter : JsonConverter<RuleCollection>
+{
+	public override RuleCollection? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		// not used
+		throw new NotImplementedException();
+	}
+
+	public override void Write(Utf8JsonWriter writer, RuleCollection value, JsonSerializerOptions options)
+	{
+		writer.WriteRules(value.Rules, options);
 	}
 }

--- a/JsonLogic/Rules/SomeRule.cs
+++ b/JsonLogic/Rules/SomeRule.cs
@@ -13,13 +13,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(SomeRuleJsonConverter))]
 public class SomeRule : Rule
 {
-	private readonly Rule _input;
-	private readonly Rule _rule;
+	internal Rule Input { get; }
+	internal Rule Rule { get; }
 
 	internal SomeRule(Rule input, Rule rule)
 	{
-		_input = input;
-		_rule = rule;
+		Input = input;
+		Rule = rule;
 	}
 
 	/// <summary>
@@ -33,12 +33,12 @@ public class SomeRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		var input = _input.Apply(data, contextData);
+		var input = Input.Apply(data, contextData);
 
 		if (input is not JsonArray arr)
 			throw new JsonLogicException("Input must evaluate to an array.");
 
-		return arr.Select(value => _rule.Apply(data, value))
+		return arr.Select(value => Rule.Apply(data, value))
 			.Any(result => result.IsTruthy());
 	}
 }
@@ -57,6 +57,12 @@ internal class SomeRuleJsonConverter : JsonConverter<SomeRule>
 
 	public override void Write(Utf8JsonWriter writer, SomeRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("some");
+		writer.WriteStartArray();
+		writer.WriteRule(value.Input, options);
+		writer.WriteRule(value.Rule, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/StrictEqualsRule.cs
+++ b/JsonLogic/Rules/StrictEqualsRule.cs
@@ -13,13 +13,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(StrictEqualsRuleJsonConverter))]
 public class StrictEqualsRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal StrictEqualsRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class StrictEqualsRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		return _a.Apply(data, contextData).IsEquivalentTo(_b.Apply(data, contextData));
+		return A.Apply(data, contextData).IsEquivalentTo(B.Apply(data, contextData));
 	}
 }
 
@@ -51,6 +51,12 @@ internal class StrictEqualsRuleJsonConverter : JsonConverter<StrictEqualsRule>
 
 	public override void Write(Utf8JsonWriter writer, StrictEqualsRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("===");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/StrictNotEqualsRule.cs
+++ b/JsonLogic/Rules/StrictNotEqualsRule.cs
@@ -13,13 +13,13 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(StrictNotEqualsRuleJsonConverter))]
 public class StrictNotEqualsRule : Rule
 {
-	private readonly Rule _a;
-	private readonly Rule _b;
+	internal Rule A { get; }
+	internal Rule B { get; }
 
 	internal StrictNotEqualsRule(Rule a, Rule b)
 	{
-		_a = a;
-		_b = b;
+		A = a;
+		B = b;
 	}
 
 	/// <summary>
@@ -33,7 +33,7 @@ public class StrictNotEqualsRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		return !_a.Apply(data, contextData).IsEquivalentTo(_b.Apply(data, contextData));
+		return !A.Apply(data, contextData).IsEquivalentTo(B.Apply(data, contextData));
 	}
 }
 
@@ -51,6 +51,12 @@ internal class StrictNotEqualsRuleJsonConverter : JsonConverter<StrictNotEqualsR
 
 	public override void Write(Utf8JsonWriter writer, StrictNotEqualsRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("!==");
+		writer.WriteStartArray();
+		writer.WriteRule(value.A, options);
+		writer.WriteRule(value.B, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/SubtractRule.cs
+++ b/JsonLogic/Rules/SubtractRule.cs
@@ -14,12 +14,12 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(SubtractRuleJsonConverter))]
 public class SubtractRule : Rule
 {
-	private readonly List<Rule> _items;
+	internal List<Rule> Items;
 
 	internal SubtractRule(Rule a, params Rule[] more)
 	{
-		_items = new List<Rule> { a };
-		_items.AddRange(more);
+		Items = new List<Rule> { a };
+		Items.AddRange(more);
 	}
 
 	/// <summary>
@@ -33,9 +33,9 @@ public class SubtractRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		if (_items.Count == 0) return 0;
+		if (Items.Count == 0) return 0;
 
-		var value = _items[0].Apply(data, contextData);
+		var value = Items[0].Apply(data, contextData);
 		var number = value.Numberify();
 
 		if (number == null)
@@ -43,9 +43,9 @@ public class SubtractRule : Rule
 
 		var result = number.Value;
 
-		if (_items.Count == 1) return -result;
+		if (Items.Count == 1) return -result;
 
-		foreach (var item in _items.Skip(1))
+		foreach (var item in Items.Skip(1))
 		{
 			value = item.Apply(data, contextData);
 
@@ -75,6 +75,9 @@ internal class SubtractRuleJsonConverter : JsonConverter<SubtractRule>
 
 	public override void Write(Utf8JsonWriter writer, SubtractRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("-");
+		writer.WriteRules(value.Items, options);
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/VariableRule.cs
+++ b/JsonLogic/Rules/VariableRule.cs
@@ -13,20 +13,20 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(VariableRuleJsonConverter))]
 public class VariableRule : Rule
 {
-	private readonly Rule? _path;
-	private readonly Rule? _defaultValue;
+	internal Rule? Path { get; }
+	internal Rule? DefaultValue { get; }
 
 	internal VariableRule()
 	{
 	}
 	internal VariableRule(Rule path)
 	{
-		_path = path;
+		Path = path;
 	}
 	internal VariableRule(Rule path, Rule defaultValue)
 	{
-		_path = path;
-		_defaultValue = defaultValue;
+		Path = path;
+		DefaultValue = defaultValue;
 	}
 
 	/// <summary>
@@ -40,9 +40,9 @@ public class VariableRule : Rule
 	/// <returns>The result of the rule.</returns>
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
-		if (_path == null) return data;
+		if (Path == null) return data;
 
-		var path = _path.Apply(data, contextData);
+		var path = Path.Apply(data, contextData);
 		var pathString = path.Stringify()!;
 		if (pathString == string.Empty) return contextData ?? data;
 
@@ -51,7 +51,7 @@ public class VariableRule : Rule
 			pointer.TryEvaluate(data, out pathEval))
 			return pathEval;
 
-		return _defaultValue?.Apply(data, contextData) ?? null;
+		return DefaultValue?.Apply(data, contextData) ?? null;
 	}
 }
 
@@ -78,6 +78,14 @@ internal class VariableRuleJsonConverter : JsonConverter<VariableRule>
 
 	public override void Write(Utf8JsonWriter writer, VariableRule value, JsonSerializerOptions options)
 	{
-		throw new NotImplementedException();
+		writer.WriteStartObject();
+		writer.WritePropertyName("var");
+		writer.WriteStartArray();
+		if (value.Path != null)
+			writer.WriteRule(value.Path, options);
+		if (value.DefaultValue != null)
+			writer.WriteRule(value.DefaultValue, options);
+		writer.WriteEndArray();
+		writer.WriteEndObject();
 	}
 }

--- a/JsonLogic/Rules/VariableRule.cs
+++ b/JsonLogic/Rules/VariableRule.cs
@@ -80,12 +80,16 @@ internal class VariableRuleJsonConverter : JsonConverter<VariableRule>
 	{
 		writer.WriteStartObject();
 		writer.WritePropertyName("var");
-		writer.WriteStartArray();
-		if (value.Path != null)
-			writer.WriteRule(value.Path, options);
 		if (value.DefaultValue != null)
+		{
+			writer.WriteStartArray();
+			writer.WriteRule(value.Path, options);
 			writer.WriteRule(value.DefaultValue, options);
-		writer.WriteEndArray();
+			writer.WriteEndArray();
+		}
+		else
+			writer.WriteRule(value.Path, options);
+
 		writer.WriteEndObject();
 	}
 }

--- a/json-everything.net/wwwroot/md/release-notes/json-logic.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-logic.md
@@ -1,3 +1,7 @@
+# [3.2.0](https://github.com/gregsdennis/json-everything/pull/329)
+
+[#328](https://github.com/gregsdennis/json-everything/issues/328) - Added serialization support.
+
 # [3.1.2](https://github.com/gregsdennis/json-everything/pull/320)
 
 [#318](https://github.com/gregsdennis/json-everything/issues/318)/[#319](https://github.com/gregsdennis/json-everything/pull/319) - Conversions to numbers shouldn't be culture-dependent.  Thanks to [@warappa](https://github.com/warappa) for reporting and fixing this.

--- a/json-everything.net/wwwroot/md/release-notes/json-more.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-more.md
@@ -1,3 +1,7 @@
+# [1.7.0](https://github.com/gregsdennis/json-everything/pull/328)
+
+Added optional parameter for serializer option in `.AsJsonString()` extensions.
+
 # [1.6.0](https://github.com/gregsdennis/json-everything/pull/280)
 
 Added supporting functionality for `JsonNode`.


### PR DESCRIPTION
Resolves #328

This isn't a complete fix.  It's kind of a hack, but it works.  For rules that have been deserialized, you'll just get the same value back.  For rules built in code, it'll prefer unwrapping arrays (arrays with single items are reduced to just the item).

There's a new group of tests that just output the computed serialization rather than just regurgitating what was deserialized.  You can use these to see what the differences are (they don't fail).