### PR TITLE
Path/boolean valued functions

### DIFF
--- a/JsonPath.Tests/JsonPointerConversionTests.cs
+++ b/JsonPath.Tests/JsonPointerConversionTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Json.Path.Tests;
+
+public class JsonPointerTests
+{
+	[Test]
+	public void Name()
+	{
+		var path = JsonPath.Parse("$['foo']");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/foo", asPointer);
+	}
+
+	[Test]
+	public void Name_Shorthand()
+	{
+		var path = JsonPath.Parse("$.foo");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/foo", asPointer);
+	}
+
+	[Test]
+	public void Index()
+	{
+		var path = JsonPath.Parse("$[1]");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/1", asPointer);
+	}
+
+	[Test]
+	public void MultipleSegments()
+	{
+		var path = JsonPath.Parse("$[1].foo");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/1/foo", asPointer);
+	}
+
+	[Test]
+	public void NameWithTilde()
+	{
+		var path = JsonPath.Parse("$['~foo']");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/~0foo", asPointer);
+	}
+
+	[Test]
+	public void NameWithSlash()
+	{
+		var path = JsonPath.Parse("$['/foo']");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/~1foo", asPointer);
+	}
+
+	[Test]
+	public void NameWithSurrogatePair()
+	{
+		var path = JsonPath.Parse("$['\\uD834\\uDD1E']");
+
+		var asPointer = path.AsJsonPointer();
+
+		Assert.AreEqual("/𝄞", asPointer);
+	}
+
+	[Test]
+	public void Slice()
+	{
+		var path = JsonPath.Parse("$[1:2]");
+
+		Assert.Throws<InvalidOperationException>(() => path.AsJsonPointer());
+	}
+
+	[Test]
+	public void RecursiveDescent()
+	{
+		var path = JsonPath.Parse("$..foo");
+
+		Assert.Throws<InvalidOperationException>(() => path.AsJsonPointer());
+	}
+
+	[Test]
+	public void Wildcard()
+	{
+		var path = JsonPath.Parse("$[*]");
+
+		Assert.Throws<InvalidOperationException>(() => path.AsJsonPointer());
+	}
+
+	[Test]
+	public void Wildcard_Shorthand()
+	{
+		var path = JsonPath.Parse("$.*");
+
+		Assert.Throws<InvalidOperationException>(() => path.AsJsonPointer());
+	}
+
+	[Test]
+	public void MultipleSelectors()
+	{
+		var path = JsonPath.Parse("$[1,'foo']");
+
+		Assert.Throws<InvalidOperationException>(() => path.AsJsonPointer());
+	}
+}

--- a/JsonPath.Tests/StackOverflowTests.cs
+++ b/JsonPath.Tests/StackOverflowTests.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using NUnit.Framework;
 
-namespace Json.Path.Tests
+namespace Json.Path.Tests;
+
+public class StackOverflowTests
 {
-	public class StackOverflowTests
+	// https://stackoverflow.com/q/71692141/878701
+	[Test]
+	public void Question71692141()
 	{
-		// https://stackoverflow.com/q/71692141/878701
-		[Test]
-		public void Question71692141()
-		{
-			var data = JsonNode.Parse(@"{
+		var data = JsonNode.Parse(@"{
     ""type"": ""object"",
     ""properties"": {
         ""period"": {
@@ -44,11 +40,10 @@ namespace Json.Path.Tests
         ]
     }
 }");
-			var path = JsonPath.Parse("$..['x-updateIndicatorProperties']");
+		var path = JsonPath.Parse("$..['x-updateIndicatorProperties']");
 
-			var results = path.Evaluate(data);
+		var results = path.Evaluate(data);
 
-			Assert.AreEqual(2, results.Matches.Count);
-		}
+		Assert.AreEqual(2, results.Matches.Count);
 	}
 }

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -60,6 +60,9 @@ public class CburgmerFeatureValidationTests
 		"$[?(false)]",
 		"$[?(null)]",
 
+		// trailing whitespace is disallowed
+		"$. a ",
+
 		// regex operator transitioned to functions
 		"$[?(@.name=~/hello.*/)]",
 		"$[?(@.name=~/@.pattern/)]",

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -48,6 +48,7 @@ public class CburgmerFeatureValidationTests
 
 		// leading zeroes are not allowed for numeric literals
 		"$[?(@.key==010)]",
+		"$[010:024:010]",
 
 		// JSON literals are not expression results
 		"$[?(@.key>0 && false)]",

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteStringifyTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteStringifyTests.cs
@@ -1,14 +1,38 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using NUnit.Framework;
 
 namespace Json.Path.Tests.Suite;
 
 public class ComplianceTestSuiteStringifyTests
 {
-	[TestCaseSource(typeof(ComplianceTestSuiteTests), nameof(ComplianceTestSuiteTests.TestCases))]
+	private const string _testsFile = @"../../../../ref-repos/jsonpath-compliance-test-suite/cts.json";
+
+	//  - id: array_index
+	//    pathSegment: $[2]
+	//    document: ["first", "second", "third", "forth", "fifth"]
+	//    consensus: ["third"]
+	//    scalar-consensus: "third"
+	public static IEnumerable<TestCaseData> TestCases
+	{
+		get
+		{
+			var fileText = File.ReadAllText(_testsFile);
+			var suite = JsonSerializer.Deserialize<ComplianceTestSuite>(fileText, new JsonSerializerOptions
+			{
+				AllowTrailingCommas = true,
+				Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+				PropertyNameCaseInsensitive = true
+			});
+			return suite.Tests.Where(x => !x.InvalidSelector).Select(t => new TestCaseData(t) { TestName = t.Name });
+		}
+	}
+
+	[TestCaseSource(nameof(TestCases))]
 	public void Stringify(ComplianceTestCase testCase)
 	{
 		Console.WriteLine();
@@ -16,24 +40,7 @@ public class ComplianceTestSuiteStringifyTests
 		Console.WriteLine(testCase);
 		Console.WriteLine();
 
-		JsonPath? path = null;
-
-		var time = Debugger.IsAttached ? int.MaxValue : 100;
-		using var cts = new CancellationTokenSource(time);
-		Task.Run(() =>
-		{
-			if (testCase.Document == null) return;
-			path = JsonPath.Parse(testCase.Selector);
-		}, cts.Token).Wait(cts.Token);
-
-		if (path != null && testCase.InvalidSelector)
-			Assert.Inconclusive($"{testCase.Selector} is not a valid path but was parsed without error.");
-
-		if (path == null)
-		{
-			if (testCase.InvalidSelector) return;
-			Assert.Fail($"Could not parse path: {testCase.Selector}");
-		}
+		var path = JsonPath.Parse(testCase.Selector);
 
 		var backToString = path.ToString();
 		Console.WriteLine(backToString);

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteStringifyTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteStringifyTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Json.Path.Tests.Suite;
+
+public class ComplianceTestSuiteStringifyTests
+{
+	[TestCaseSource(typeof(ComplianceTestSuiteTests), nameof(ComplianceTestSuiteTests.TestCases))]
+	public void Stringify(ComplianceTestCase testCase)
+	{
+		Console.WriteLine();
+		Console.WriteLine();
+		Console.WriteLine(testCase);
+		Console.WriteLine();
+
+		JsonPath? path = null;
+
+		var time = Debugger.IsAttached ? int.MaxValue : 100;
+		using var cts = new CancellationTokenSource(time);
+		Task.Run(() =>
+		{
+			if (testCase.Document == null) return;
+			path = JsonPath.Parse(testCase.Selector);
+		}, cts.Token).Wait(cts.Token);
+
+		if (path != null && testCase.InvalidSelector)
+			Assert.Inconclusive($"{testCase.Selector} is not a valid path but was parsed without error.");
+
+		if (path == null)
+		{
+			if (testCase.InvalidSelector) return;
+			Assert.Fail($"Could not parse path: {testCase.Selector}");
+		}
+
+		var backToString = path.ToString();
+		Console.WriteLine(backToString);
+
+		if (testCase.Selector != backToString)
+			Assert.Inconclusive();
+	}
+}

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
@@ -82,41 +82,4 @@ public class ComplianceTestSuiteTests
 		var expected = testCase.Result.ToJsonArray();
 		Assert.IsTrue(expected.IsEquivalentTo(actualValues));
 	}
-
-	[TestCaseSource(nameof(TestCases))]
-	public void Stringify(ComplianceTestCase testCase)
-	{
-		if (_notSupported.Contains(testCase.Selector))
-			Assert.Inconclusive("This case will not be supported.");
-
-		Console.WriteLine();
-		Console.WriteLine();
-		Console.WriteLine(testCase);
-		Console.WriteLine();
-
-		JsonPath? path = null;
-
-		var time = Debugger.IsAttached ? int.MaxValue : 100;
-		using var cts = new CancellationTokenSource(time);
-		Task.Run(() =>
-		{
-			if (testCase.Document == null) return;
-			path = JsonPath.Parse(testCase.Selector);
-		}, cts.Token).Wait(cts.Token);
-
-		if (path != null && testCase.InvalidSelector)
-			Assert.Inconclusive($"{testCase.Selector} is not a valid path but was parsed without error.");
-
-		if (path == null)
-		{
-			if (testCase.InvalidSelector) return;
-			Assert.Fail($"Could not parse path: {testCase.Selector}");
-		}
-
-		var backToString = path.ToString();
-		Console.WriteLine(backToString);
-
-		if (testCase.Selector != backToString)
-			Assert.Inconclusive();
-	}
 }

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using Json.More;
 using NUnit.Framework;
 
@@ -50,29 +47,30 @@ public class ComplianceTestSuiteTests
 		Console.WriteLine(testCase);
 		Console.WriteLine();
 
-		JsonPath? path = null;
-		PathResult? actual = null;
-
-		var time = Debugger.IsAttached ? int.MaxValue : 100;
-		using var cts = new CancellationTokenSource(time);
-		Task.Run(() =>
+		if (testCase.InvalidSelector)
 		{
-			if (testCase.Document == null) return;
-			path = JsonPath.Parse(testCase.Selector);
-			
-			actual = path.Evaluate(testCase.Document);
-		}, cts.Token).Wait(cts.Token);
+			bool tryParseResult;
+			try
+			{
+				tryParseResult = JsonPath.TryParse(testCase.Selector, out _);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				Assert.Fail("TryParse() threw an exception");
+				throw; // this will never run, but the compiler doesn't know that Assert.Fail() will always throw.
+			}
+			Assert.IsTrue(tryParseResult);
 
-		if (path != null && testCase.InvalidSelector)
-			Assert.Inconclusive($"{testCase.Selector} is not a valid path but was parsed without error.");
-
-		if (actual == null)
-		{
-			if (testCase.InvalidSelector) return;
-			Assert.Fail($"Could not parse path: {testCase.Selector}");
+			var exception = Assert.Throws<PathParseException>(() => JsonPath.Parse(testCase.Selector));
+			Console.WriteLine($"Error: {exception!.Message}");
+			return;
 		}
 
-		var actualValues = actual!.Matches!.Select(m => m.Value).ToJsonArray();
+		var path = JsonPath.Parse(testCase.Selector);
+		var actual = path.Evaluate(testCase.Document);
+
+		var actualValues = actual.Matches!.Select(m => m.Value).ToJsonArray();
 		Console.WriteLine($"Actual (values): {actualValues}");
 		Console.WriteLine();
 		Console.WriteLine($"Actual: {JsonSerializer.Serialize(actual, new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping })}");

--- a/JsonPath/CountFunction.cs
+++ b/JsonPath/CountFunction.cs
@@ -25,6 +25,14 @@ public class CountFunction : IPathFunctionDefinition
 	/// </summary>
 	public int MaxArgumentCount => 1;
 
+	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
+		new[]
+		{
+			new[] { ParameterType.Array | ParameterType.String }
+		};
+
+	public FunctionType ReturnType => FunctionType.Value;
+
 	/// <summary>
 	/// Evaluates the function.
 	/// </summary>

--- a/JsonPath/CountFunction.cs
+++ b/JsonPath/CountFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 
@@ -16,21 +17,35 @@ public class CountFunction : IPathFunctionDefinition
 	public string Name => "count";
 
 	/// <summary>
-	/// The minimum argument count accepted by the function.
+	/// Defines the sets of parameters that are valid for this function.
 	/// </summary>
-	public int MinArgumentCount => 1;
-
-	/// <summary>
-	/// The maximum argument count accepted by the function.
-	/// </summary>
-	public int MaxArgumentCount => 1;
-
+	/// <remarks>
+	/// The value of this property is a collection of collections where
+	/// each inner collection represents a single parameter set.  The
+	/// outer collection represents differing parameter sets and can
+	/// be thought of as "overloads."
+	/// </remarks>
 	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
 		new[]
 		{
 			new[] { ParameterType.Array | ParameterType.String }
 		};
 
+	/// <summary>
+	/// The type returned by the function.
+	/// </summary>
+	/// <remarks>
+	/// This is important for function composition: using a function
+	/// as a parameter of another function.
+	///
+	/// This library assumes that a function may return `Nothing` and
+	/// automatically handles that case.  This value should be set to
+	/// what kind of non-`Nothing` type the function returns.
+	///
+	/// Registration of the function will throw an
+	/// <see cref="InvalidOperationException"/> if the value is
+	/// <see cref="FunctionType.Unspecified"/>
+	/// </remarks>
 	public FunctionType ReturnType => FunctionType.Value;
 
 	/// <summary>

--- a/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
+++ b/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
@@ -43,7 +43,11 @@ internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 		var i = index;
 		var nestLevel = 0;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			expression = null;
+			return false;
+		}
 		while (i < source.Length && source[i] == '(')
 		{
 			nestLevel++;
@@ -73,7 +77,11 @@ internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 			return false;
 		}
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			expression = null;
+			return false;
+		}
 		while (i < source.Length && source[i] == ')' && nestLevel > 0)
 		{
 			nestLevel--;

--- a/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
+++ b/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
@@ -38,7 +38,7 @@ internal class BinaryComparativeExpressionNode : ComparativeExpressionNode
 
 internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression, PathParsingOptions options)
 	{
 		var i = index;
 		var nestLevel = 0;
@@ -57,7 +57,7 @@ internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 			throw new PathParseException(i, "Unexpected end of input");
 
 		// parse value
-		if (!ValueExpressionParser.TryParse(source, ref i, out var left))
+		if (!ValueExpressionParser.TryParse(source, ref i, out var left, options))
 		{
 			expression = null;
 			return false;
@@ -71,7 +71,7 @@ internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 		}
 
 		// parse value
-		if (!ValueExpressionParser.TryParse(source, ref i, out var right))
+		if (!ValueExpressionParser.TryParse(source, ref i, out var right, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/BinaryLogicalExpressionNode.cs
+++ b/JsonPath/Expressions/BinaryLogicalExpressionNode.cs
@@ -42,7 +42,7 @@ internal class BinaryLogicalExpressionNode : LogicalExpressionNode
 
 internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 	{
 		int i = index;
 		var nestLevel = 0;
@@ -68,7 +68,7 @@ internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 		}
 
 		// first get a comparison
-		if (!ComparativeExpressionParser.TryParse(source, ref i, out var comp))
+		if (!ComparativeExpressionParser.TryParse(source, ref i, out var comp, options))
 		{
 			expression = null;
 			return false;
@@ -114,7 +114,7 @@ internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 			}
 
 			// parse right
-			if (!BooleanResultExpressionParser.TryParse(source, ref i, out var right))
+			if (!BooleanResultExpressionParser.TryParse(source, ref i, out var right, options))
 			{
 				// if we don't get a comparison, then the syntax is wrong
 				expression = null;

--- a/JsonPath/Expressions/BinaryLogicalExpressionNode.cs
+++ b/JsonPath/Expressions/BinaryLogicalExpressionNode.cs
@@ -49,14 +49,23 @@ internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 
 		int Precedence(IBinaryLogicalOperator op) => nestLevel * 10 + op.Precedence;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			expression = null;
+			return false;
+		}
+
 		while (i < source.Length && source[i] == '(')
 		{
 			nestLevel++;
 			i++;
 		}
-		if (i == source.Length)
-			throw new PathParseException(i, "Unexpected end of input");
+
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			expression = null;
+			return false;
+		}
 
 		// first get a comparison
 		if (!ComparativeExpressionParser.TryParse(source, ref i, out var comp))
@@ -70,7 +79,11 @@ internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 		while (i < source.Length)
 		{
 			// handle )
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref i))
+			{
+				expression = null;
+				return false;
+			}
 			if (source[i] == ')' && nestLevel > 0)
 			{
 				while (i < source.Length && source[i] == ')' && nestLevel > 0)
@@ -89,7 +102,11 @@ internal class BinaryLogicalExpressionParser : ILogicalExpressionParser
 				break; // if we don't get an op, then we're done
 
 			// handle (
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref i))
+			{
+				expression = null;
+				return false;
+			}
 			if (source[i] == '(')
 			{
 				nextNest++;

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -67,6 +67,12 @@ internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
 			return false;
 		}
 
+		if (function.ReturnType != FunctionType.Boolean)
+		{
+			expression = null;
+			return false;
+		}
+
 		expression = new BooleanFunctionExpressionNode(function, parameters);
 		return true;
 	}

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -61,19 +61,21 @@ internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
 {
 	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 	{
-		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function, options))
+		int i = index;
+		if (!FunctionExpressionParser.TryParseFunction(source, ref i, out var parameters, out var function, options))
 		{
 			expression = null;
 			return false;
 		}
 
-		if (function.ReturnType.HasFlag(FunctionType.Boolean))
+		if (!function.ReturnType.HasFlag(FunctionType.Boolean))
 		{
 			expression = null;
 			return false;
 		}
 
 		expression = new BooleanFunctionExpressionNode(function, parameters);
+		index = i;
 		return true;
 	}
 }

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -67,7 +67,7 @@ internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
 			return false;
 		}
 
-		if (function.ReturnType != FunctionType.Boolean)
+		if (function.ReturnType.HasFlag(FunctionType.Boolean))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -61,71 +61,13 @@ internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
 {
 	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
 	{
-		int i = index;
-
-		source.ConsumeWhitespace(ref i);
-
-		// parse function name
-		if (!source.TryParseName(ref i, out var name))
-		{
-			expression = null;
-			return false;
-		}
-
-		source.ConsumeWhitespace(ref i);
-
-		// consume (
-		if (source[i] != '(')
-		{
-			expression = null;
-			return false;
-		}
-		i++;
-
-		// parse list of parameters - all value expressions
-		var parameters = new List<ValueExpressionNode>();
-		var done = false;
-
-		while (i < source.Length && !done)
-		{
-			source.ConsumeWhitespace(ref i);
-
-			if (!ValueExpressionParser.TryParse(source, ref i, out var parameter)) break;
-
-			parameters.Add(parameter);
-
-			source.ConsumeWhitespace(ref i);
-		
-			switch (source[i])
-			{
-				case ')':
-					done = true;
-					i++;
-					break;
-				case ',':
-					i++;
-					break;
-				default:
-					expression = null;
-					return false;
-			}
-		}
-
-		if (!FunctionRepository.TryGet(name, out var function))
-		{
-			expression = null;
-			return false;
-		}
-
-		if (function.MinArgumentCount > parameters.Count ||
-		    parameters.Count > function.MaxArgumentCount)
+		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function))
 		{
 			expression = null;
 			return false;
 		}
 
 		expression = new BooleanFunctionExpressionNode(function, parameters);
-		index = i;
 		return true;
 	}
 }

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -59,9 +59,9 @@ internal class BooleanFunctionExpressionNode : LogicalExpressionNode
 
 internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 	{
-		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function))
+		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanFunctionExpressionNode.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using Json.More;
+
+namespace Json.Path.Expressions;
+
+internal class BooleanFunctionExpressionNode : LogicalExpressionNode
+{
+	public IPathFunctionDefinition Function { get; }
+	public ValueExpressionNode[] Parameters { get; }
+
+	public BooleanFunctionExpressionNode(IPathFunctionDefinition function, IEnumerable<ValueExpressionNode> parameters)
+	{
+		Function = function;
+		Parameters = parameters.ToArray();
+	}
+
+	public override bool Evaluate(JsonNode? globalParameter, JsonNode? localParameter)
+	{
+		var parameterValues = Parameters.Select(x =>
+		{
+			var result = x.Evaluate(globalParameter, localParameter);
+			if (result != null) return (NodeList)result;
+			return NodeList.Empty;
+		});
+
+		var nodeList = Function.Evaluate(parameterValues);
+
+		return nodeList.Count == 1 && nodeList[0].Value.IsEquivalentTo(true);
+	}
+
+	public override void BuildString(StringBuilder builder)
+	{
+		builder.Append(Function.Name);
+		builder.Append('(');
+
+		if (Parameters.Any())
+		{
+			Parameters[0].BuildString(builder);
+			for (int i = 1; i < Parameters.Length; i++)
+			{
+				builder.Append(',');
+				Parameters[i].BuildString(builder);
+			}
+		}
+
+		builder.Append(')');
+	}
+
+	public override string ToString()
+	{
+		return $"{Function.Name}({string.Join(',', (IEnumerable<ValueExpressionNode>)Parameters)})";
+	}
+}
+
+internal class BooleanFunctionExpressionParser : ILogicalExpressionParser
+{
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+	{
+		int i = index;
+
+		source.ConsumeWhitespace(ref i);
+
+		// parse function name
+		if (!source.TryParseName(ref i, out var name))
+		{
+			expression = null;
+			return false;
+		}
+
+		source.ConsumeWhitespace(ref i);
+
+		// consume (
+		if (source[i] != '(')
+		{
+			expression = null;
+			return false;
+		}
+		i++;
+
+		// parse list of parameters - all value expressions
+		var parameters = new List<ValueExpressionNode>();
+		var done = false;
+
+		while (i < source.Length && !done)
+		{
+			source.ConsumeWhitespace(ref i);
+
+			if (!ValueExpressionParser.TryParse(source, ref i, out var parameter)) break;
+
+			parameters.Add(parameter);
+
+			source.ConsumeWhitespace(ref i);
+		
+			switch (source[i])
+			{
+				case ')':
+					done = true;
+					i++;
+					break;
+				case ',':
+					i++;
+					break;
+				default:
+					expression = null;
+					return false;
+			}
+		}
+
+		if (!FunctionRepository.TryGet(name, out var function))
+		{
+			expression = null;
+			return false;
+		}
+
+		if (function.MinArgumentCount > parameters.Count ||
+		    parameters.Count > function.MaxArgumentCount)
+		{
+			expression = null;
+			return false;
+		}
+
+		expression = new BooleanFunctionExpressionNode(function, parameters);
+		index = i;
+		return true;
+	}
+}

--- a/JsonPath/Expressions/BooleanResultExpressionNode.cs
+++ b/JsonPath/Expressions/BooleanResultExpressionNode.cs
@@ -14,15 +14,15 @@ internal abstract class BooleanResultExpressionNode
 
 internal static class BooleanResultExpressionParser
 {
-	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out BooleanResultExpressionNode? expression)
+	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out BooleanResultExpressionNode? expression, PathParsingOptions options)
 	{
-		if (LogicalExpressionParser.TryParse(source, ref index, out var logic))
+		if (LogicalExpressionParser.TryParse(source, ref index, out var logic, options))
 		{
 			expression = logic;
 			return true;
 		}
 
-		if (ComparativeExpressionParser.TryParse(source, ref index, out var comparison))
+		if (ComparativeExpressionParser.TryParse(source, ref index, out var comparison, options))
 		{
 			expression = comparison;
 			return true;

--- a/JsonPath/Expressions/ComparativeExpressionNode.cs
+++ b/JsonPath/Expressions/ComparativeExpressionNode.cs
@@ -15,12 +15,12 @@ internal static class ComparativeExpressionParser
 		new UnaryComparativeExpressionParser()
 	};
 
-	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression)
+	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression, PathParsingOptions options)
 	{
 		// TODO (efficiency opportunity) the first value is parsed twice
 		foreach (var parser in _parsers)
 		{
-			if (parser.TryParse(source, ref index, out expression)) return true;
+			if (parser.TryParse(source, ref index, out expression, options)) return true;
 		}
 
 		expression = null;

--- a/JsonPath/Expressions/ExistsOperator.cs
+++ b/JsonPath/Expressions/ExistsOperator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Linq;
+using System.Text.Json.Nodes;
 
 namespace Json.Path.Expressions;
 
@@ -8,7 +9,13 @@ internal class ExistsOperator : IUnaryComparativeOperator
 
 	public bool Evaluate(JsonNode? value)
 	{
-		return value is not null;
+		if (value is not JsonValue jValue)
+			return value is not null;
+
+		if (jValue.TryGetValue(out NodeList? nodeList))
+			return nodeList.Any();
+
+		return true;
 	}
 
 	public override string ToString()

--- a/JsonPath/Expressions/ExpressionParser.cs
+++ b/JsonPath/Expressions/ExpressionParser.cs
@@ -5,9 +5,9 @@ namespace Json.Path.Expressions
 {
 	internal static class ExpressionParser
 	{
-		public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+		public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 		{
-			return LogicalExpressionParser.TryParse(source, ref index, out expression);
+			return LogicalExpressionParser.TryParse(source, ref index, out expression, options);
 		}
 	}
 }

--- a/JsonPath/Expressions/FunctionExpressionParser.cs
+++ b/JsonPath/Expressions/FunctionExpressionParser.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
@@ -112,29 +111,12 @@ internal static class FunctionExpressionParser
 		}
 
 		var parameterTypes = parameters.Select(x => x.GetParameterType()).ToList();
-		if (options.StrictTypeChecking)
-		{
 			if (!function.ParameterSets.Any(x => x.SequenceEqual(parameterTypes, EqualOrUnspecifiedEqualityComparer.Instance)))
 			{
 				parameters = null;
 				function = null;
 				return false;
 			}
-		}
-		else if (function.ParameterSets.All(x => x.Count() != parameterTypes.Count))
-		{
-			parameters = null;
-			function = null;
-			return false;
-		}
-
-		//if (function.MinArgumentCount > parameters.Count ||
-		//    parameters.Count > function.MaxArgumentCount)
-		//{
-		//	parameters = null;
-		//	function = null;
-		//	return false;
-		//}
 
 		index = i;
 		return true;

--- a/JsonPath/Expressions/FunctionExpressionParser.cs
+++ b/JsonPath/Expressions/FunctionExpressionParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;
@@ -31,7 +32,12 @@ internal static class FunctionExpressionParser
 	{
 		int i = index;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
 
 		// parse function name
 		if (!source.TryParseName(ref i, out var name))
@@ -41,7 +47,12 @@ internal static class FunctionExpressionParser
 			return false;
 		}
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref i))
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
 
 		// consume (
 		if (source[i] != '(')
@@ -59,13 +70,23 @@ internal static class FunctionExpressionParser
 
 		while (i < source.Length && !done)
 		{
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref i))
+			{
+				parameters = null;
+				function = null;
+				return false;
+			}
 
 			if (!ValueExpressionParser.TryParse(source, ref i, out var parameter)) break;
 
 			parameters.Add(parameter);
 
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref i))
+			{
+				parameters = null;
+				function = null;
+				return false;
+			}
 
 			switch (source[i])
 			{

--- a/JsonPath/Expressions/FunctionExpressionParser.cs
+++ b/JsonPath/Expressions/FunctionExpressionParser.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.More;
+
+namespace Json.Path.Expressions;
+
+internal static class FunctionExpressionParser
+{
+	private class EqualOrUnspecifiedEqualityComparer : IEqualityComparer<ParameterType>
+	{
+		public static EqualOrUnspecifiedEqualityComparer Instance { get; } = new();
+
+		private EqualOrUnspecifiedEqualityComparer(){}
+
+		public bool Equals(ParameterType x, ParameterType y)
+		{
+			return x == ParameterType.Unspecified || y == ParameterType.Unspecified || x == y;
+		}
+
+		public int GetHashCode(ParameterType obj)
+		{
+			return 0;
+		}
+	}
+
+	public static bool TryParseFunction(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out List<ValueExpressionNode>? parameters, [NotNullWhen(true)] out IPathFunctionDefinition? function)
+	{
+		int i = index;
+
+		source.ConsumeWhitespace(ref i);
+
+		// parse function name
+		if (!source.TryParseName(ref i, out var name))
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
+
+		source.ConsumeWhitespace(ref i);
+
+		// consume (
+		if (source[i] != '(')
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
+
+		i++;
+
+		// parse list of parameters - all value expressions
+		parameters = new List<ValueExpressionNode>();
+		var done = false;
+
+		while (i < source.Length && !done)
+		{
+			source.ConsumeWhitespace(ref i);
+
+			if (!ValueExpressionParser.TryParse(source, ref i, out var parameter)) break;
+
+			parameters.Add(parameter);
+
+			source.ConsumeWhitespace(ref i);
+
+			switch (source[i])
+			{
+				case ')':
+					done = true;
+					i++;
+					break;
+				case ',':
+					i++;
+					break;
+				default:
+					parameters = null;
+					function = null;
+					return false;
+			}
+		}
+
+		if (!FunctionRepository.TryGet(name, out function))
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
+
+		var parameterTypes = parameters.Select(x => x.GetParameterType()).ToList();
+		if (!function.ParameterSets.Any(x => x.SequenceEqual(parameterTypes, EqualOrUnspecifiedEqualityComparer.Instance)))
+		{
+			parameters = null;
+			function = null;
+			return false;
+		}
+
+		//if (function.MinArgumentCount > parameters.Count ||
+		//    parameters.Count > function.MaxArgumentCount)
+		//{
+		//	parameters = null;
+		//	function = null;
+		//	return false;
+		//}
+
+		index = i;
+		return true;
+	}
+
+	private static ParameterType GetParameterType(this ValueExpressionNode valueNode)
+	{
+		if (valueNode is not LiteralExpressionNode literal) return ParameterType.Unspecified;
+
+		return GetParameterType(literal.Value);
+	}
+
+	private static ParameterType GetParameterType(this JsonNode? node)
+	{
+		if (node is null) return ParameterType.Null;
+		if (node is JsonArray) return ParameterType.Array;
+		if (node is JsonObject) return ParameterType.Object;
+		if (node is JsonValue value)
+		{
+			var obj = value.GetValue<object>();
+			if (obj is JsonNull) return ParameterType.Null;
+			if (obj is JsonElement element) return GetParameterType(element);
+			var objType = obj.GetType();
+			if (objType.IsNumber()) return ParameterType.Number;
+			if (obj is string) return ParameterType.String;
+			if (obj is bool) return ParameterType.Boolean;
+		}
+
+		throw new ArgumentOutOfRangeException(nameof(node));
+	}
+
+	private static ParameterType GetParameterType(JsonElement element) =>
+		element.ValueKind switch
+		{
+			JsonValueKind.Object => ParameterType.Object,
+			JsonValueKind.Array => ParameterType.Array,
+			JsonValueKind.String => ParameterType.String,
+			JsonValueKind.Number => ParameterType.Number,
+			JsonValueKind.True => ParameterType.Boolean,
+			JsonValueKind.False => ParameterType.Boolean,
+			JsonValueKind.Null => ParameterType.Null,
+			_ => throw new ArgumentOutOfRangeException(nameof(element.ValueKind), element.ValueKind, null)
+		};
+
+}

--- a/JsonPath/Expressions/IComparativeExpressionParser.cs
+++ b/JsonPath/Expressions/IComparativeExpressionParser.cs
@@ -5,5 +5,5 @@ namespace Json.Path.Expressions;
 
 internal interface IComparativeExpressionParser
 {
-	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression);
+	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression, PathParsingOptions options);
 }

--- a/JsonPath/Expressions/ILogicalExpressionParser.cs
+++ b/JsonPath/Expressions/ILogicalExpressionParser.cs
@@ -5,5 +5,5 @@ namespace Json.Path.Expressions;
 
 internal interface ILogicalExpressionParser
 {
-	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression);
+	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options);
 }

--- a/JsonPath/Expressions/IValueExpressionParser.cs
+++ b/JsonPath/Expressions/IValueExpressionParser.cs
@@ -5,5 +5,5 @@ namespace Json.Path.Expressions;
 
 internal interface IValueExpressionParser
 {
-	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression);
+	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options);
 }

--- a/JsonPath/Expressions/LiteralExpressionNode.cs
+++ b/JsonPath/Expressions/LiteralExpressionNode.cs
@@ -33,7 +33,7 @@ internal class LiteralExpressionNode : ValueExpressionNode
 
 internal class LiteralExpressionParser : IValueExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options)
 	{
 		if (!source.TryParseJson(ref index, out var node))
 		{

--- a/JsonPath/Expressions/LogicalExpressionNode.cs
+++ b/JsonPath/Expressions/LogicalExpressionNode.cs
@@ -12,7 +12,8 @@ internal static class LogicalExpressionParser
 	private static readonly ILogicalExpressionParser[] _parsers =
 	{
 		new BinaryLogicalExpressionParser(),
-		new UnaryLogicalExpressionParser()
+		new UnaryLogicalExpressionParser(),
+		new BooleanFunctionExpressionParser()
 	};
 
 	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)

--- a/JsonPath/Expressions/LogicalExpressionNode.cs
+++ b/JsonPath/Expressions/LogicalExpressionNode.cs
@@ -16,12 +16,12 @@ internal static class LogicalExpressionParser
 		new BooleanFunctionExpressionParser()
 	};
 
-	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 	{
 		// TODO (efficiency opportunity) the first comparison is parsed twice
 		foreach (var parser in _parsers)
 		{
-			if (parser.TryParse(source, ref index, out expression)) return true;
+			if (parser.TryParse(source, ref index, out expression, options)) return true;
 		}
 
 		expression = null;

--- a/JsonPath/Expressions/Operators.cs
+++ b/JsonPath/Expressions/Operators.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
 
 namespace Json.Path.Expressions;
 
@@ -30,7 +31,11 @@ internal static class ValueOperatorParser
 {
 	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out IBinaryValueOperator? op)
 	{
-		source.ConsumeWhitespace(ref index);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			op = null;
+			return false;
+		}
 
 		switch (source[index])
 		{
@@ -63,7 +68,11 @@ internal static class BinaryComparativeOperatorParser
 {
 	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out IBinaryComparativeOperator? op)
 	{
-		source.ConsumeWhitespace(ref index);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			op = null;
+			return false;
+		}
 
 		if (index > source.Length - 2)
 		{
@@ -118,7 +127,11 @@ internal static class BinaryLogicalOperatorParser
 {
 	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out IBinaryLogicalOperator? op)
 	{
-		source.ConsumeWhitespace(ref index);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			op = null;
+			return false;
+		}
 
 		if (index > source.Length - 2)
 		{
@@ -152,7 +165,11 @@ internal static class UnaryLogicalOperatorParser
 {
 	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out IUnaryLogicalOperator? op)
 	{
-		source.ConsumeWhitespace(ref index);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			op = null;
+			return false;
+		}
 
 		if (source[index] == '!')
 		{

--- a/JsonPath/Expressions/PathExpressionNode.cs
+++ b/JsonPath/Expressions/PathExpressionNode.cs
@@ -46,9 +46,9 @@ internal class PathExpressionNode : ValueExpressionNode
 
 internal class PathExpressionParser : IValueExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options)
 	{
-		if (!PathParser.TryParse(source, ref index, out var path))
+		if (!PathParser.TryParse(source, ref index, out var path, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/PathExpressionNode.cs
+++ b/JsonPath/Expressions/PathExpressionNode.cs
@@ -25,7 +25,7 @@ internal class PathExpressionNode : ValueExpressionNode
 
 		return result.Matches?.Count == 1
 			? result.Matches[0].Value ?? JsonNull.SignalNode
-			: null;
+			: result.Matches ?? NodeList.Empty;
 	}
 
 	public override void BuildString(StringBuilder builder)

--- a/JsonPath/Expressions/UnaryComparativeExpressionNode.cs
+++ b/JsonPath/Expressions/UnaryComparativeExpressionNode.cs
@@ -37,13 +37,13 @@ internal class UnaryComparativeExpressionParser : IComparativeExpressionParser
 {
 	private static readonly PathExpressionParser _pathParser = new();
 
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ComparativeExpressionNode? expression, PathParsingOptions options)
 	{
 		// currently only the "exists" operator is defined
 		// it expects a path and has no operator
 
 		// parse path
-		if (!_pathParser.TryParse(source, ref index, out var path))
+		if (!_pathParser.TryParse(source, ref index, out var path, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/UnaryLogicalExpressionNode.cs
+++ b/JsonPath/Expressions/UnaryLogicalExpressionNode.cs
@@ -41,7 +41,7 @@ internal class UnaryLogicalExpressionNode : LogicalExpressionNode
 
 internal class UnaryLogicalExpressionParser : ILogicalExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out LogicalExpressionNode? expression, PathParsingOptions options)
 	{
 		// currently only the "not" operator is known
 		// it expects a ! then either a comparison or logical expression
@@ -71,7 +71,7 @@ internal class UnaryLogicalExpressionParser : ILogicalExpressionParser
 		}
 
 		// parse comparison
-		if (!BooleanResultExpressionParser.TryParse(source, ref i, out var right))
+		if (!BooleanResultExpressionParser.TryParse(source, ref i, out var right, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/UnaryLogicalExpressionNode.cs
+++ b/JsonPath/Expressions/UnaryLogicalExpressionNode.cs
@@ -49,7 +49,12 @@ internal class UnaryLogicalExpressionParser : ILogicalExpressionParser
 		var i = index;
 		var nestLevel = 0;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			expression = null;
+			return false;
+		}
+
 		while (i < source.Length && source[i] == '(')
 		{
 			nestLevel++;
@@ -72,7 +77,12 @@ internal class UnaryLogicalExpressionParser : ILogicalExpressionParser
 			return false;
 		}
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			expression = null;
+			return false;
+		}
+
 		while (i < source.Length && source[i] == ')' && nestLevel > 0)
 		{
 			nestLevel--;

--- a/JsonPath/Expressions/ValueExpressionNode.cs
+++ b/JsonPath/Expressions/ValueExpressionNode.cs
@@ -21,7 +21,7 @@ internal static class ValueExpressionParser
 		new PathExpressionParser(),
 	};
 
-	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
+	public static bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options)
 	{
 		int i = index;
 		var nestLevel = 0;
@@ -46,7 +46,7 @@ internal static class ValueExpressionParser
 		ValueExpressionNode? left = null;
 		foreach (var parser in _operandParsers)
 		{
-			if (parser.TryParse(source, ref i, out left)) break;
+			if (parser.TryParse(source, ref i, out left, options)) break;
 		}
 
 		if (left == null)
@@ -98,7 +98,7 @@ internal static class ValueExpressionParser
 			ValueExpressionNode? right = null;
 			foreach (var parser in _operandParsers)
 			{
-				if (parser.TryParse(source, ref i, out right)) break;
+				if (parser.TryParse(source, ref i, out right, options)) break;
 			}
 
 			if (right == null)

--- a/JsonPath/Expressions/ValueExpressionNode.cs
+++ b/JsonPath/Expressions/ValueExpressionNode.cs
@@ -16,7 +16,7 @@ internal static class ValueExpressionParser
 {
 	private static readonly IValueExpressionParser[] _operandParsers =
 	{
-		new FunctionExpressionParser(),
+		new ValueFunctionExpressionParser(),
 		new LiteralExpressionParser(),
 		new PathExpressionParser(),
 	};

--- a/JsonPath/Expressions/ValueExpressionNode.cs
+++ b/JsonPath/Expressions/ValueExpressionNode.cs
@@ -28,7 +28,12 @@ internal static class ValueExpressionParser
 
 		int Precedence(IBinaryValueOperator op) => nestLevel * 10 + op.Precedence;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			expression = null;
+			return false;
+		}
+
 		while (i < source.Length && source[i] == '(')
 		{
 			nestLevel++;
@@ -53,7 +58,12 @@ internal static class ValueExpressionParser
 		while (i < source.Length)
 		{
 			// handle )
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref index))
+			{
+				expression = null;
+				return false;
+			}
+
 			if (source[i] == ')' && nestLevel > 0)
 			{
 				while (i < source.Length && source[i] == ')' && nestLevel > 0)
@@ -72,7 +82,12 @@ internal static class ValueExpressionParser
 				break; // if we don't get an op, then we're done
 
 			// handle (
-			source.ConsumeWhitespace(ref i);
+			if (!source.ConsumeWhitespace(ref index))
+			{
+				expression = null;
+				return false;
+			}
+
 			if (source[i] == '(')
 			{
 				nextNest++;

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -64,7 +64,7 @@ internal class ValueFunctionExpressionParser : IValueExpressionParser
 			return false;
 		}
 
-		if (function.ReturnType != FunctionType.Value)
+		if (function.ReturnType.HasFlag(FunctionType.Value))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -58,18 +58,20 @@ internal class ValueFunctionExpressionParser : IValueExpressionParser
 {
 	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options)
 	{
-		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function, options))
+		int i = index;
+		if (!FunctionExpressionParser.TryParseFunction(source, ref i, out var parameters, out var function, options))
 		{
 			expression = null;
 			return false;
 		}
 
-		if (function.ReturnType.HasFlag(FunctionType.Value))
+		if (!function.ReturnType.HasFlag(FunctionType.Value))
 		{
 			expression = null;
 			return false;
 		}
 
+		index = i;
 		expression = new ValueFunctionExpressionNode(function, parameters);
 		return true;
 	}

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -64,6 +64,12 @@ internal class ValueFunctionExpressionParser : IValueExpressionParser
 			return false;
 		}
 
+		if (function.ReturnType != FunctionType.Value)
+		{
+			expression = null;
+			return false;
+		}
+
 		expression = new ValueFunctionExpressionNode(function, parameters);
 		return true;
 	}

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -58,71 +58,13 @@ internal class ValueFunctionExpressionParser : IValueExpressionParser
 {
 	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
 	{
-		int i = index;
-
-		source.ConsumeWhitespace(ref i);
-
-		// parse function name
-		if (!source.TryParseName(ref i, out var name))
-		{
-			expression = null;
-			return false;
-		}
-
-		source.ConsumeWhitespace(ref i);
-
-		// consume (
-		if (source[i] != '(')
-		{
-			expression = null;
-			return false;
-		}
-		i++;
-
-		// parse list of parameters - all value expressions
-		var parameters = new List<ValueExpressionNode>();
-		var done = false;
-
-		while (i < source.Length && !done)
-		{
-			source.ConsumeWhitespace(ref i);
-
-			if (!ValueExpressionParser.TryParse(source, ref i, out var parameter)) break;
-
-			parameters.Add(parameter);
-
-			source.ConsumeWhitespace(ref i);
-		
-			switch (source[i])
-			{
-				case ')':
-					done = true;
-					i++;
-					break;
-				case ',':
-					i++;
-					break;
-				default:
-					expression = null;
-					return false;
-			}
-		}
-
-		if (!FunctionRepository.TryGet(name, out var function))
-		{
-			expression = null;
-			return false;
-		}
-
-		if (function.MinArgumentCount > parameters.Count ||
-		    parameters.Count > function.MaxArgumentCount)
+		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function))
 		{
 			expression = null;
 			return false;
 		}
 
 		expression = new ValueFunctionExpressionNode(function, parameters);
-		index = i;
 		return true;
 	}
 }

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -7,12 +7,12 @@ using System.Text.Json.Nodes;
 
 namespace Json.Path.Expressions;
 
-internal class FunctionExpressionNode : ValueExpressionNode
+internal class ValueFunctionExpressionNode : ValueExpressionNode
 {
 	public IPathFunctionDefinition Function { get; }
 	public ValueExpressionNode[] Parameters { get; }
 
-	public FunctionExpressionNode(IPathFunctionDefinition function, IEnumerable<ValueExpressionNode> parameters)
+	public ValueFunctionExpressionNode(IPathFunctionDefinition function, IEnumerable<ValueExpressionNode> parameters)
 	{
 		Function = function;
 		Parameters = parameters.ToArray();
@@ -54,7 +54,7 @@ internal class FunctionExpressionNode : ValueExpressionNode
 	}
 }
 
-internal class FunctionExpressionParser : IValueExpressionParser
+internal class ValueFunctionExpressionParser : IValueExpressionParser
 {
 	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
 	{
@@ -121,7 +121,7 @@ internal class FunctionExpressionParser : IValueExpressionParser
 			return false;
 		}
 
-		expression = new FunctionExpressionNode(function, parameters);
+		expression = new ValueFunctionExpressionNode(function, parameters);
 		index = i;
 		return true;
 	}

--- a/JsonPath/Expressions/ValueFunctionExpressionNode.cs
+++ b/JsonPath/Expressions/ValueFunctionExpressionNode.cs
@@ -56,9 +56,9 @@ internal class ValueFunctionExpressionNode : ValueExpressionNode
 
 internal class ValueFunctionExpressionParser : IValueExpressionParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ValueExpressionNode? expression, PathParsingOptions options)
 	{
-		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function))
+		if (!FunctionExpressionParser.TryParseFunction(source, ref index, out var parameters, out var function, options))
 		{
 			expression = null;
 			return false;

--- a/JsonPath/FilterSelector.cs
+++ b/JsonPath/FilterSelector.cs
@@ -52,7 +52,7 @@ internal class FilterSelector : ISelector
 
 internal class FilterSelectorParser : ISelectorParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options)
 	{
 		if (source[index] != '?')
 		{
@@ -61,7 +61,7 @@ internal class FilterSelectorParser : ISelectorParser
 		}
 
 		index++; // consume ?
-		if (!ExpressionParser.TryParse(source, ref index, out var expression))
+		if (!ExpressionParser.TryParse(source, ref index, out var expression, options))
 		{
 			selector = null;
 			return false;

--- a/JsonPath/FunctionRepository.cs
+++ b/JsonPath/FunctionRepository.cs
@@ -44,7 +44,6 @@ public static class FunctionRepository
 	/// <summary>
 	/// Unregisters a function implementation.
 	/// </summary>
-	/// <typeparam name="T">The name of the function.</typeparam>
 	public static void Unregister(string name)
 	{
 		_functions.Remove(name);

--- a/JsonPath/FunctionType.cs
+++ b/JsonPath/FunctionType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Json.Path;
+
+/// <summary>
+/// Indicates the return type of a filter expression function.
+/// </summary>
+[Flags]
+public enum FunctionType
+{
+	/// <summary>
+	/// Holder for a default value.  Not an actual valid function type.
+	/// </summary>
+	Unspecified,
+	/// <summary>
+	/// Indicates the function returns a JSON-like value that can be
+	/// compared with equality and inequality operators.
+	/// </summary>
+	Value,
+	/// <summary>
+	/// Indicates the function returns a non-JSON boolean value that can be
+	/// compared with logical operators.
+	/// </summary>
+	Boolean
+}

--- a/JsonPath/FunctionType.cs
+++ b/JsonPath/FunctionType.cs
@@ -1,11 +1,8 @@
-﻿using System;
-
-namespace Json.Path;
+﻿namespace Json.Path;
 
 /// <summary>
 /// Indicates the return type of a filter expression function.
 /// </summary>
-[Flags]
 public enum FunctionType
 {
 	/// <summary>
@@ -21,5 +18,9 @@ public enum FunctionType
 	/// Indicates the function returns a non-JSON boolean value that can be
 	/// compared with logical operators.
 	/// </summary>
-	Boolean
+	Boolean,
+	/// <summary>
+	/// Indicates the function returns a nodelist.
+	/// </summary>
+	Nodelist
 }

--- a/JsonPath/IPathFunctionDefinition.cs
+++ b/JsonPath/IPathFunctionDefinition.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Json.Path;
 
@@ -22,9 +23,50 @@ public interface IPathFunctionDefinition
 	int MaxArgumentCount { get; }
 
 	/// <summary>
+	/// Defines the sets of parameters that are valid for this function.
+	/// </summary>
+	/// <remarks>
+	/// The value of this property is a collection of collections where
+	/// each inner collection represents a single parameter set.  The
+	/// outer collection represents differing parameter sets and can
+	/// be thought of as "overloads."
+	/// </remarks>
+	IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; }
+
+	/// <summary>
+	/// The type returned by the function.
+	/// </summary>
+	/// <remarks>
+	/// This is important for function composition: using a function
+	/// as a parameter of another function.
+	/// </remarks>
+	FunctionType ReturnType { get; }
+
+	/// <summary>
 	/// Evaluates the function.
 	/// </summary>
 	/// <param name="arguments">A collection of nodelists where each nodelist in the collection corresponds to a single argument.</param>
 	/// <returns>A nodelist.  If the evaluation fails, an empty nodelist is returned.</returns>
 	NodeList Evaluate(IEnumerable<NodeList> arguments);
+}
+
+public enum FunctionType
+{
+	Unspecified,
+	Value,
+	Boolean,
+	NodeList
+}
+
+[Flags]
+public enum ParameterType
+{
+	Unspecified,
+	Object,
+	Array,
+	String,
+	Number,
+	Boolean,
+	Null,
+	Nothing
 }

--- a/JsonPath/IPathFunctionDefinition.cs
+++ b/JsonPath/IPathFunctionDefinition.cs
@@ -13,14 +13,6 @@ public interface IPathFunctionDefinition
 	/// Gets the function name.
 	/// </summary>
 	string Name { get; }
-	/// <summary>
-	/// The minimum argument count accepted by the function.
-	/// </summary>
-	int MinArgumentCount { get; }
-	/// <summary>
-	/// The maximum argument count accepted by the function.
-	/// </summary>
-	int MaxArgumentCount { get; }
 
 	/// <summary>
 	/// Defines the sets of parameters that are valid for this function.

--- a/JsonPath/IPathFunctionDefinition.cs
+++ b/JsonPath/IPathFunctionDefinition.cs
@@ -39,6 +39,14 @@ public interface IPathFunctionDefinition
 	/// <remarks>
 	/// This is important for function composition: using a function
 	/// as a parameter of another function.
+	///
+	/// This library assumes that a function may return `Nothing` and
+	/// automatically handles that case.  This value should be set to
+	/// what kind of non-`Nothing` type the function returns.
+	///
+	/// Registration of the function will throw an
+	/// <see cref="InvalidOperationException"/> if the value is
+	/// <see cref="FunctionType.Unspecified"/>
 	/// </remarks>
 	FunctionType ReturnType { get; }
 
@@ -54,8 +62,7 @@ public enum FunctionType
 {
 	Unspecified,
 	Value,
-	Boolean,
-	NodeList
+	Boolean
 }
 
 [Flags]

--- a/JsonPath/IPathFunctionDefinition.cs
+++ b/JsonPath/IPathFunctionDefinition.cs
@@ -49,23 +49,3 @@ public interface IPathFunctionDefinition
 	/// <returns>A nodelist.  If the evaluation fails, an empty nodelist is returned.</returns>
 	NodeList Evaluate(IEnumerable<NodeList> arguments);
 }
-
-public enum FunctionType
-{
-	Unspecified,
-	Value,
-	Boolean
-}
-
-[Flags]
-public enum ParameterType
-{
-	Unspecified,
-	Object,
-	Array,
-	String,
-	Number,
-	Boolean,
-	Null,
-	Nothing
-}

--- a/JsonPath/ISelectorParser.cs
+++ b/JsonPath/ISelectorParser.cs
@@ -5,5 +5,5 @@ namespace Json.Path;
 
 internal interface ISelectorParser
 {
-	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector);
+	bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options);
 }

--- a/JsonPath/IndexSelector.cs
+++ b/JsonPath/IndexSelector.cs
@@ -43,7 +43,7 @@ internal class IndexSelector : ISelector
 
 internal class IndexSelectorParser : ISelectorParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options)
 	{
 		if (!source.TryGetInt(ref index, out var value))
 		{

--- a/JsonPath/JsonNodeExtensions.cs
+++ b/JsonPath/JsonNodeExtensions.cs
@@ -23,15 +23,7 @@ public static class JsonNodeExtensions
 			return false;
 		}
 
-		var obj = val.GetValue<object>();
-		if (obj is T objAsT)
-		{
-			value = objAsT;
-			return true;
-		}
-
-		value = default;
-		return false;
+		return val.TryGetValue(out value);
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -25,6 +25,25 @@ public class JsonPath
 	/// </summary>
 	public PathScope Scope { get; }
 
+	/// <summary>
+	/// Gets whether the path is a singular path.  That is, it can only return a nodelist
+	/// containing at most a single value.
+	/// </summary>
+	/// <remarks>
+	/// A singular path can only contain segments which must meet all of the following
+	/// conditions:
+	///
+	/// - is not a recursive descent (`..`)
+	/// - contains a single selector
+	/// - that selector is either an index selector or a name selector
+	///
+	/// For example, `$['foo'][1]` is a singular path.  Shorthand syntax (e.g. `$.foo[1]`)
+	/// is also allowed.
+	/// </remarks>
+	public bool IsSingular => _segments.All(x => !x.IsRecursive &&
+	                                             x.Selectors.Length == 1 &&
+	                                             x.Selectors.All(y => y is IndexSelector or NameSelector));
+
 	internal JsonPath(PathScope scope, IEnumerable<PathSegment> segments)
 	{
 		Scope = scope;

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -54,24 +54,30 @@ public class JsonPath
 	/// Parses a <see cref="JsonPath"/> from a string.
 	/// </summary>
 	/// <param name="source">The source string.</param>
+	/// <param name="options">(optional) The parsing options.</param>
 	/// <returns>The parsed path.</returns>
 	/// <exception cref="PathParseException">Thrown if a syntax error occurred.</exception>
-	public static JsonPath Parse(string source)
+	public static JsonPath Parse(string source, PathParsingOptions? options = null)
 	{
+		options ??= new PathParsingOptions();
+
 		int index = 0;
-		return PathParser.Parse(source, ref index, true);
+		return PathParser.Parse(source, ref index, options, true);
 	}
 
 	/// <summary>
 	/// Parses a <see cref="JsonPath"/> from a string.
 	/// </summary>
 	/// <param name="source">The source string.</param>
+	/// <param name="options">(optional) The parsing options.</param>
 	/// <param name="path">The parsed path, if successful; otherwise null.</param>
 	/// <returns>True if successful; otherwise false.</returns>
-	public static bool TryParse(string source, [NotNullWhen(true)] out JsonPath? path)
+	public static bool TryParse(string source, [NotNullWhen(true)] out JsonPath? path, PathParsingOptions? options = null)
 	{
+		options ??= new PathParsingOptions();
+	
 		int index = 0;
-		return PathParser.TryParse(source.Trim(), ref index, out path, true);
+		return PathParser.TryParse(source.Trim(), ref index, out path, options, true);
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -59,7 +59,7 @@ public class JsonPath
 	public static JsonPath Parse(string source)
 	{
 		int index = 0;
-		return PathParser.Parse(source.Trim(), ref index, true);
+		return PathParser.Parse(source, ref index, true);
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -14,9 +14,9 @@
 		<PackageIcon>json-logo-256.png</PackageIcon>
 		<PackageTags>json-path jsonpath query path json</PackageTags>
 		<PackageReleaseNotes>Release notes can be found on [GitHub](https://github.com/gregsdennis/json-everything/blob/master/json-everything.net/wwwroot/md/release-notes/json-path.md) and https://json-everything.net/json-path</PackageReleaseNotes>
-		<Version>0.3.3</Version>
-		<FileVersion>0.3.3.0</FileVersion>
-		<AssemblyVersion>0.3.0.0</AssemblyVersion>
+		<Version>0.4.0</Version>
+		<FileVersion>0.4.0.0</FileVersion>
+		<AssemblyVersion>0.4.0.0</AssemblyVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonPath.Net.xml</DocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/JsonPath/JsonPathExtensions.cs
+++ b/JsonPath/JsonPathExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+
+namespace Json.Path;
+
+/// <summary>
+/// Provides extended functionality for <see cref="JsonPath"/>.
+/// </summary>
+public static class JsonPathExtensions
+{
+	/// <summary>
+	/// Renders a Singular Path as a JSON Pointer.
+	/// </summary>
+	/// <param name="path">A JSON Path which is a Singular Path.</param>
+	/// <returns>A string containing a JSON Pointer.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if the path is not singular.</exception>
+	public static string AsJsonPointer(this JsonPath path)
+	{
+		if (!path.IsSingular)
+			throw new InvalidOperationException("Only a Singular Path can be written as a JSON Pointer");
+
+		return string.Concat(path.Segments.Select(x =>
+		{
+			var segment = x.Selectors[0] switch
+			{
+				IndexSelector index => $"/{index}",
+				NameSelector name => $"/{PointerEncode(name.Name)}",
+				// ReSharper disable once NotResolvedInText
+				_ => throw new ArgumentOutOfRangeException("selector", "Selector is not of the right type for conversion to JSON Pointer.  This shouldn't happen.")
+			};
+
+			return segment;
+		}));
+	}
+
+	private static string PointerEncode(string segment)
+	{
+		return segment.Replace("~", "~0").Replace("/", "~1");
+	}
+}

--- a/JsonPath/LengthFunction.cs
+++ b/JsonPath/LengthFunction.cs
@@ -27,6 +27,14 @@ public class LengthFunction : IPathFunctionDefinition
 	/// </summary>
 	public int MaxArgumentCount => 1;
 
+	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
+		new[]
+		{
+			new[] { ParameterType.Array | ParameterType.String }
+		};
+
+	public FunctionType ReturnType => FunctionType.Value;
+
 	/// <summary>
 	/// Evaluates the function.
 	/// </summary>

--- a/JsonPath/LengthFunction.cs
+++ b/JsonPath/LengthFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 
@@ -18,21 +19,35 @@ public class LengthFunction : IPathFunctionDefinition
 	public string Name => "length";
 
 	/// <summary>
-	/// The minimum argument count accepted by the function.
+	/// Defines the sets of parameters that are valid for this function.
 	/// </summary>
-	public int MinArgumentCount => 1;
-
-	/// <summary>
-	/// The maximum argument count accepted by the function.
-	/// </summary>
-	public int MaxArgumentCount => 1;
-
+	/// <remarks>
+	/// The value of this property is a collection of collections where
+	/// each inner collection represents a single parameter set.  The
+	/// outer collection represents differing parameter sets and can
+	/// be thought of as "overloads."
+	/// </remarks>
 	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
 		new[]
 		{
 			new[] { ParameterType.Array | ParameterType.String }
 		};
 
+	/// <summary>
+	/// The type returned by the function.
+	/// </summary>
+	/// <remarks>
+	/// This is important for function composition: using a function
+	/// as a parameter of another function.
+	///
+	/// This library assumes that a function may return `Nothing` and
+	/// automatically handles that case.  This value should be set to
+	/// what kind of non-`Nothing` type the function returns.
+	///
+	/// Registration of the function will throw an
+	/// <see cref="InvalidOperationException"/> if the value is
+	/// <see cref="FunctionType.Unspecified"/>
+	/// </remarks>
 	public FunctionType ReturnType => FunctionType.Value;
 
 	/// <summary>

--- a/JsonPath/MatchFunction.cs
+++ b/JsonPath/MatchFunction.cs
@@ -34,8 +34,8 @@ public class MatchFunction : IPathFunctionDefinition
 	public NodeList Evaluate(IEnumerable<NodeList> arguments)
 	{
 		var args = arguments.ToArray();
-		if (!args[0].TryGetSingleValue().TryGetValue<string>(out var regex)) return NodeList.Empty;
-		if (!args[1].TryGetSingleValue().TryGetValue<string>(out var text)) return NodeList.Empty;
+		if (!args[0].TryGetSingleValue().TryGetValue<string>(out var text)) return NodeList.Empty;
+		if (!args[1].TryGetSingleValue().TryGetValue<string>(out var regex)) return NodeList.Empty;
 
 		return (JsonValue)Regex.IsMatch(text, $"^{regex}$", RegexOptions.ECMAScript);
 	}

--- a/JsonPath/MatchFunction.cs
+++ b/JsonPath/MatchFunction.cs
@@ -26,6 +26,14 @@ public class MatchFunction : IPathFunctionDefinition
 	/// </summary>
 	public int MaxArgumentCount => 2;
 
+	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
+		new[]
+		{
+			new[] { ParameterType.String, ParameterType.String }
+		};
+
+	public FunctionType ReturnType => FunctionType.Boolean;
+
 	/// <summary>
 	/// Evaluates the function.
 	/// </summary>

--- a/JsonPath/MatchFunction.cs
+++ b/JsonPath/MatchFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -17,21 +18,35 @@ public class MatchFunction : IPathFunctionDefinition
 	public string Name => "match";
 
 	/// <summary>
-	/// The minimum argument count accepted by the function.
+	/// Defines the sets of parameters that are valid for this function.
 	/// </summary>
-	public int MinArgumentCount => 2;
-
-	/// <summary>
-	/// The maximum argument count accepted by the function.
-	/// </summary>
-	public int MaxArgumentCount => 2;
-
+	/// <remarks>
+	/// The value of this property is a collection of collections where
+	/// each inner collection represents a single parameter set.  The
+	/// outer collection represents differing parameter sets and can
+	/// be thought of as "overloads."
+	/// </remarks>
 	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
 		new[]
 		{
 			new[] { ParameterType.String, ParameterType.String }
 		};
 
+	/// <summary>
+	/// The type returned by the function.
+	/// </summary>
+	/// <remarks>
+	/// This is important for function composition: using a function
+	/// as a parameter of another function.
+	///
+	/// This library assumes that a function may return `Nothing` and
+	/// automatically handles that case.  This value should be set to
+	/// what kind of non-`Nothing` type the function returns.
+	///
+	/// Registration of the function will throw an
+	/// <see cref="InvalidOperationException"/> if the value is
+	/// <see cref="FunctionType.Unspecified"/>
+	/// </remarks>
 	public FunctionType ReturnType => FunctionType.Boolean;
 
 	/// <summary>

--- a/JsonPath/NameSelector.cs
+++ b/JsonPath/NameSelector.cs
@@ -96,6 +96,11 @@ internal class NameSelectorParser : ISelectorParser
 			}
 			else
 			{
+				if (!source.EnsureValidNameCharacter(i))
+				{
+					selector = null;
+					return false;
+				}
 				sb.Append(source[i]);
 				i++;
 			}

--- a/JsonPath/NameSelector.cs
+++ b/JsonPath/NameSelector.cs
@@ -50,7 +50,7 @@ internal class NameSelector : ISelector, IHaveShorthand
 
 internal class NameSelectorParser : ISelectorParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options)
 	{
 		char quoteChar;
 		var i = index;

--- a/JsonPath/NameSelector.cs
+++ b/JsonPath/NameSelector.cs
@@ -37,7 +37,7 @@ internal class NameSelector : ISelector, IHaveShorthand
 		var node = match.Value;
 		if (node is not JsonObject obj) yield break;
 
-		if (obj.TryGetPropertyValue(Name, out var value)) yield return new Node(value, match.Location.Append(Name));
+		if (obj.TryGetPropertyValue(Name, out var value)) yield return new Node(value, match.Location!.Append(Name));
 	}
 
 	public void BuildString(StringBuilder builder)

--- a/JsonPath/ParameterType.cs
+++ b/JsonPath/ParameterType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Json.Path;
+
+[Flags]
+public enum ParameterType
+{
+	Unspecified,
+	Object,
+	Array,
+	String,
+	Number,
+	Boolean,
+	Null,
+	Nothing
+}

--- a/JsonPath/PathEvaluationOptions.cs
+++ b/JsonPath/PathEvaluationOptions.cs
@@ -8,5 +8,5 @@
 /// </remarks>
 public class PathEvaluationOptions
 {
-//	public bool Strict { get; set; } // TODO
+//	public bool Strict { get; set; } // TODO: what would this mean?
 }

--- a/JsonPath/PathParser.cs
+++ b/JsonPath/PathParser.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq.Expressions;
 
 namespace Json.Path;
 

--- a/JsonPath/PathParser.cs
+++ b/JsonPath/PathParser.cs
@@ -25,11 +25,11 @@ internal static class PathParser
 		var segments = new List<PathSegment>();
 		PathScope scope;
 
-		if (source[0] == '$')
+		if (source[index] == '$')
 			scope = PathScope.Global;
 		else if (requireGlobal)
 			throw new PathParseException(index, "Path must start with '$'");
-		else if (source[0] == '@')
+		else if (source[index] == '@')
 			scope = PathScope.Local;
 		else
 			throw new PathParseException(index, "Path must start with '$' or '@'");
@@ -54,11 +54,11 @@ internal static class PathParser
 
 		var i = index;
 
-		if (!source.ConsumeWhitespace(ref index))
-		{
-			path = null;
-			return false;
-		}
+		//if (!source.ConsumeWhitespace(ref index))
+		//{
+		//	path = null;
+		//	return false;
+		//}
 
 		var segments = new List<PathSegment>();
 		PathScope scope;

--- a/JsonPath/PathParser.cs
+++ b/JsonPath/PathParser.cs
@@ -105,6 +105,9 @@ internal static class PathParser
 				isRecursive = true;
 				index++; // consume second .
 
+				if (!source.ConsumeWhitespace(ref index))
+					throw new PathParseException(index, "Unexpected end of input");
+
 				if (source[index] == '[') 
 					ParseBracketed(source, ref index, selectors);
 				else if (source[index] == '*')
@@ -165,6 +168,12 @@ internal static class PathParser
 			{
 				isRecursive = true;
 				index++; // consume second .
+
+				if (!source.ConsumeWhitespace(ref index))
+				{
+					segment = null;
+					return false;
+				}
 
 				if (source[index] == '[')
 				{

--- a/JsonPath/PathParsingOptions.cs
+++ b/JsonPath/PathParsingOptions.cs
@@ -5,17 +5,4 @@
 /// </summary>
 public class PathParsingOptions
 {
-	/// <summary>
-	/// Gets or sets whether explicit typing errors are checked for
-	/// filter expressions.
-	/// </summary>
-	/// <remarks>
-	/// For example, `length(1)` is invalid because `1` is not
-	/// something that has a length.
-	///
-	/// This kind of type checking is not prescribed by the specification.
-	/// The specification requires that such expressions are to be
-	/// accepted and tolerated during evaluation.
-	/// </remarks>
-	public bool StrictTypeChecking { get; set; }
 }

--- a/JsonPath/PathParsingOptions.cs
+++ b/JsonPath/PathParsingOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace Json.Path;
+
+/// <summary>
+/// Defines a set of configuration options to control parsing behavior.
+/// </summary>
+public class PathParsingOptions
+{
+	/// <summary>
+	/// Gets or sets whether explicit typing errors are checked for
+	/// filter expressions.
+	/// </summary>
+	/// <remarks>
+	/// For example, `length(1)` is invalid because `1` is not
+	/// something that has a length.
+	///
+	/// This kind of type checking is not prescribed by the specification.
+	/// The specification requires that such expressions are to be
+	/// accepted and tolerated during evaluation.
+	/// </remarks>
+	public bool StrictTypeChecking { get; set; }
+}

--- a/JsonPath/SearchFunction.cs
+++ b/JsonPath/SearchFunction.cs
@@ -34,8 +34,8 @@ public class SearchFunction : IPathFunctionDefinition
 	public NodeList Evaluate(IEnumerable<NodeList> arguments)
 	{
 		var args = arguments.ToArray();
-		if (!args[0].TryGetSingleValue().TryGetValue<string>(out var regex)) return NodeList.Empty;
-		if (!args[1].TryGetSingleValue().TryGetValue<string>(out var text)) return NodeList.Empty;
+		if (!args[0].TryGetSingleValue().TryGetValue<string>(out var text)) return NodeList.Empty;
+		if (!args[1].TryGetSingleValue().TryGetValue<string>(out var regex)) return NodeList.Empty;
 
 		return (JsonValue)Regex.IsMatch(text, regex, RegexOptions.ECMAScript);
 	}

--- a/JsonPath/SearchFunction.cs
+++ b/JsonPath/SearchFunction.cs
@@ -26,6 +26,14 @@ public class SearchFunction : IPathFunctionDefinition
 	/// </summary>
 	public int MaxArgumentCount => 2;
 
+	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
+		new[]
+		{
+			new[] { ParameterType.String, ParameterType.String }
+		};
+
+	public FunctionType ReturnType => FunctionType.Boolean;
+
 	/// <summary>
 	/// Evaluates the function.
 	/// </summary>

--- a/JsonPath/SearchFunction.cs
+++ b/JsonPath/SearchFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -17,21 +18,35 @@ public class SearchFunction : IPathFunctionDefinition
 	public string Name => "search";
 
 	/// <summary>
-	/// The minimum argument count accepted by the function.
+	/// Defines the sets of parameters that are valid for this function.
 	/// </summary>
-	public int MinArgumentCount => 2;
-
-	/// <summary>
-	/// The maximum argument count accepted by the function.
-	/// </summary>
-	public int MaxArgumentCount => 2;
-
+	/// <remarks>
+	/// The value of this property is a collection of collections where
+	/// each inner collection represents a single parameter set.  The
+	/// outer collection represents differing parameter sets and can
+	/// be thought of as "overloads."
+	/// </remarks>
 	public IEnumerable<IEnumerable<ParameterType>> ParameterSets { get; } =
 		new[]
 		{
 			new[] { ParameterType.String, ParameterType.String }
 		};
 
+	/// <summary>
+	/// The type returned by the function.
+	/// </summary>
+	/// <remarks>
+	/// This is important for function composition: using a function
+	/// as a parameter of another function.
+	///
+	/// This library assumes that a function may return `Nothing` and
+	/// automatically handles that case.  This value should be set to
+	/// what kind of non-`Nothing` type the function returns.
+	///
+	/// Registration of the function will throw an
+	/// <see cref="InvalidOperationException"/> if the value is
+	/// <see cref="FunctionType.Unspecified"/>
+	/// </remarks>
 	public FunctionType ReturnType => FunctionType.Boolean;
 
 	/// <summary>

--- a/JsonPath/SliceSelector.cs
+++ b/JsonPath/SliceSelector.cs
@@ -44,6 +44,7 @@ internal class SliceSelector : ISelector
 			{
 				yield return new Node(arr[i], match.Location.Append(i));
 				i += step;
+				if (i < 0) break; // overflow
 			}
 		}
 		else
@@ -53,6 +54,7 @@ internal class SliceSelector : ISelector
 			{
 				yield return new Node(arr[i], match.Location.Append(i));
 				i += step;
+				if (i < 0) break; // overflow
 			}
 		}
 	}

--- a/JsonPath/SliceSelector.cs
+++ b/JsonPath/SliceSelector.cs
@@ -1,6 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Nodes;
 
@@ -105,10 +105,10 @@ internal class SliceSelectorParser : ISelectorParser
 		var i = index;
 		int? start = null, end = null, step = null;
 
-		if (source.TryGetInt(ref i, out var value)) 
+		if (source.TryGetInt(ref i, out var value))
 			start = value;
 
-		if (!source.ConsumeWhitespace(ref index))
+		if (!source.ConsumeWhitespace(ref i))
 		{
 			selector = null;
 			return false;
@@ -122,16 +122,16 @@ internal class SliceSelectorParser : ISelectorParser
 
 		i++; // consume :
 
-		if (!source.ConsumeWhitespace(ref index))
+		if (!source.ConsumeWhitespace(ref i))
 		{
 			selector = null;
 			return false;
 		}
 
-		if (source.TryGetInt(ref i, out value)) 
+		if (source.TryGetInt(ref i, out value))
 			end = value;
 
-		if (!source.ConsumeWhitespace(ref index))
+		if (!source.ConsumeWhitespace(ref i))
 		{
 			selector = null;
 			return false;
@@ -141,7 +141,7 @@ internal class SliceSelectorParser : ISelectorParser
 		{
 			i++; // consume :
 
-			if (!source.ConsumeWhitespace(ref index))
+			if (!source.ConsumeWhitespace(ref i))
 			{
 				selector = null;
 				return false;

--- a/JsonPath/SliceSelector.cs
+++ b/JsonPath/SliceSelector.cs
@@ -100,7 +100,7 @@ internal class SliceSelector : ISelector
 
 internal class SliceSelectorParser : ISelectorParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options)
 	{
 		var i = index;
 		int? start = null, end = null, step = null;

--- a/JsonPath/SliceSelector.cs
+++ b/JsonPath/SliceSelector.cs
@@ -108,7 +108,11 @@ internal class SliceSelectorParser : ISelectorParser
 		if (source.TryGetInt(ref i, out var value)) 
 			start = value;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			selector = null;
+			return false;
+		}
 
 		if (source[i] != ':')
 		{
@@ -118,19 +122,31 @@ internal class SliceSelectorParser : ISelectorParser
 
 		i++; // consume :
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			selector = null;
+			return false;
+		}
 
 		if (source.TryGetInt(ref i, out value)) 
 			end = value;
 
-		source.ConsumeWhitespace(ref i);
-		
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			selector = null;
+			return false;
+		}
+
 		if (source[i] == ':')
 		{
 			i++; // consume :
 
-			source.ConsumeWhitespace(ref i);
-			
+			if (!source.ConsumeWhitespace(ref index))
+			{
+				selector = null;
+				return false;
+			}
+
 			if (source.TryGetInt(ref i, out value))
 				step = value;
 		}

--- a/JsonPath/SliceSelector.cs
+++ b/JsonPath/SliceSelector.cs
@@ -42,7 +42,7 @@ internal class SliceSelector : ISelector
 			var i = lower;
 			while (i < upper)
 			{
-				yield return new Node(arr[i], match.Location.Append(i));
+				yield return new Node(arr[i], match.Location!.Append(i));
 				i += step;
 				if (i < 0) break; // overflow
 			}
@@ -52,7 +52,7 @@ internal class SliceSelector : ISelector
 			var i = upper;
 			while (lower < i)
 			{
-				yield return new Node(arr[i], match.Location.Append(i));
+				yield return new Node(arr[i], match.Location!.Append(i));
 				i += step;
 				if (i < 0) break; // overflow
 			}

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -45,12 +44,12 @@ internal static class SpanExtensions
 
 			if (!foundNumber && span[i] == '0')
 				zeroStart = true;
-			
+
 			foundNumber = true;
 			if (!overflowed)
 			{
 				parsedValue = parsedValue * 10 + span[i] - '0';
-				overflowed = parsedValue is <= -2L << 53 or > 2L << 53;
+				overflowed = parsedValue is <= -2L << 53 or >= 2L << 53;
 			}
 
 			i++;

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json.Nodes;
 using Json.More;
 
@@ -63,7 +64,11 @@ internal static class SpanExtensions
 
 	public static bool TryParseJson(this ReadOnlySpan<char> span, ref int i, [NotNullWhen(true)] out JsonNode? node)
 	{
-		span.ConsumeWhitespace(ref i);
+		if (!span.ConsumeWhitespace(ref i))
+		{
+			node = null;
+			return false;
+		}
 
 		try
 		{

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -50,11 +50,14 @@ internal static class SpanExtensions
 			if (!overflowed)
 			{
 				parsedValue = parsedValue * 10 + span[i] - '0';
-				overflowed = parsedValue is < int.MinValue or > int.MaxValue;
+				overflowed = parsedValue is <= -2L << 53 or > 2L << 53;
 			}
 
 			i++;
 		}
+
+		if (overflowed) return false;
+
 		if (negative) parsedValue = -parsedValue;
 
 		index = i;

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using Json.More;
@@ -8,19 +7,25 @@ namespace Json.Path;
 
 internal static class SpanExtensions
 {
-	public static void ConsumeWhitespace(this ReadOnlySpan<char> span, ref int i)
+	public static bool ConsumeWhitespace(this ReadOnlySpan<char> span, ref int i)
 	{
 		while (i < span.Length && char.IsWhiteSpace(span[i]))
 		{
 			i++;
 		}
-		if (i == span.Length)
-			throw new PathParseException(i, "Unexpected end of input");
+		return i != span.Length;
 	}
 
-	public static bool TryGetInt(this ReadOnlySpan<char> span, ref int i, out int value)
+	public static bool EnsureValidNameCharacter(this ReadOnlySpan<char> span, int i)
+	{
+		return span[i] >= 0x20;
+		//throw new PathParseException(i, "Characters in the range U+0000..U+001F are disallowed");
+	}
+
+	public static bool TryGetInt(this ReadOnlySpan<char> span, ref int index, out int value)
 	{
 		var negative = false;
+		var i = index;
 		if (span[i] == '-')
 		{
 			negative = true;
@@ -29,15 +34,30 @@ internal static class SpanExtensions
 
 		// Now move past digits
 		var foundNumber = false;
+		var zeroStart = false;
+		long parsedValue = 0;
+		var overflowed = false;
 		value = 0;
 		while (i < span.Length && char.IsDigit(span[i]))
 		{
+			if (zeroStart) return false;
+
+			if (!foundNumber && span[i] == '0')
+				zeroStart = true;
+			
 			foundNumber = true;
-			value = value * 10 + span[i] - '0';
+			if (!overflowed)
+			{
+				parsedValue = parsedValue * 10 + span[i] - '0';
+				overflowed = parsedValue is < int.MinValue or > int.MaxValue;
+			}
+
 			i++;
 		}
+		if (negative) parsedValue = -parsedValue;
 
-		if (negative) value = -value;
+		index = i;
+		value = (int)Math.Min(int.MaxValue, Math.Max(int.MinValue, parsedValue));
 		return foundNumber;
 	}
 
@@ -138,24 +158,5 @@ internal static class SpanExtensions
 			node = default;
 			return false;
 		}
-	}
-
-	public static bool TryParseName(this ReadOnlySpan<char> source, ref int index, List<ISelector> selectors)
-	{
-		var i = index;
-
-		source.ConsumeWhitespace(ref i);
-
-		while (i < source.Length && source[i].IsValidForPropertyName())
-		{
-			i++;
-		}
-
-		if (index == i) return false;
-
-		var name = source[index..i].ToString();
-		selectors.Add(new NameSelector(name));
-		index = i;
-		return true;
 	}
 }

--- a/JsonPath/UtilityExtensions.cs
+++ b/JsonPath/UtilityExtensions.cs
@@ -40,7 +40,6 @@ internal static class UtilityExtensions
 	{
 		return ch.In('a'..('z' + 1)) ||
 		       ch.In('A'..('Z' + 1)) ||
-		       ch.In('_') ||
 		       ch.In(0x80..0x10FFFF);
 	}
 

--- a/JsonPath/UtilityExtensions.cs
+++ b/JsonPath/UtilityExtensions.cs
@@ -30,20 +30,21 @@ internal static class UtilityExtensions
 	private static bool IsValidForPropertyName(this char ch)
 	{
 		return ch.In('a'..('z' + 1)) ||
-		       ch.In('A'..('Z' + 1)) ||
-		       ch.In('0'..('9' + 1)) ||
-		       ch.In('_') ||
-		       ch.In(0x80..0x10FFFF);
+			   ch.In('A'..('Z' + 1)) ||
+			   ch.In('0'..('9' + 1)) ||
+			   ch.In('_') ||
+			   ch.In(0x80..0x10FFFF);
 	}
 
 	private static bool IsValidForPropertyNameStart(this char ch)
 	{
 		return ch.In('a'..('z' + 1)) ||
-		       ch.In('A'..('Z' + 1)) ||
-		       ch.In(0x80..0x10FFFF);
+			   ch.In('A'..('Z' + 1)) ||
+			   ch.In('_') ||
+			   ch.In(0x80..0x10FFFF);
 	}
 
-	public static bool TryParseName(this ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)]out string? name)
+	public static bool TryParseName(this ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out string? name)
 	{
 		var i = index;
 
@@ -67,7 +68,7 @@ internal static class UtilityExtensions
 			name = null;
 			return false;
 		}
-		
+
 		name = source[index..i].ToString();
 		index = i;
 		return true;

--- a/JsonPath/UtilityExtensions.cs
+++ b/JsonPath/UtilityExtensions.cs
@@ -47,7 +47,7 @@ internal static class UtilityExtensions
 	{
 		var i = index;
 
-		if (!source.ConsumeWhitespace(ref index))
+		if (!source.ConsumeWhitespace(ref i))
 		{
 			name = null;
 			return false;

--- a/JsonPath/UtilityExtensions.cs
+++ b/JsonPath/UtilityExtensions.cs
@@ -27,7 +27,7 @@ internal static class UtilityExtensions
 		yield return item;
 	}
 
-	public static bool IsValidForPropertyName(this char ch)
+	private static bool IsValidForPropertyName(this char ch)
 	{
 		return ch.In('a'..('z' + 1)) ||
 		       ch.In('A'..('Z' + 1)) ||
@@ -36,7 +36,7 @@ internal static class UtilityExtensions
 		       ch.In(0x80..0x10FFFF);
 	}
 
-	public static bool IsValidForPropertyNameStart(this char ch)
+	private static bool IsValidForPropertyNameStart(this char ch)
 	{
 		return ch.In('a'..('z' + 1)) ||
 		       ch.In('A'..('Z' + 1)) ||
@@ -47,7 +47,11 @@ internal static class UtilityExtensions
 	{
 		var i = index;
 
-		source.ConsumeWhitespace(ref i);
+		if (!source.ConsumeWhitespace(ref index))
+		{
+			name = null;
+			return false;
+		}
 
 		if (i < source.Length && source[i].IsValidForPropertyNameStart())
 		{

--- a/JsonPath/WildcardSelector.cs
+++ b/JsonPath/WildcardSelector.cs
@@ -51,7 +51,7 @@ internal class WildcardSelector : ISelector, IHaveShorthand
 
 internal class WildcardSelectorParser : ISelectorParser
 {
-	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector)
+	public bool TryParse(ReadOnlySpan<char> source, ref int index, [NotNullWhen(true)] out ISelector? selector, PathParsingOptions options)
 	{
 		if (source[index] != '*')
 		{

--- a/json-everything.net/wwwroot/md/json-path.md
+++ b/json-everything.net/wwwroot/md/json-path.md
@@ -59,7 +59,7 @@ _**NOTE** Arithmetic operations are not part of the specification (yet), and can
 
 #### Functions
 
-There is also support for functions, which works as an extension point to add your own custom logic.
+There is also support for functions within query expressions, which works as an extension point to add your own custom logic.
 
 A function is a name followed by a parentheses containing zero or more parameters separated by commas.  Parameters can be JSON literals, JSON Paths (global or local), or even other functions.  (That is, the return value of function calls can be parameters, e.g. `min(max(@,0),10)`; passing one function into another isn't supported.)
 

--- a/json-everything.net/wwwroot/md/release-notes/json-path.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-path.md
@@ -1,3 +1,11 @@
+# [0.4.0](https://github.com/gregsdennis/json-everything/pull/372)
+
+- Updated function definition
+  - list parameter sets to support type checking and overloads rather than a minimum and maximum parameter count
+  - add return type to support type checking within expressions
+- fixes around `TryParse()` to ensure that it doesn't throw exceptions (at least not from this code)
+- more fixes based on [expanded tests](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/12) in the compliance test suite
+
 # [0.3.3](https://github.com/gregsdennis/json-everything/pull/367)
 
 I added a bunch of tests to the JSON Path test suite and found a few bugs in filter expressions. This release fixes those bugs.


### PR DESCRIPTION
Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/12
Depends on https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/387
Depends on https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/403
Resolves #287 

This update:

- fixes some areas that just needed testing represented in the CTS
- adds type checking support for function arguments and returns
- fixes `TryParse()` so that it "never" throws an exception (at least not in my code)