### PR TITLE
Non-circular `$ref`

### DIFF
--- a/JsonSchema.Tests/DevTest.cs
+++ b/JsonSchema.Tests/DevTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -9,34 +10,25 @@ namespace Json.Schema.Tests;
 public class DevTest
 {
 	[Test]
-	public void Test()
+	public void Issue435()
 	{
-		JsonSchema schema = new JsonSchemaBuilder()
-			.Schema(MetaSchemas.Draft202012Id)
-			.Id("example-schema")
-			.Type(SchemaValueType.Object)
-			.Title("foo object schema")
-			.Properties(
-				("foo", new JsonSchemaBuilder()
-					.Title("foo's title")
-					.Description("foo's description")
-					.Type(SchemaValueType.String)
-					.Pattern("^foo ")
-					.MinLength(10)
-				)
-			)
-			.Required("foo")
-			.AdditionalProperties(false);
+		var backslashes = "C:\\projects\\json-everything\\JsonSchema.Tests\\bin\\Debug\\netcoreapp3.1\\Files\\Issue435_schema.json";
+		var backslashesUri = new Uri(backslashes);
+		
+		var fileUri = new Uri("file:///C:/projects/json-everything/JsonSchema.Tests/bin/Debug/netcoreapp3.1/Files/Issue435_schema.json", UriKind.RelativeOrAbsolute);
+		var pointer = new Uri("#/$defs/DerivedType", UriKind.RelativeOrAbsolute);
 
-		var instance = new JsonObject { ["foo"] = "foo awe;ovinawe" };
+		var backslashesUriResult = new Uri(backslashesUri, pointer);
+		var fileUriResult = new Uri(fileUri, pointer);
 
-		var results = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.Hierarchical });
-
-		Console.WriteLine(JsonSerializer.Serialize(results, new JsonSerializerOptions
-		{
-			WriteIndented = true,
-			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-			Converters = { new Pre202012EvaluationResultsJsonConverter() }
-		}));
+		Console.WriteLine("File path: {0}", backslashes);
+		Console.WriteLine("File path (URI): {0}", backslashesUri.OriginalString);
+		Console.WriteLine();
+		Console.WriteLine("Direct URI: {0}", fileUri.OriginalString);
+		Console.WriteLine();
+		Console.WriteLine("Fragment: {0}", pointer.OriginalString);
+		Console.WriteLine();
+		Console.WriteLine("Combined, backslashes: {0}", backslashesUriResult);
+		Console.WriteLine("Combined, direct:      {0}", fileUriResult);
 	}
 }

--- a/JsonSchema.Tests/DevTest.cs
+++ b/JsonSchema.Tests/DevTest.cs
@@ -10,25 +10,24 @@ namespace Json.Schema.Tests;
 public class DevTest
 {
 	[Test]
-	public void Issue435()
+	public void Test()
 	{
-		var backslashes = "C:\\Folder\\Issue435_schema.json";
-		var backslashesUri = new Uri(backslashes);
+		var filePath = "C:\\Folder\\Issue435_schema.json";
+
+		var withoutProtocol = new Uri(filePath);
+		var withProtocol = new Uri($"file:///{filePath}");
 		
-		var fileUri = new Uri($"file:///{backslashes}", UriKind.RelativeOrAbsolute);
-		var pointer = new Uri("#/$defs/DerivedType", UriKind.RelativeOrAbsolute);
+		var fragment = new Uri("#/$defs/DerivedType", UriKind.RelativeOrAbsolute);
 
-		var backslashesUriResult = new Uri(backslashesUri, pointer);
-		var fileUriResult = new Uri(fileUri, pointer);
+		var withoutProtocolResult = new Uri(withoutProtocol, fragment);
+		var fileUriResult = new Uri(withProtocol, fragment);
 
-		Console.WriteLine("File path: {0}", backslashes);
-		Console.WriteLine("File path (URI): {0}", backslashesUri.OriginalString);
+		Console.WriteLine("File path: {0}", filePath);
 		Console.WriteLine();
-		Console.WriteLine("Direct URI: {0}", fileUri.OriginalString);
+		Console.WriteLine("Without protocol: {0}", withoutProtocol);
+		Console.WriteLine("With protocol:    {0}", withProtocol);
 		Console.WriteLine();
-		Console.WriteLine("Fragment: {0}", pointer.OriginalString);
-		Console.WriteLine();
-		Console.WriteLine("Combined, backslashes: {0}", backslashesUriResult);
-		Console.WriteLine("Combined, direct:      {0}", fileUriResult);
+		Console.WriteLine("Combined, Without: {0}", withoutProtocolResult);
+		Console.WriteLine("Combined, With:    {0}", fileUriResult);
 	}
 }

--- a/JsonSchema.Tests/DevTest.cs
+++ b/JsonSchema.Tests/DevTest.cs
@@ -12,10 +12,10 @@ public class DevTest
 	[Test]
 	public void Issue435()
 	{
-		var backslashes = "C:\\projects\\json-everything\\JsonSchema.Tests\\bin\\Debug\\netcoreapp3.1\\Files\\Issue435_schema.json";
+		var backslashes = "C:\\Folder\\Issue435_schema.json";
 		var backslashesUri = new Uri(backslashes);
 		
-		var fileUri = new Uri("file:///C:/projects/json-everything/JsonSchema.Tests/bin/Debug/netcoreapp3.1/Files/Issue435_schema.json", UriKind.RelativeOrAbsolute);
+		var fileUri = new Uri($"file:///{backslashes}", UriKind.RelativeOrAbsolute);
 		var pointer = new Uri("#/$defs/DerivedType", UriKind.RelativeOrAbsolute);
 
 		var backslashesUriResult = new Uri(backslashesUri, pointer);

--- a/JsonSchema.Tests/Files/Issue435_schema.json
+++ b/JsonSchema.Tests/Files/Issue435_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "type": "array",
+  "items": { "$ref": "#/$defs/DerivedType" },
+
+  "$defs": {
+
+    "BaseType": {
+      "type": "object",
+      "properties": {
+        "field1": { "type": "string" }
+      }
+    },
+
+    "DerivedType": {
+      "allOf": [
+        { "$ref": "#/$defs/BaseType" },
+        { "properties": { "field2": { "type": "string" } } }
+      ]
+    }
+  }
+}

--- a/JsonSchema.Tests/GithubTests.cs
+++ b/JsonSchema.Tests/GithubTests.cs
@@ -879,4 +879,52 @@ public class GithubTests
 		
 		result.AssertValid();
 	}
+
+	[Test]
+	public void Issue435_NonRecursiveRefThrowing()
+	{
+		var schema = JsonSchema.FromText(@"{
+  ""$schema"": ""https://json-schema.org/draft/2020-12/schema"",
+
+  ""type"": ""array"",
+  ""items"": { ""$ref"": ""#/$defs/DerivedType"" },
+
+  ""$defs"": {
+
+    ""BaseType"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""field1"": { ""type"": ""string"" }
+      }
+    },
+
+    ""DerivedType"": {
+      ""allOf"": [
+        { ""$ref"": ""#/$defs/BaseType"" },
+        { ""properties"": { ""field2"": { ""type"": ""string"" } } }
+      ]
+    }
+  }
+}");
+
+		//var instance = new JsonArray
+		//{
+		//	new JsonObject
+		//	{
+		//		["field1"] = "foo",
+		//		["field2"] = "bar"
+		//	}
+		//};
+
+		var instance = JsonNode.Parse(@"[
+  {
+    ""field1"": ""foo"",
+    ""field2"": ""bar""
+  }
+]");
+
+		var result = schema.Evaluate(instance, new EvaluationOptions{OutputFormat = OutputFormat.List});
+
+		result.AssertValid();
+	}
 }

--- a/JsonSchema.Tests/GithubTests.cs
+++ b/JsonSchema.Tests/GithubTests.cs
@@ -881,7 +881,7 @@ public class GithubTests
 	}
 
 	[Test]
-	public void Issue435_NonRecursiveRefThrowing()
+	public void Issue435_NonCircularRefThrowing()
 	{
 		var schema = JsonSchema.FromText(@"{
   ""$schema"": ""https://json-schema.org/draft/2020-12/schema"",
@@ -922,6 +922,27 @@ public class GithubTests
     ""field2"": ""bar""
   }
 ]");
+
+		var result = schema.Evaluate(instance, new EvaluationOptions{OutputFormat = OutputFormat.List});
+
+		result.AssertValid();
+	}
+
+	[Test]
+	public void Issue435_NonCircularRefThrowing_File()
+	{
+		var file = GetFile(435, "schema");
+
+		var schema = JsonSchema.FromFile(file);
+
+		var instance = new JsonArray
+		{
+			new JsonObject
+			{
+				["field1"] = "foo",
+				["field2"] = "bar"
+			}
+		};
 
 		var result = schema.Evaluate(instance, new EvaluationOptions{OutputFormat = OutputFormat.List});
 

--- a/JsonSchema.Tests/JsonSchema.Tests.csproj
+++ b/JsonSchema.Tests/JsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 
 		<IsPackable>false</IsPackable>

--- a/JsonSchema.Tests/JsonSchema.Tests.csproj
+++ b/JsonSchema.Tests/JsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 
 		<IsPackable>false</IsPackable>

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -96,7 +96,7 @@ public class JsonSchema : IEquatable<JsonSchema>, IBaseDocument
 	{
 		var text = File.ReadAllText(fileName);
 		var schema = FromText(text, options);
-		schema.BaseUri = new Uri(Path.GetFullPath(fileName));
+		schema.BaseUri = new Uri($"file:///{Path.GetFullPath(fileName)}");
 		return schema;
 	}
 

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -12,8 +12,8 @@
 		<PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
 		<PackageTags>json-schema validation schema json</PackageTags>
-		<Version>4.0.5</Version>
-		<FileVersion>4.0.5.0</FileVersion>
+		<Version>4.0.6</Version>
+		<FileVersion>4.0.6.0</FileVersion>
 		<AssemblyVersion>4.0.0.0</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<AssemblyName>JsonSchema.Net</AssemblyName>

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -47,20 +47,8 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 	{
 		context.EnterKeyword(Name);
 
-		Uri newUri;
-		string fragment;
-
-		// If the uri is a file we need to set the fragment manually because it will be lost in the uri
-		//if (context.Scope.LocalScope.IsFile && Reference.OriginalString.StartsWith("#"))
-		//{
-		//	newUri = context.Scope.LocalScope;
-		//	fragment = Reference.OriginalString;
-		//}
-		//else
-		//{
-		newUri = new Uri(context.Scope.LocalScope, Reference);
-		fragment = newUri.Fragment;
-		//}
+		var newUri = new Uri(context.Scope.LocalScope, Reference);
+		var fragment = newUri.Fragment;
 
 		var navigation = (newUri.OriginalString, context.InstanceLocation);
 		if (context.NavigatedReferences.Contains(navigation))

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -51,16 +51,16 @@ public class RefKeyword : IJsonSchemaKeyword, IEquatable<RefKeyword>
 		string fragment;
 
 		// If the uri is a file we need to set the fragment manually because it will be lost in the uri
-		if (context.Scope.LocalScope.IsFile && Reference.OriginalString.StartsWith("#"))
-		{
-			newUri = context.Scope.LocalScope;
-			fragment = Reference.OriginalString;
-		}
-		else
-		{
-			newUri = new Uri(context.Scope.LocalScope, Reference);
-			fragment = newUri.Fragment;
-		}
+		//if (context.Scope.LocalScope.IsFile && Reference.OriginalString.StartsWith("#"))
+		//{
+		//	newUri = context.Scope.LocalScope;
+		//	fragment = Reference.OriginalString;
+		//}
+		//else
+		//{
+		newUri = new Uri(context.Scope.LocalScope, Reference);
+		fragment = newUri.Fragment;
+		//}
 
 		var navigation = (newUri.OriginalString, context.InstanceLocation);
 		if (context.NavigatedReferences.Contains(navigation))

--- a/json-everything.net/wwwroot/md/release-notes/json-schema.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-schema.md
@@ -1,3 +1,7 @@
+# [4.0.6](https://github.com/gregsdennis/json-everything/pull/436) {#release-schema-4.0.6}
+
+Schemas loaded with `.FromFile()` have a bad URI set that prevents fragments being added.  This is a .Net bug.  The result of this bug is that schemas loaded with `.FromFile()` cannot resolve references correctly.  This update includes a workaround to fix the behavior.  Thanks to [@faldor20](https://github.com/faldor20) for working on the issue initially, and to [@jpmikkers](https://github.com/jpmikkers) for finding a scenario that led to finding the root cause.
+
 # [4.0.5](https://github.com/gregsdennis/json-everything/pull/434) {#release-schema-4.0.5}
 
 [#432](https://github.com/gregsdennis/json-everything/issues/432) - Local `$ref`s that occur at the root of a draft 6 or 7 schema cause nested `$ref`s in the same schema resource to fail.  Thanks to [@Jeroen-VDW](https://github.com/Jeroen-VDW) for following up.

--- a/json-everything.net/wwwroot/md/release-notes/json-schema.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-schema.md
@@ -1,6 +1,6 @@
 # [4.0.6](https://github.com/gregsdennis/json-everything/pull/436) {#release-schema-4.0.6}
 
-Schemas loaded with `.FromFile()` have a bad URI set that prevents fragments being added.  This is a .Net bug.  The result of this bug is that schemas loaded with `.FromFile()` cannot resolve references correctly.  This update includes a workaround to fix the behavior.  Thanks to [@faldor20](https://github.com/faldor20) for working on the issue initially, and to [@jpmikkers](https://github.com/jpmikkers) for finding a scenario that led to finding the root cause.
+Schemas loaded with `.FromFile()` have a bad URI set that prevents fragments being added.  This is a [.Net bug](https://github.com/dotnet/runtime/issues/85229).  The result of this bug is that schemas loaded with `.FromFile()` cannot resolve references correctly.  This update includes a workaround to fix the behavior.  Thanks to [@faldor20](https://github.com/faldor20) for working on the issue initially, and to [@jpmikkers](https://github.com/jpmikkers) for finding a scenario that led to finding the root cause.
 
 # [4.0.5](https://github.com/gregsdennis/json-everything/pull/434) {#release-schema-4.0.5}
 


### PR DESCRIPTION
Resolves #435 
Closes #430

I haven't been able to replicate this.  I've added .net 7 as a target and a test case with the reported schema/instance.