### PR TITLE
Further file fragment fixes

### DIFF
--- a/JsonSchema.Tests/Files/Referencing/base_data.json
+++ b/JsonSchema.Tests/Files/Referencing/base_data.json
@@ -1,0 +1,4 @@
+{
+	"$schema":"./base_schema.json",
+	"referencedDate": "2007-04-05T14:30Z"
+}

--- a/JsonSchema.Tests/Files/Referencing/base_schema.json
+++ b/JsonSchema.Tests/Files/Referencing/base_schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema":"https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"$schema":{},
+		"referencedDate": {
+			"$ref": "./ref_schema.json#/definitions/myDate"
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"referencedDate"
+	]
+}

--- a/JsonSchema.Tests/Files/Referencing/ref_schema.json
+++ b/JsonSchema.Tests/Files/Referencing/ref_schema.json
@@ -1,0 +1,21 @@
+{
+	"$schema":"https://json-schema.org/draft/2020-12/schema",
+	
+	"definitions": {
+		"myDate":{
+			"type":"string",
+			"format":"date-time"
+		},
+
+		"myData":{
+			"type":"object",
+			"required":[
+				"name"
+			],
+			"properties":{
+				
+				"name":{"type":"string"}
+			}
+		}
+	}
+}

--- a/JsonSchema.Tests/ReferenceTests.cs
+++ b/JsonSchema.Tests/ReferenceTests.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Text.Json.Nodes;
+using NUnit.Framework;
+
+namespace Json.Schema.Tests;
+
+public class References
+{
+	
+	private static string GetFile( string name)
+	{
+		return Path.Combine(TestContext.CurrentContext.WorkDirectory, "Files","Referencing", $"{name}.json")
+			.AdjustForPlatform();
+	}
+
+	private static string GetResource( string name)
+	{
+		return File.ReadAllText(GetFile( name));
+	}
+
+	[Test]
+	public void ReferenceFragmentFromFile()
+	{
+		var baseSchema =JsonSchema.FromFile(GetFile("base_schema"));
+		var refSchema =JsonSchema.FromFile(GetFile("ref_schema"));
+		
+		var baseData = JsonNode.Parse( GetResource("base_data"));
+		
+		SchemaRegistry.Global.Register(refSchema);
+		SchemaRegistry.Global.Register(baseSchema);
+
+		var res=baseSchema.Evaluate(baseData);
+		
+		res.AssertValid();
+	}
+	
+}

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -52,9 +52,6 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 		// If the uri is a file we need to set the fragment manually because it will be lost in the uri
 		if (context.Scope.LocalScope.IsFile && Reference.OriginalString.Contains("#"))
 		{
-			//Ideas to detect fragment better and support paths with hashes in them:
-			//last # if the uri doens't end in a .json
-			//any hash that looks like '.json#/'
 			if (Reference.OriginalString.StartsWith("#"))
 			{
 				fragment = Reference.OriginalString;
@@ -65,7 +62,7 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 			{
 				var parts=Reference.OriginalString.Split('#');
 				if (parts.Length != 2)
-					throw new ArgumentException(
+					throw new JsonSchemaException(
 						$"Given a reference with more than one '#' in it. We cannot tell if this is a fragment, or where the fragment starts. Please don't use '#'s in fileNames or paths.\n Reference:{Reference.OriginalString} ");
 				fragment = '#'+parts[1];
 				newUri =new Uri(context.Scope.LocalScope, parts[0]);

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -49,12 +49,28 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 
 		Uri newUri;
 		string fragment;
-
 		// If the uri is a file we need to set the fragment manually because it will be lost in the uri
-		if (context.Scope.LocalScope.IsFile && Reference.OriginalString.StartsWith("#"))
+		if (context.Scope.LocalScope.IsFile && Reference.OriginalString.Contains("#"))
 		{
-			newUri = context.Scope.LocalScope;
-			fragment = Reference.OriginalString;
+			//Ideas to detect fragment better and support paths with hashes in them:
+			//last # if the uri doens't end in a .json
+			//any hash that looks like '.json#/'
+			if (Reference.OriginalString.StartsWith("#"))
+			{
+				fragment = Reference.OriginalString;
+				newUri = context.Scope.LocalScope;
+			}
+
+			else
+			{
+				var parts=Reference.OriginalString.Split('#');
+				if (parts.Length != 2)
+					throw new ArgumentException(
+						$"Given a reference with more than one '#' in it. We cannot tell if this is a fragment, or where the fragment starts. Please don't use '#'s in fileNames or paths.\n Reference:{Reference.OriginalString} ");
+				fragment = '#'+parts[1];
+				newUri =new Uri(context.Scope.LocalScope, parts[0]);
+
+			}
 		}
 		else
 		{

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -63,7 +63,7 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 				var parts=Reference.OriginalString.Split('#');
 				if (parts.Length != 2)
 					throw new JsonSchemaException(
-						$"Given a reference with more than one '#' in it. We cannot tell if this is a fragment, or where the fragment starts. Please don't use '#'s in fileNames or paths.\n Reference:{Reference.OriginalString} ");
+						"File references with multiple hashes are not supported.");
 				fragment = '#'+parts[1];
 				newUri =new Uri(context.Scope.LocalScope, parts[0]);
 


### PR DESCRIPTION
Okay,  so I recently realised my file fragment fix still breaks sometimes. If you reference a file like so:
```json
{
"$ref":"./potato.json#/definitions/leek"
}
```
it doesn't detect that it's a fragment, then joins it to the base fileURI and breaks 

This attempts to fix that. Currently It uses the most simple approach possible:
Split at a hash and error if there is more that one because we cannot tell what is fragment and what isn't

### Ideas to detect fragments better and support paths with hashes in them:
- anything after the last # if the uri doesn't end in a .json 
- any thing after a block of text that looks like '.json#/'
- 
Both of these are somewhat flawed. They don't work if you have combinations of the following:

- File paths and names can have hashes.
- files with json in them don't necessarily need to end in .json 

What are your thoughts on this? Maybe you can think of a better way.




