### PR TITLE
improved naming for $defs keys

### DIFF
--- a/JsonSchema.Generation.Tests/ArrayGenerationTests.cs
+++ b/JsonSchema.Generation.Tests/ArrayGenerationTests.cs
@@ -146,7 +146,7 @@ public class ArrayGenerationTests
 	{
 		var expected = new JsonSchemaBuilder()
 			.Defs(
-				("EnumTest", new JsonSchemaBuilder()
+				("enumTestInArrayGenerationTests", new JsonSchemaBuilder()
 					.Enum("One", "Two")
 					.Title("A test enum")
 				)
@@ -155,9 +155,9 @@ public class ArrayGenerationTests
 			.Properties(
 				("List", new JsonSchemaBuilder()
 					.Type(SchemaValueType.Array)
-					.Items(new JsonSchemaBuilder().Ref("#/$defs/EnumTest"))
+					.Items(new JsonSchemaBuilder().Ref("#/$defs/enumTestInArrayGenerationTests"))
 				),
-				("Single", new JsonSchemaBuilder().Ref("#/$defs/EnumTest"))
+				("Single", new JsonSchemaBuilder().Ref("#/$defs/enumTestInArrayGenerationTests"))
 			);
 
 		var actual = new JsonSchemaBuilder().FromType<MultipleTestEnums>();

--- a/JsonSchema.Generation.Tests/ClientTests.cs
+++ b/JsonSchema.Generation.Tests/ClientTests.cs
@@ -68,7 +68,7 @@ public class ClientTests
 		JsonSchema expected = new JsonSchemaBuilder()
 			.Type(SchemaValueType.Object)
 			.Defs(
-				(nameof(TreeNodeMetaData), new JsonSchemaBuilder()
+				("treeNodeMetaDataInClientTests", new JsonSchemaBuilder()
 					.Type(SchemaValueType.Object)
 					.Properties(
 						(nameof(TreeNodeMetaData.Node), new JsonSchemaBuilder().Ref("#")),
@@ -81,10 +81,10 @@ public class ClientTests
 					.Type(SchemaValueType.String)
 				),
 				("left", new JsonSchemaBuilder()
-					.Ref($"#/$defs/{nameof(TreeNodeMetaData)}")
+					.Ref($"#/$defs/treeNodeMetaDataInClientTests")
 				),
 				("right", new JsonSchemaBuilder()
-					.Ref($"#/$defs/{nameof(TreeNodeMetaData)}")
+					.Ref($"#/$defs/treeNodeMetaDataInClientTests")
 				)
 			);
 
@@ -150,11 +150,11 @@ public class ClientTests
 		JsonSchema expected = new JsonSchemaBuilder()
 			.Type(SchemaValueType.Object)
 			.Properties(
-				("Property1", new JsonSchemaBuilder().Ref("#/$defs/Guid")),
-				("Property2", new JsonSchemaBuilder().Ref("#/$defs/Guid"))
+				("Property1", new JsonSchemaBuilder().Ref("#/$defs/guid")),
+				("Property2", new JsonSchemaBuilder().Ref("#/$defs/guid"))
 			)
 			.Defs(
-				("Guid", new JsonSchemaBuilder()
+				("guid", new JsonSchemaBuilder()
 					.Type(SchemaValueType.String)
 					.Format(Formats.Uuid)
 				)

--- a/JsonSchema.Generation/ITypeNameGenerator.cs
+++ b/JsonSchema.Generation/ITypeNameGenerator.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Json.Schema.Generation;
+
+/// <summary>
+/// Allows custom `$defs` key naming functionality.
+/// </summary>
+public interface ITypeNameGenerator
+{
+	/// <summary>
+	/// Generates a `$defs` key for a type.
+	/// </summary>
+	/// <param name="type">The type.</param>
+	/// <returns>A string to use for the type; null to use the library-provided behavior.</returns>
+	string? GenerateName(Type type);
+}

--- a/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonSchema.Net.Generation.xml</DocumentationFile>
 		<LangVersion>latest</LangVersion>
-		<Version>3.1.1</Version>
-		<FileVersion>3.1.1.0</FileVersion>
+		<Version>3.2.0</Version>
+		<FileVersion>3.2.0.0</FileVersion>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/JsonSchema.Generation/SchemaGenerationContextOptimizer.cs
+++ b/JsonSchema.Generation/SchemaGenerationContextOptimizer.cs
@@ -14,6 +14,11 @@ namespace Json.Schema.Generation;
 /// </summary>
 public static class SchemaGenerationContextOptimizer
 {
+	/// <summary>
+	/// Provides custom naming functionality.
+	/// </summary>
+	public static ITypeNameGenerator? TypeNameGenerator { get; set; }
+
 	internal static void Optimize()
 	{
 		var allContexts = SchemaGenerationContextCache.Cache.Values;
@@ -62,9 +67,9 @@ public static class SchemaGenerationContextOptimizer
 
 	private static string GetDefName(SchemaGenerationContextBase context, List<string> currentNames)
 	{
-		var name = GetName(context.Type).Camelize();
+		var name = TypeNameGenerator?.GenerateName(context.Type) ?? GetName(context.Type).Camelize();
 		var regex = new Regex($@"^{name}\d*$");
-		var count = currentNames.Count(n => regex.IsMatch(n));
+		var count = currentNames.Count(regex.IsMatch);
 		if (count != 0)
 			name += count;
 

--- a/json-everything.net/wwwroot/md/release-notes/json-schema-generation.md
+++ b/json-everything.net/wwwroot/md/release-notes/json-schema-generation.md
@@ -1,3 +1,9 @@
+# [3.2.0](https://github.com/gregsdennis/json-everything/pull/456) {#release-schemagen-3.2.0}
+
+[#455](https://github.com/gregsdennis/json-everything/issues/455) - Better naming for `$defs` keys.
+
+Also added `ITypeNameGenerator` and `SchemaGenerationContextOptimizer.TypeNameGenerator` to allow custom naming.
+
 # [3.1.1](https://github.com/gregsdennis/json-everything/pull/454) {#release-schemagen-3.1.1}
 
 [#450](https://github.com/gregsdennis/json-everything/issues/450) - Fixed an edge case issue where a recursive class structure defining the same property type caused a stack overflow when the outer class property was decorated with `[Nullable]`.


### PR DESCRIPTION
Resolves #455 

This will generate the following:

| Type | Generated Name |
|:-|:-|
| Guid | guid |
| MyType | myType |
| int | integer |
| int[] / List<int> / IEnumerable<int> | arrayOfInteger |

There may still be some oddiities, though.  There is also a new static property on `SchemaGenerationContextOptimizer` that allows the user to provide custom naming functionality.