### PR TITLE
Possible approach to support schemas nested in non-schema docs

### DIFF
--- a/JsonSchema.Data/Vocabularies.cs
+++ b/JsonSchema.Data/Vocabularies.cs
@@ -25,6 +25,6 @@ public static class Vocabularies
 
 		vocabRegistry.Register(Data);
 		SchemaKeywordRegistry.Register<DataKeyword>();
-		schemaRegistry.Register(MetaSchemas.DataId, MetaSchemas.Data);
+		schemaRegistry.Register(MetaSchemas.Data);
 	}
 }

--- a/JsonSchema.OpenApi.Tests/JsonSchema.OpenApi.Tests.csproj
+++ b/JsonSchema.OpenApi.Tests/JsonSchema.OpenApi.Tests.csproj
@@ -8,6 +8,7 @@
 		<RootNamespace>Json.Schema.OpenApi.Tests</RootNamespace>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../json-everything.snk</AssemblyOriginatorKeyFile>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,6 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\JsonPath\JsonPath.csproj" />
 		<ProjectReference Include="..\JsonSchema.OpenApi\JsonSchema.OpenApi.csproj" />
 		<ProjectReference Include="..\JsonSchema.Tests\JsonSchema.Tests.csproj" />
 	</ItemGroup>

--- a/JsonSchema.OpenApi.Tests/OpenApiDoc.cs
+++ b/JsonSchema.OpenApi.Tests/OpenApiDoc.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Json.More;
+using Json.Path;
+using Json.Pointer;
+
+namespace Json.Schema.OpenApi.Tests;
+
+// OpenAPI.Net would need to set up their root document class to handle this
+// This implementation is not optimal, but it seems to work
+// Having a base URI is very important.  The resolution system will break if one is not present.
+// If needed, generate one.
+public class OpenApiDoc : IBaseDocument
+{
+	private static readonly JsonPointer _componentSchemasLocation = JsonPointer.Parse("/components/schemas");
+	private static readonly JsonPath _schemasQuery = JsonPath.Parse("$..schema");
+
+	private readonly Dictionary<JsonPointer, JsonSchema> _lookup = new();
+
+	// implements IBaseDocument
+	public Uri BaseUri { get; }
+
+	public OpenApiDoc(Uri baseUri, JsonNode definition)
+	{
+		BaseUri = baseUri;
+
+		// Register this doc under the URI so that it's resolved when requested
+		SchemaRegistry.Global.Register(baseUri, this);
+
+		Initialize(definition);
+	}
+
+	// implements IBaseDocument
+	public JsonSchema? FindSubschema(JsonPointer pointer, EvaluationOptions options)
+	{
+		return _lookup.TryGetValue(pointer, out var schema) ? schema : null;
+	}
+
+	private void Initialize(JsonNode definition)
+	{
+		// Register schemas in places we know schemas live
+		if (_componentSchemasLocation.TryEvaluate(definition, out var componentSchemas))
+		{
+			foreach (var (name, node) in componentSchemas!.AsObject())
+			{
+				var location = _componentSchemasLocation.Combine(name);
+				var schema = node.Deserialize<JsonSchema>()!;
+				schema.BaseUri = BaseUri;
+				_lookup[location] = schema;
+			}
+		}
+
+		// Search the document for other places a schema might be hiding
+		var otherSchemaLocations = _schemasQuery.Evaluate(definition.ToJsonDocument().RootElement);
+		if (otherSchemaLocations.Matches != null)
+		{
+			foreach (var match in otherSchemaLocations.Matches)
+			{
+				var location = ConvertToPointer(match.Location);
+				var schema = match.Value.Deserialize<JsonSchema>()!;
+				schema.BaseUri = BaseUri;
+				_lookup[location] = schema;
+			}
+		}
+	}
+
+	// Paths are returned like: $['components']['schemas']
+	// but we need pointers like /components/schemas to do lookups
+	// I have an open issue to make this better, but this works for
+	// most cases.
+	private static JsonPointer ConvertToPointer(JsonPath path)
+	{
+		var pathString = path.ToString();
+		var removeDollar = pathString[1..];
+		var escapeTildes = removeDollar.Replace("~", "~0");
+		var escapeSlashes = escapeTildes.Replace("/", "~1");
+		var pointerString = Regex.Replace(escapeSlashes, @"\['(?<selector>.*?)'\]", @"/$1");
+
+		return JsonPointer.Parse(pointerString);
+	}
+}

--- a/JsonSchema.OpenApi.Tests/Tests.cs
+++ b/JsonSchema.OpenApi.Tests/Tests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -88,7 +87,7 @@ public class SpecExampleTests
 ";
 
 		var openApiDocNode = JsonNode.Parse(openApiDocText);
-		var openApiDoc = new OpenApiDoc(new Uri("http://localhost:1234/openapi"), openApiDocNode);
+		var openApiDoc = new OpenApiDoc(new Uri("http://localhost:1234/openapi"), openApiDocNode!);
 		var targetSchema = openApiDoc.FindSubschema(JsonPointer.Parse("/webhooks/newPet/post/requestBody/content/application~1json/schema"), EvaluationOptions.Default);
 
 		var payload = new JsonObject
@@ -98,7 +97,7 @@ public class SpecExampleTests
 			["tag"] = "a very good dog"
 		};
 
-		var result = targetSchema.Evaluate(payload);
+		var result = targetSchema!.Evaluate(payload);
 
 		result.AssertValid();
 	}

--- a/JsonSchema.OpenApi/Vocabularies.cs
+++ b/JsonSchema.OpenApi/Vocabularies.cs
@@ -33,6 +33,6 @@ public static class Vocabularies
 		SchemaKeywordRegistry.Register<DiscriminatorKeyword>();
 		SchemaKeywordRegistry.Register<ExternalDocsKeyword>();
 		SchemaKeywordRegistry.Register<XmlKeyword>();
-		schemaRegistry.Register(MetaSchemas.OpenApiMetaId, MetaSchemas.OpenApiMeta);
+		schemaRegistry.Register(MetaSchemas.OpenApiMeta);
 	}
 }

--- a/JsonSchema.Tests/FormatTests.cs
+++ b/JsonSchema.Tests/FormatTests.cs
@@ -80,7 +80,6 @@ public class FormatTests
 			OutputFormat = OutputFormat.Hierarchical,
 			OnlyKnownFormats = true
 		};
-		options.SchemaRegistry.Register(_formatAssertionMetaSchemaId, _formatAssertionMetaSchema);
 
 		var schemaText = $@"{{
 	""$schema"": ""{_formatAssertionMetaSchemaId}"",
@@ -88,6 +87,7 @@ public class FormatTests
 	""format"": ""something-dumb""
 }}";
 		var schema = JsonSchema.FromText(schemaText);
+		options.SchemaRegistry.Register(_formatAssertionMetaSchema);
 		var instance = JsonNode.Parse("\"a value\"");
 
 		var results = schema.Evaluate(instance, options);

--- a/JsonSchema.Tests/VocabularyTests.cs
+++ b/JsonSchema.Tests/VocabularyTests.cs
@@ -254,7 +254,7 @@ public class VocabularyTests
 		{
 			ValidateAgainstMetaSchema = true
 		};
-		options.SchemaRegistry.Register(new Uri("http://mydates.com/schema"), DatesMetaSchema);
+		options.SchemaRegistry.Register(DatesMetaSchema);
 		var results = schema.Evaluate(instance, options);
 
 		Console.WriteLine(JsonSerializer.Serialize(schema, _serializerOptions));
@@ -274,7 +274,7 @@ public class VocabularyTests
 		var instance = JsonNode.Parse($"\"{DateTime.Now.ToUniversalTime():O}\"");
 
 		var options = new EvaluationOptions();
-		options.SchemaRegistry.Register(new Uri("http://mydates.com/schema"), DatesMetaSchema);
+		options.SchemaRegistry.Register(DatesMetaSchema);
 		var results = schema.Evaluate(instance, options);
 
 		Console.WriteLine(JsonSerializer.Serialize(schema, _serializerOptions));
@@ -351,7 +351,7 @@ public class VocabularyTests
 		{
 			ValidateAgainstMetaSchema = true
 		};
-		options.SchemaRegistry.Register(new Uri("http://mydates.com/schema"), DatesMetaSchema);
+		options.SchemaRegistry.Register(DatesMetaSchema);
 		options.VocabularyRegistry.Register(DatesVocabulary);
 		var results = schema.Evaluate(instance, options);
 

--- a/JsonSchema.UniqueKeys/Vocabularies.cs
+++ b/JsonSchema.UniqueKeys/Vocabularies.cs
@@ -25,6 +25,6 @@ public static class Vocabularies
 
 		vocabRegistry.Register(UniqueKeys);
 		SchemaKeywordRegistry.Register<UniqueKeysKeyword>();
-		schemaRegistry.Register(MetaSchemas.UniqueKeysId, MetaSchemas.UniqueKeys);
+		schemaRegistry.Register(MetaSchemas.UniqueKeys);
 	}
 }

--- a/JsonSchema/DynamicRefKeyword.cs
+++ b/JsonSchema/DynamicRefKeyword.cs
@@ -59,10 +59,14 @@ public class DynamicRefKeyword : IJsonSchemaKeyword, IEquatable<DynamicRefKeywor
 			if (scopeRoot == null)
 				throw new Exception("This shouldn't happen");
 
-			if (!scopeRoot.Anchors.TryGetValue(anchorName, out var anchor) || !anchor.IsDynamic) continue;
+			if (scopeRoot is not JsonSchema schemaRoot)
+				throw new Exception("Does OpenAPI use anchors?");
 
-			if (context.Options.EvaluatingAs == SpecVersion.Draft202012 &&
-			    (!targetBase.Anchors.TryGetValue(anchorName, out var targetAnchor) || !targetAnchor.IsDynamic)) break;
+			if (!schemaRoot.Anchors.TryGetValue(anchorName, out var anchor) || !anchor.IsDynamic) continue;
+
+			if (targetBase is JsonSchema targetBaseSchema &&
+			    context.Options.EvaluatingAs == SpecVersion.Draft202012 &&
+			    (!targetBaseSchema.Anchors.TryGetValue(anchorName, out var targetAnchor) || !targetAnchor.IsDynamic)) break;
 
 			targetSchema = anchor.Schema;
 			break;
@@ -78,7 +82,8 @@ public class DynamicRefKeyword : IJsonSchemaKeyword, IEquatable<DynamicRefKeywor
 				if (!AnchorKeyword.AnchorPattern.IsMatch(anchorName))
 					throw new JsonSchemaException($"Unrecognized fragment type `{newUri}`");
 			
-				if (targetBase.Anchors.TryGetValue(anchorName, out var anchorDefinition))
+				if (targetBase is JsonSchema targetBaseSchema &&
+				    targetBaseSchema.Anchors.TryGetValue(anchorName, out var anchorDefinition))
 					targetSchema = anchorDefinition.Schema;
 			}
 

--- a/JsonSchema/IBaseDocument.cs
+++ b/JsonSchema/IBaseDocument.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Json.Pointer;
+
+namespace Json.Schema;
+
+/// <summary>
+/// Represents an identifiable or locatable base document that may be or contain a JSON Schema.
+/// </summary>
+public interface IBaseDocument
+{
+	/// <summary>
+	/// Gets the base URI that applies to this schema.  This may be defined by a parent schema.
+	/// </summary>
+	/// <remarks>
+	/// This property is initialized to a generated random value that matches `https://json-everything.net/{random}`
+	/// where `random` is 10 hex characters.
+	///
+	/// It may change after the initial evaluation based on whether the schema contains an `$id` keyword
+	/// or is a child of another schema.
+	/// </remarks>
+	Uri BaseUri { get; }
+
+	/// <summary>
+	/// Finds a schema within the document.
+	/// </summary>
+	/// <param name="pointer">A JSON Pointer to the location of the schema within the document.</param>
+	/// <param name="options">Evaluation options.  This is needed for internal processing.</param>
+	/// <returns>A JSON Schema, if found.</returns>
+	JsonSchema? FindSubschema(JsonPointer pointer, EvaluationOptions options);
+}

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -11,23 +11,6 @@ using Json.Pointer;
 
 namespace Json.Schema;
 
-public interface IBaseDocument
-{
-	/// <summary>
-	/// Gets the base URI that applies to this schema.  This may be defined by a parent schema.
-	/// </summary>
-	/// <remarks>
-	/// This property is initialized to a generated random value that matches `https://json-everything.net/{random}`
-	/// where `random` is 10 hex characters.
-	///
-	/// It may change after the initial evaluation based on whether the schema contains an `$id` keyword
-	/// or is a child of another schema.
-	/// </remarks>
-	Uri BaseUri { get; }
-
-	JsonSchema? FindSubschema(JsonPointer pointer, EvaluationOptions options);
-}
-
 /// <summary>
 /// Represents a JSON Schema.
 /// </summary>

--- a/JsonSchema/JsonSchemaBuilder.cs
+++ b/JsonSchema/JsonSchemaBuilder.cs
@@ -11,6 +11,13 @@ namespace Json.Schema;
 public class JsonSchemaBuilder
 {
 	private readonly Dictionary<string, IJsonSchemaKeyword> _keywords = new();
+	private Uri? _baseUri;
+
+	internal void TrySetBaseUri(Uri uri)
+	{
+		if (uri.IsAbsoluteUri)
+			_baseUri = uri;
+	}
 
 	/// <summary>
 	/// Adds a new keyword.
@@ -63,7 +70,10 @@ public class JsonSchemaBuilder
 		if (duplicates.Any())
 			throw new ArgumentException($"Found duplicate keywords: [{string.Join(", ", duplicates)}]");
 
-		return new JsonSchema(_keywords.Values);
+		var build = new JsonSchema(_keywords.Values);
+		if (_baseUri != null)
+			build.BaseUri = _baseUri;
+		return build;
 	}
 
 	/// <summary>

--- a/JsonSchema/JsonSchemaBuilderExtensions.cs
+++ b/JsonSchema/JsonSchemaBuilderExtensions.cs
@@ -456,6 +456,7 @@ public static class JsonSchemaBuilderExtensions
 	public static JsonSchemaBuilder Id(this JsonSchemaBuilder builder, Uri id)
 	{
 		builder.Add(new IdKeyword(id));
+		builder.TrySetBaseUri(id);
 		return builder;
 	}
 
@@ -467,7 +468,9 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder Id(this JsonSchemaBuilder builder, string id)
 	{
-		builder.Add(new IdKeyword(new Uri(id, UriKind.RelativeOrAbsolute)));
+		var uri = new Uri(id, UriKind.RelativeOrAbsolute);
+		builder.Add(new IdKeyword(uri));
+		builder.TrySetBaseUri(uri);
 		return builder;
 	}
 

--- a/JsonSchema/RecursiveRefKeyword.cs
+++ b/JsonSchema/RecursiveRefKeyword.cs
@@ -55,11 +55,15 @@ public class RecursiveRefKeyword : IJsonSchemaKeyword, IEquatable<RecursiveRefKe
 			if (scopeRoot == null)
 				throw new Exception("This shouldn't happen");
 
-			if (scopeRoot.RecursiveAnchor == null) continue;
+			if (scopeRoot is not JsonSchema schemaRoot)
+				throw new Exception("Does OpenAPI use anchors?");
 
-			if (targetBase.RecursiveAnchor == null) break;
+			if (schemaRoot.RecursiveAnchor == null) continue;
 
-			targetSchema = scopeRoot.RecursiveAnchor;
+			if (targetBase is JsonSchema targetBaseSchema &&
+			    targetBaseSchema.RecursiveAnchor == null) break;
+
+			targetSchema = schemaRoot.RecursiveAnchor;
 			break;
 		}
 
@@ -76,7 +80,8 @@ public class RecursiveRefKeyword : IJsonSchemaKeyword, IEquatable<RecursiveRefKe
 				if (!AnchorKeyword.AnchorPattern.IsMatch(anchorFragment))
 					throw new JsonSchemaException($"Unrecognized fragment type `{newUri}`");
 
-				if (targetBase.Anchors.TryGetValue(anchorFragment, out var anchorDefinition))
+				if (targetBase is JsonSchema targetBaseSchema &&
+				    targetBaseSchema.Anchors.TryGetValue(anchorFragment, out var anchorDefinition))
 					targetSchema = anchorDefinition.Schema;
 			}
 

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -71,7 +71,8 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 			if (!AnchorKeyword.AnchorPattern.IsMatch(anchorFragment))
 				throw new JsonSchemaException($"Unrecognized fragment type `{newUri}`");
 
-			if (targetBase.Anchors.TryGetValue(anchorFragment, out var anchorDefinition))
+			if (targetBase is JsonSchema targetBaseSchema &&
+			    targetBaseSchema.Anchors.TryGetValue(anchorFragment, out var anchorDefinition))
 				targetSchema = anchorDefinition.Schema;
 		}
 

--- a/JsonSchema/SchemaKeyword.cs
+++ b/JsonSchema/SchemaKeyword.cs
@@ -47,7 +47,7 @@ public class SchemaKeyword : IJsonSchemaKeyword, IEquatable<SchemaKeyword>
 	public void Evaluate(EvaluationContext context)
 	{
 		context.EnterKeyword(Name);
-		var metaSchema = context.Options.SchemaRegistry.Get(Schema);
+		var metaSchema = context.Options.SchemaRegistry.Get(Schema) as JsonSchema;
 		if (metaSchema == null)
 			throw new JsonSchemaException($"Cannot resolve meta-schema `{Schema}`");
 

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -70,6 +70,15 @@ public class SchemaRegistry
 	/// <summary>
 	/// Registers a schema by URI.
 	/// </summary>
+	/// <param name="document">The schema.</param>
+	public void Register(IBaseDocument document)
+	{
+		RegisterSchema(document.BaseUri, document);
+	}
+
+	/// <summary>
+	/// Registers a schema by URI.
+	/// </summary>
 	/// <param name="uri">The URI ID of the schema..</param>
 	/// <param name="document">The schema.</param>
 	public void Register(Uri? uri, IBaseDocument document)


### PR DESCRIPTION
Resolves #355 
Relates to https://github.com/microsoft/OpenAPI.NET/issues/795

There are some comments in the code, but basically the `SchemaRegistry` now tracks `IBaseDocument`s instead of just `JsonSchema`s.  The `OpenApiDoc` (or whatever it'll be called) will need to:

- implement `IBaseDocument`
- register itself under a base URI
- perform an initialization scan to discover the schemas it contains
- set the document's base URI on every contained schema

It's a bit hacked together right now, but it works.