### PR TITLE
add support for json source generation to JsonPatch

### DIFF
--- a/JsonPatch/JsonPatch.cs
+++ b/JsonPatch/JsonPatch.cs
@@ -83,7 +83,7 @@ public class JsonPatch : IEquatable<JsonPatch>
 	}
 }
 
-internal class PatchJsonConverter : JsonConverter<JsonPatch>
+public class PatchJsonConverter : JsonConverter<JsonPatch>
 {
 	public override JsonPatch Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{


### PR DESCRIPTION
Json Source Generation requires that JsonConverter be public.  This is a small PR to make the PatchJsonConverter public to support source generation.

Reference:
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation
