### PR TITLE
Path/parse options

### DIFF
--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -122,7 +122,8 @@ public class CburgmerFeatureValidationTests
 	{
 		AllowMathOperations = true,
 		AllowRelativePathStart = true,
-		AllowJsonConstructs = true
+		AllowJsonConstructs = true,
+		TolerateLeadingAndTrailingWhitespace = true
 	};
 
 	//  - id: array_index

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -123,7 +123,8 @@ public class CburgmerFeatureValidationTests
 		AllowMathOperations = true,
 		AllowRelativePathStart = true,
 		AllowJsonConstructs = true,
-		TolerateLeadingAndTrailingWhitespace = true
+		TolerateSurroundingWhitespace = true,
+		AllowInOperator = true
 	};
 
 	//  - id: array_index

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -81,6 +81,7 @@ public class CburgmerFeatureValidationTests
 
 		// only literals are supported in expressions
 		"$[?(@.d==['v1','v2'])]",
+		"$[?(!(@.d==[\"v1\",\"v2\"]) || (@.d == true))]",
 
 		// only singular paths are allowed in comparisons
 		"$[?(@[0:1]==[1])]",  // also array literals are disallowed
@@ -120,7 +121,8 @@ public class CburgmerFeatureValidationTests
 	private static readonly PathParsingOptions _parsingOptions = new()
 	{
 		AllowMathOperations = true,
-		AllowRelativePathStart = true
+		AllowRelativePathStart = true,
+		AllowJsonConstructs = true
 	};
 
 	//  - id: array_index

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -119,7 +119,8 @@ public class CburgmerFeatureValidationTests
 
 	private static readonly PathParsingOptions _parsingOptions = new()
 	{
-		AllowMathOperations = true
+		AllowMathOperations = true,
+		AllowRelativePathStart = true
 	};
 
 	//  - id: array_index
@@ -152,7 +153,7 @@ public class CburgmerFeatureValidationTests
 				if (TryMatch(line, _idPattern, out var value))
 				{
 					if (currentTestCase != null)
-						yield return new TestCaseData(currentTestCase) { TestName = currentTestCase.TestName };
+						yield return new TestCaseData(currentTestCase) { TestName = $"{currentTestCase.PathString} - {currentTestCase.TestName}" };
 					currentTestCase = new CburgmerTestCase { TestName = value };
 				}
 				else if (TryMatch(line, _selectorPattern, out value))
@@ -174,9 +175,6 @@ public class CburgmerFeatureValidationTests
 	[TestCaseSource(nameof(TestCases))]
 	public void Run(CburgmerTestCase testCase)
 	{
-		if (_notSupported.Contains(testCase.PathString))
-			Assert.Inconclusive("This case will not be supported.");
-
 		Console.WriteLine();
 		Console.WriteLine();
 		Console.WriteLine(testCase);
@@ -197,14 +195,17 @@ public class CburgmerFeatureValidationTests
 
 		if (actual == null)
 		{
-			if (testCase.Consensus == "NOT_SUPPORTED")
-			{
-				if (exception != null) 
-					Console.WriteLine(exception);
-				return;
-			}
+			if (exception != null)
+				Console.WriteLine(exception);
 
-			if (exception != null) throw exception;
+			if (testCase.Consensus == "NOT_SUPPORTED") return;
+
+			if (exception != null)
+			{
+				if (_notSupported.Contains(testCase.PathString))
+					Assert.Inconclusive("This case will not be supported.");
+				throw exception;
+			}
 
 			if (testCase.Consensus == null)
 				Assert.Inconclusive("Test case has no consensus result.  Cannot validate.");

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
@@ -55,7 +55,7 @@ public class ComplianceTestSuiteTests
 				Assert.Fail("TryParse() threw an exception");
 				throw; // this will never run, but the compiler doesn't know that Assert.Fail() will always throw.
 			}
-			Assert.IsTrue(tryParseResult);
+			Assert.IsFalse(tryParseResult);
 
 			var exception = Assert.Throws<PathParseException>(() => JsonPath.Parse(testCase.Selector));
 			Console.WriteLine($"Error: {exception!.Message}");

--- a/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
+++ b/JsonPath/Expressions/BinaryComparativeExpressionNode.cs
@@ -70,6 +70,12 @@ internal class BinaryComparativeExpressionParser : IComparativeExpressionParser
 			return false;
 		}
 
+		if (op is InOperator && !options.AllowInOperator)
+		{
+			expression = null;
+			return false;
+		}
+
 		// parse value
 		if (!ValueExpressionParser.TryParse(source, ref i, out var right, options))
 		{

--- a/JsonPath/Expressions/InOperator.cs
+++ b/JsonPath/Expressions/InOperator.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Json.More;
+
+namespace Json.Path.Expressions;
+
+internal class InOperator : IBinaryComparativeOperator
+{
+	public int Precedence => 10;
+
+	public bool Evaluate(PathValue? left, PathValue? right)
+	{
+		var jLeft = left?.TryGetJson();
+		var jRight = right?.TryGetJson();
+
+		IEnumerable<JsonNode?>? values = jRight switch
+		{
+			JsonArray arr => arr,
+			JsonObject obj => obj.Select(x => x.Value),
+			_ => null
+		};
+
+		if (values == null) return false;
+
+		return values.Contains(jLeft, JsonNodeEqualityComparer.Instance);
+	}
+
+	public override string ToString()
+	{
+		return "<";
+	}
+}

--- a/JsonPath/Expressions/LiteralExpressionNode.cs
+++ b/JsonPath/Expressions/LiteralExpressionNode.cs
@@ -41,6 +41,12 @@ internal class LiteralExpressionParser : IValueExpressionParser
 			return false;
 		}
 
+		if (node is not JsonValue && !options.AllowJsonConstructs)
+		{
+			expression = null;
+			return false;
+		}
+
 		expression = new LiteralExpressionNode(node);
 		return true;
 	}

--- a/JsonPath/Expressions/Operators.cs
+++ b/JsonPath/Expressions/Operators.cs
@@ -17,6 +17,7 @@ internal static class Operators
 	public static readonly IBinaryComparativeOperator LessThanOrEqualTo = new LessThanOrEqualToOperator();
 	public static readonly IBinaryComparativeOperator GreaterThan = new GreaterThanOperator();
 	public static readonly IBinaryComparativeOperator GreaterThanOrEqualTo = new GreaterThanOrEqualToOperator();
+	public static readonly IBinaryComparativeOperator In = new InOperator();
 
 	public static readonly IUnaryComparativeOperator Exists = new ExistsOperator();
 
@@ -112,6 +113,11 @@ internal static class BinaryComparativeOperatorParser
 		{
 			op = Operators.GreaterThan;
 			index++;
+		}
+		else if (portion.Equals("in", StringComparison.Ordinal))
+		{
+			op = Operators.In;
+			index += 2;
 		}
 		else
 		{

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -62,7 +62,7 @@ public class JsonPath
 		options ??= new PathParsingOptions();
 
 		int index = 0;
-		return PathParser.Parse(source, ref index, options, true);
+		return PathParser.Parse(source, ref index, options, !options.AllowRelativePathStart);
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -61,7 +61,7 @@ public class JsonPath
 	{
 		options ??= new PathParsingOptions();
 
-		if (options.TolerateLeadingAndTrailingWhitespace)
+		if (options.TolerateSurroundingWhitespace)
 			source = source.Trim();
 
 		int index = 0;
@@ -79,7 +79,7 @@ public class JsonPath
 	{
 		options ??= new PathParsingOptions();
 
-		if (options.TolerateLeadingAndTrailingWhitespace)
+		if (options.TolerateSurroundingWhitespace)
 			source = source.Trim();
 
 		int index = 0;

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -61,6 +61,9 @@ public class JsonPath
 	{
 		options ??= new PathParsingOptions();
 
+		if (options.TolerateLeadingAndTrailingWhitespace)
+			source = source.Trim();
+
 		int index = 0;
 		return PathParser.Parse(source, ref index, options, !options.AllowRelativePathStart);
 	}
@@ -75,9 +78,12 @@ public class JsonPath
 	public static bool TryParse(string source, [NotNullWhen(true)] out JsonPath? path, PathParsingOptions? options = null)
 	{
 		options ??= new PathParsingOptions();
-	
+
+		if (options.TolerateLeadingAndTrailingWhitespace)
+			source = source.Trim();
+
 		int index = 0;
-		return PathParser.TryParse(source.Trim(), ref index, out path, options, true);
+		return PathParser.TryParse(source, ref index, out path, options, true);
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -79,11 +79,23 @@ public class JsonPath
 	{
 		options ??= new PathParsingOptions();
 
-		if (options.TolerateSurroundingWhitespace)
-			source = source.Trim();
+		if (!options.TolerateSurroundingWhitespace && (char.IsWhiteSpace(source[0]) || char.IsWhiteSpace(source[^1])))
+		{
+			path = null;
+			return false;
+		}
+
+		source = source.Trim();
 
 		int index = 0;
-		return PathParser.TryParse(source, ref index, out path, options, true);
+		if (!PathParser.TryParse(source, ref index, out path, options, true)) return false;
+		if (index != source.Length)
+		{
+			path = null;
+			return false;
+		}
+
+		return true;
 	}
 
 	/// <summary>

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -14,8 +14,8 @@
 		<PackageIcon>json-logo-256.png</PackageIcon>
 		<PackageTags>json-path jsonpath query path json</PackageTags>
 		<PackageReleaseNotes>Release notes can be found on [GitHub](https://github.com/gregsdennis/json-everything/blob/master/json-everything.net/wwwroot/md/release-notes/json-path.md) and https://json-everything.net/json-path</PackageReleaseNotes>
-		<Version>0.5.0</Version>
-		<FileVersion>0.5.0.0</FileVersion>
+		<Version>0.5.1</Version>
+		<FileVersion>0.5.1.0</FileVersion>
 		<AssemblyVersion>0.5.0.0</AssemblyVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonPath.Net.xml</DocumentationFile>

--- a/JsonPath/PathParser.cs
+++ b/JsonPath/PathParser.cs
@@ -155,71 +155,73 @@ internal static class PathParser
 		var isRecursive = false;
 		var isShorthand = false;
 
-		if (!source.ConsumeWhitespace(ref index))
+		var i = index;
+
+		if (!source.ConsumeWhitespace(ref i))
 		{
 			segment = null;
 			return false;
 		}
 
-		if (source[index] == '[')
+		if (source[i] == '[')
 		{
-			if (!TryParseBracketed(source, ref index, selectors, options))
+			if (!TryParseBracketed(source, ref i, selectors, options))
 			{
 				segment = null;
 				return false;
 			}
 		}
-		else if (source[index] == '.')
+		else if (source[i] == '.')
 		{
-			index++; // consume .
+			i++; // consume .
 
-			if (source[index] == '.')
+			if (source[i] == '.')
 			{
 				isRecursive = true;
-				index++; // consume second .
+				i++; // consume second .
 
-				if (!source.ConsumeWhitespace(ref index))
+				if (!source.ConsumeWhitespace(ref i))
 				{
 					segment = null;
 					return false;
 				}
 
-				if (source[index] == '[')
+				if (source[i] == '[')
 				{
-					if (!TryParseBracketed(source, ref index, selectors, options))
+					if (!TryParseBracketed(source, ref i, selectors, options))
 					{
 						segment = null;
 						return false;
 					}
 				}
-				else if (source[index] == '*')
+				else if (source[i] == '*')
 				{
 					selectors.Add(new WildcardSelector());
 					isRecursive = true;
 					isShorthand = true;
-					index++;
+					i++;
 				}
 				else
 				{
 					isRecursive = true;
 					isShorthand = true;
-					if (!TryParseName(source, ref index, selectors))
+					if (!TryParseName(source, ref i, selectors))
 					{
 						segment = null;
 						return false;
 					}
 				}
 			}
-			else if (source[index] == '*')
+			else if (source[i] == '*')
 			{
 				selectors.Add(new WildcardSelector());
 				isShorthand = true;
-				index++;
+				i++;
 			}
 			else
 			{
 				isShorthand = true;
-				if (!TryParseName(source, ref index, selectors))
+				if (!TryParseName(source, ref i, selectors))
 				{
 					segment = null;
 					return false;
@@ -239,6 +241,7 @@ internal static class PathParser
 			return false;
 		}
 
+		index = i;
 		segment = new PathSegment(selectors, isRecursive, isShorthand);
 		return true;
 	}

--- a/JsonPath/PathParsingOptions.cs
+++ b/JsonPath/PathParsingOptions.cs
@@ -6,11 +6,51 @@
 public class PathParsingOptions
 {
 	/// <summary>
-	/// Gets or sets whether mathematical operators will be allowed.
+	/// Gets or sets whether mathematical operators are allowed.
 	/// </summary>
 	/// <remarks>
 	/// These operators are an extension of the specification, so they
 	/// are disallowed by default.
 	/// </remarks>
 	public bool AllowMathOperations { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether a JSON Path can start with the `@` symbol
+	/// instead of `$`.
+	/// </summary>
+	public bool AllowRelativePathStart { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether JSON objects and arrays are permitted in
+	/// expression syntax.
+	/// </summary>
+	/// <remarks>
+	/// Per the specification, only numbers, strings, `null`, `true`,
+	/// and `false` are permitted.
+	/// </remarks>
+	public bool AllowJsonConstructs { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether the JSON Path can contain leading and
+	/// trailing whitespace.
+	/// </summary>
+	/// <remarks>
+	/// Per the specification, such whitespace is not strictly part of
+	/// the syntax, so they are forbidden.  It is expected that such
+	/// whitespace will be removed before passing the string onto
+	/// parsing functionality.
+	/// </remarks>
+	public bool TolerateLeadingAndTrailingWhitespace { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether the `in` operator is allowed.
+	/// </summary>
+	/// <remarks>
+	/// These operators are an extension of the specification, so they
+	/// are disallowed by default.
+	///
+	/// Also requires that <see cref="AllowJsonConstructs"/> be set to
+	/// `true`.
+	/// </remarks>
+	public bool AllowInOperator { get; set; }
 }

--- a/JsonPath/PathParsingOptions.cs
+++ b/JsonPath/PathParsingOptions.cs
@@ -21,8 +21,8 @@ public class PathParsingOptions
 	public bool AllowRelativePathStart { get; set; }
 
 	/// <summary>
-	/// Gets or sets whether JSON objects and arrays are permitted in
-	/// expression syntax.
+	/// Gets or sets whether JSON objects and arrays (double-quotes only)
+	/// are permitted in expression syntax.
 	/// </summary>
 	/// <remarks>
 	/// Per the specification, only numbers, strings, `null`, `true`,

--- a/JsonPath/PathParsingOptions.cs
+++ b/JsonPath/PathParsingOptions.cs
@@ -40,7 +40,7 @@ public class PathParsingOptions
 	/// whitespace will be removed before passing the string onto
 	/// parsing functionality.
 	/// </remarks>
-	public bool TolerateLeadingAndTrailingWhitespace { get; set; }
+	public bool TolerateSurroundingWhitespace { get; set; }
 
 	/// <summary>
 	/// Gets or sets whether the `in` operator is allowed.
@@ -49,8 +49,8 @@ public class PathParsingOptions
 	/// These operators are an extension of the specification, so they
 	/// are disallowed by default.
 	///
-	/// Also requires that <see cref="AllowJsonConstructs"/> be set to
-	/// `true`.
+	/// May also require that <see cref="AllowJsonConstructs"/> be set to
+	/// `true` so that array and object literals are also permitted.
 	/// </remarks>
 	public bool AllowInOperator { get; set; }
 }

--- a/json-everything.net/wwwroot/md/release-notes/json-path.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-path.md
@@ -1,3 +1,12 @@
+# [0.5.1](https://github.com/gregsdennis/json-everything/pull/412) {#release-path-0.5.1}
+
+Added optional support for:
+
+- allowing leading and trailing whitespace
+- `in` operator in expressions
+- JSON constructs as literals in expressions
+- relative paths (starting a path with `@`)
+
 # [0.5.0](https://github.com/gregsdennis/json-everything/pull/407) {#release-path-0.5.0}
 
 Updated to meet the requirements in [draft 11](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-11.html).


### PR DESCRIPTION
Add support for

- allowing leading and trailing whitespace
- `in` operator in expressions
- JSON constructs as literals in expressions
- relative paths (starting a path with `@`)

Ref: https://github.com/cburgmer/json-path-comparison/issues/127#issuecomment-1481885400