### PR TITLE
date-time validation check using regex

### DIFF
--- a/JsonSchema.Tests/FormatTests.cs
+++ b/JsonSchema.Tests/FormatTests.cs
@@ -33,6 +33,18 @@ public class FormatTests
 		Assert.False(result.IsValid);
 	}
 
+	[Test]
+	public void longDateTime_pass()
+	{
+		JsonSchema schema = new JsonSchemaBuilder()
+			.Format(Formats.DateTime);
+
+		var value = JsonNode.Parse("\"2023-03-22T07:56:28.610645938Z\"");
+
+		var result = schema.Evaluate(value, new EvaluationOptions { RequireFormatValidation = true });
+
+		Assert.True(result.IsValid);
+	}
 	private static readonly Uri _formatAssertionMetaSchemaId = new("https://json-everything/test/format-assertion");
 	private static readonly JsonSchema _formatAssertionMetaSchema =
 		new JsonSchemaBuilder()


### PR DESCRIPTION
DateTimes that have very high precision eg: 2023-03-20T05:41:23.802351665Z can be parsed by dotnet and are allowed by jsonschema but don't get accepted by TryParseExact
This uses regex as a fallback to check a datetime just incase it's actually compliant event though TryParseExact disagrees.

