### PR TITLE
Set quote style for strings to support roundtrip

### DIFF
--- a/Yaml2JsonNode.Tests/ClientTests.cs
+++ b/Yaml2JsonNode.Tests/ClientTests.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Nodes;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Nodes;
 using Json.More;
 using NUnit.Framework;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
 
 namespace Yaml2JsonNode.Tests;
 
@@ -31,5 +28,29 @@ public class ClientTests
 		Console.WriteLine(jsonRoundText);
 
 		Assert.True(json.IsEquivalentTo(jsonRoundTripped));
+	}
+
+	[Test]
+	public void Issue476_YamlNumberAsString()
+	{
+		var yamlValue = new YamlScalarNode("123");
+		var yamlKey = new YamlScalarNode("a");
+
+		var yamlObject = new YamlMappingNode(new Dictionary<YamlNode, YamlNode>
+		{
+			[yamlKey] = yamlValue
+		});
+
+		var builder = new SerializerBuilder();
+
+		var serializer = builder.Build();
+
+		using var writer = new StringWriter();
+
+		serializer.Serialize(writer, yamlObject);
+
+		var text = writer.ToString();
+
+		Console.WriteLine(text);
 	}
 }

--- a/Yaml2JsonNode.Tests/ClientTests.cs
+++ b/Yaml2JsonNode.Tests/ClientTests.cs
@@ -42,13 +42,9 @@ public class ClientTests
 		});
 
 		var builder = new SerializerBuilder();
-
 		var serializer = builder.Build();
-
 		using var writer = new StringWriter();
-
 		serializer.Serialize(writer, yamlObject);
-
 		var text = writer.ToString();
 
 		Console.WriteLine(text);

--- a/Yaml2JsonNode.Tests/ClientTests.cs
+++ b/Yaml2JsonNode.Tests/ClientTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Json.More;
+using NUnit.Framework;
+
+namespace Yaml2JsonNode.Tests;
+
+public class ClientTests
+{
+	[Test]
+	public void Issue476_RoundTripJson()
+	{
+		var jsonText = "{\"foo\":123,\"foz\":\"123\",\"bar\":1.23,\"baz\": \"1.23\"}";
+		var json = JsonNode.Parse(jsonText)!;
+		var yaml = json.ToYamlNode();
+		var yamlText = YamlSerializer.Serialize(yaml: yaml);
+
+		var jsonRoundTripped = YamlSerializer.Parse(yamlText).Single().ToJsonNode();
+		var jsonRoundText = jsonRoundTripped.ToJsonString();
+
+		Console.WriteLine("# jsonText:");
+		Console.WriteLine(jsonText);
+		Console.WriteLine();
+		Console.WriteLine("# yamlText:");
+		Console.WriteLine(yamlText);
+		Console.WriteLine("# jsonRoundText:");
+		Console.WriteLine(jsonRoundText);
+
+		Assert.True(json.IsEquivalentTo(jsonRoundTripped));
+	}
+}

--- a/Yaml2JsonNode.Tests/Files/expected-serialized.yaml
+++ b/Yaml2JsonNode.Tests/Files/expected-serialized.yaml
@@ -1,4 +1,4 @@
-﻿StringProp: string
+﻿StringProp: "string"
 IntProp: 42
 DecimalProp: 42.5
 DoubleProp: 42.9
@@ -9,7 +9,7 @@ ListOfInts:
 - 3
 - 4
 MapOfStrings:
-  string1: found
-  string2: lost
+  string1: "found"
+  string2: "lost"
 NestedObject:
-  OtherString: yep
+  OtherString: "yep"

--- a/Yaml2JsonNode/Yaml2JsonNode.csproj
+++ b/Yaml2JsonNode/Yaml2JsonNode.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <PackageId>Yaml2JsonNode</PackageId>
 	  <Authors>Greg Dennis</Authors>
-	  <Version>1.2.0</Version>
+	  <Version>1.2.1</Version>
 	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
-	  <FileVersion>1.2.0.0</FileVersion>
+	  <FileVersion>1.2.1.0</FileVersion>
 	  <Description>Allows conversion of YamlDotNet's YAML models to JsonNodes.</Description>
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>

--- a/Yaml2JsonNode/YamlConverter.cs
+++ b/Yaml2JsonNode/YamlConverter.cs
@@ -122,7 +122,11 @@ public static class YamlConverter
 
 	private static YamlScalarNode ToYamlScalar(this JsonValue val)
 	{
-		if (val.TryGetValue(out string? s)) return new YamlScalarNode(s);
+		if (val.TryGetValue(out string? s))
+			return new YamlScalarNode(s)
+			{
+				Style = s.Contains('"') ? ScalarStyle.SingleQuoted : ScalarStyle.DoubleQuoted
+			};
 
 		return new YamlScalarNode(val.ToJsonString());
 	}

--- a/tools/ApiDocsGenerator/release-notes/rn-yaml.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-yaml.md
@@ -4,6 +4,12 @@ title: Yaml2JsonNode
 icon: fas fa-tag
 order: "8.12"
 ---
+# [1.2.1](https://github.com/gregsdennis/json-everything/pull/477) {#release-yaml-1.2.1}
+
+[#476](https://github.com/gregsdennis/json-everything/issues/476) - [@amis92](https://github.com/amis92) discovered that JSON -> YAML -> JSON doesn't work when the data has string-encoded numbers and proposed the fix.
+
+This change sets _all_ strings to have double-quotes unless the string itself has a double-quote, in which case it'll set for single-quotes.
+
 # [1.2.0](https://github.com/gregsdennis/json-everything/pull/475) {#release-yaml-1.2.0}
 
 Add `YamlSerializer` static class to provide more natural serializer methods.


### PR DESCRIPTION
Resolves #476 

This will set _all_ strings to have double-quotes unless the string itself has a double-quote, in which case it'll set for single-quotes.