### PR TITLE
Schema/culture option

### DIFF
--- a/JsonSchema.Tests/LocalizationTests.cs
+++ b/JsonSchema.Tests/LocalizationTests.cs
@@ -85,26 +85,28 @@ public class LocalizationTests
 
 		string RunWithCulture(CultureInfo culture)
 		{
-			try
+			var results = schema.Evaluate(instance, new EvaluationOptions
 			{
-				ErrorMessages.Culture = culture;
-				
-				var results = schema.Evaluate(instance, new EvaluationOptions { OutputFormat = OutputFormat.Hierarchical });
+				OutputFormat = OutputFormat.Hierarchical,
+				Culture = culture
+			});
 
-				return results.Errors!["minimum"];
-			}
-			finally
-			{
-				ErrorMessages.Culture = null!;
-			}
+			return results.Errors!["minimum"];
 		}
 
-		var messages = await Task.WhenAll(
-			Task.Run(() => RunWithCulture(CultureInfo.GetCultureInfo("es"))),
-			Task.Run(() => RunWithCulture(CultureInfo.GetCultureInfo("en-us")))
-		);
+		try
+		{
+			var messages = await Task.WhenAll(
+				Task.Run(() => RunWithCulture(CultureInfo.GetCultureInfo("es"))),
+				Task.Run(() => RunWithCulture(CultureInfo.GetCultureInfo("en-us")))
+			);
 
-		Assert.AreEqual("5 es menor o igual que 10", messages[0]);
-		Assert.AreEqual("This is a custom error message with 5 and 10", messages[1]);
+			Assert.AreEqual("5 es menor o igual que 10", messages[0]);
+			Assert.AreEqual("5 should be at least 10", messages[1]);
+		}
+		finally
+		{
+			ErrorMessages.Culture = null;
+		}
 	}
 }

--- a/JsonSchema.UniqueKeys/JsonSchema.UniqueKeys.csproj
+++ b/JsonSchema.UniqueKeys/JsonSchema.UniqueKeys.csproj
@@ -20,8 +20,8 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonSchema.Net.UniqueKeys.xml</DocumentationFile>
 		<LangVersion>latest</LangVersion>
-		<Version>3.0.0</Version>
-		<FileVersion>3.0.0.0</FileVersion>
+		<Version>3.0.1</Version>
+		<FileVersion>3.0.1.0</FileVersion>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/JsonSchema.UniqueKeys/UniqueKeysKeyword.cs
+++ b/JsonSchema.UniqueKeys/UniqueKeysKeyword.cs
@@ -101,7 +101,7 @@ public class UniqueKeysKeyword : IJsonSchemaKeyword
 		if (matchedIndexPairs.Any())
 		{
 			var pairs = string.Join(", ", matchedIndexPairs.Select(d => $"({d.Item1}, {d.Item2})"));
-			evaluation.Results.Fail(Name, ErrorMessages.UniqueItems, ("duplicates", pairs));
+			evaluation.Results.Fail(Name, ErrorMessages.GetUniqueItems(context.Options.Culture), ("duplicates", pairs));
 		}
 	}
 }

--- a/JsonSchema/ConstKeyword.cs
+++ b/JsonSchema/ConstKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -61,7 +62,7 @@ public class ConstKeyword : IJsonSchemaKeyword
 	private void Evaluator(KeywordEvaluation evaluation, EvaluationContext context)
 	{
 		if (!evaluation.LocalInstance.IsEquivalentTo(Value))
-			evaluation.Results.Fail(Name, ErrorMessages.Const, ("value", Value.AsJsonString()));
+			evaluation.Results.Fail(Name, ErrorMessages.GetConst(context.Options.Culture), ("value", Value.AsJsonString()));
 	}
 }
 
@@ -82,8 +83,6 @@ internal class ConstKeywordJsonConverter : JsonConverter<ConstKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _const;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="ConstKeyword"/>.
 	/// </summary>
@@ -91,9 +90,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[value]] - the value in the schema
 	/// </remarks>
-	public static string Const
+	public static string? Const { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="ConstKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[value]] - the value in the schema
+	/// </remarks>
+	public static string GetConst(CultureInfo? culture)
 	{
-		get => _const ?? Get();
-		set => _const = value;
+		return Const ?? Get(culture);
 	}
 }

--- a/JsonSchema/ContainsKeyword.cs
+++ b/JsonSchema/ContainsKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -98,9 +99,9 @@ public class ContainsKeyword : IJsonSchemaKeyword, ISchemaContainer
 			
 			var actual = validIndices.Length;
 			if (actual < minimum)
-				evaluation.Results.Fail(Name, ErrorMessages.ContainsTooFew, ("received", actual), ("minimum", minimum));
+				evaluation.Results.Fail(Name, ErrorMessages.GetContainsTooFew(context.Options.Culture), ("received", actual), ("minimum", minimum));
 			else if (actual > maximum)
-				evaluation.Results.Fail(Name, ErrorMessages.ContainsTooMany, ("received", actual), ("maximum", maximum));
+				evaluation.Results.Fail(Name, ErrorMessages.GetContainsTooMany(context.Options.Culture), ("received", actual), ("maximum", maximum));
 			return;
 		}
 
@@ -122,9 +123,9 @@ public class ContainsKeyword : IJsonSchemaKeyword, ISchemaContainer
 			
 			var actual = validProperties.Length;
 			if (actual < minimum)
-				evaluation.Results.Fail(Name, ErrorMessages.ContainsTooFew, ("received", actual), ("minimum", minimum));
+				evaluation.Results.Fail(Name, ErrorMessages.GetContainsTooFew(context.Options.Culture), ("received", actual), ("minimum", minimum));
 			else if (actual > maximum)
-				evaluation.Results.Fail(Name, ErrorMessages.ContainsTooMany, ("received", actual), ("maximum", maximum));
+				evaluation.Results.Fail(Name, ErrorMessages.GetContainsTooMany(context.Options.Culture), ("received", actual), ("maximum", maximum));
 			return;
 		}
 
@@ -149,9 +150,6 @@ internal class ContainsKeywordJsonConverter : JsonConverter<ContainsKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _containsTooFew;
-	private static string? _containsTooMany;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="ContainsKeyword"/> when there are too few matching items.
 	/// </summary>
@@ -160,10 +158,20 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of matching items provided in the JSON instance
 	///   - [[minimum]] - the lower limit specified in the schema
 	/// </remarks>
-	public static string ContainsTooFew
+	public static string? ContainsTooFew { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="ContainsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of matching items provided in the JSON instance
+	///   - [[minimum]] - the lower limit specified in the schema
+	/// </remarks>
+	public static string GetContainsTooFew(CultureInfo? culture)
 	{
-		get => _containsTooFew ?? Get();
-		set => _containsTooFew = value;
+		return ContainsTooFew ?? Get(culture);
 	}
 
 	/// <summary>
@@ -174,9 +182,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of matching items provided in the JSON instance
 	///   - [[maximum]] - the upper limit specified in the schema
 	/// </remarks>
-	public static string ContainsTooMany
+	public static string? ContainsTooMany { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="ContainsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of matching items provided in the JSON instance
+	///   - [[maximum]] - the upper limit specified in the schema
+	/// </remarks>
+	public static string GetContainsTooMany(CultureInfo? culture)
 	{
-		get => _containsTooMany ?? Get();
-		set => _containsTooMany = value;
+		return ContainsTooMany ?? Get(culture);
 	}
 }

--- a/JsonSchema/DependenciesKeyword.cs
+++ b/JsonSchema/DependenciesKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -99,7 +100,7 @@ public class DependenciesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 		}
 
 		if (missing.Count != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.DependentRequired, ("missing", missing));
+			evaluation.Results.Fail(Name, ErrorMessages.GetDependentRequired(context.Options.Culture), ("missing", missing));
 
 		
 		var failedProperties = evaluation.ChildEvaluations
@@ -109,7 +110,7 @@ public class DependenciesKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 		evaluation.Results.SetAnnotation(Name, evaluation.ChildEvaluations.Select(x => (JsonNode)x.Results.EvaluationPath.Segments.Last().Value!).ToJsonArray());
 
 		if (failedProperties.Length != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.DependentSchemas, ("failed", failedProperties));
+			evaluation.Results.Fail(Name, ErrorMessages.GetDependentSchemas(context.Options.Culture), ("failed", failedProperties));
 	}
 }
 
@@ -252,6 +253,7 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[properties]] - the properties which failed to match the requirements
 	/// </remarks>
+	[Obsolete("Use " + nameof(DependentRequired) + " or " + nameof(DependentSchemas) + " to set the appropriate message.")]
 	public static string Dependencies
 	{
 		get => _dependencies ?? Get();

--- a/JsonSchema/DependentRequiredKeyword.cs
+++ b/JsonSchema/DependentRequiredKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -77,7 +78,7 @@ public class DependentRequiredKeyword : IJsonSchemaKeyword
 		}
 
 		if (missing.Count != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.DependentRequired, ("missing", missing));
+			evaluation.Results.Fail(Name, ErrorMessages.GetDependentRequired(context.Options.Culture), ("missing", missing));
 	}
 }
 
@@ -106,8 +107,6 @@ internal class DependentRequiredKeywordJsonConverter : JsonConverter<DependentRe
 
 public static partial class ErrorMessages
 {
-	private static string? _dependentRequired;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="DependentRequiredKeyword"/>.
 	/// </summary>
@@ -115,9 +114,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[missing]] - the value in the schema
 	/// </remarks>
-	public static string DependentRequired
+	public static string? DependentRequired { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="DependentRequiredKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[missing]] - the value in the schema
+	/// </remarks>
+	public static string GetDependentRequired(CultureInfo? culture)
 	{
-		get => _dependentRequired ?? Get();
-		set => _dependentRequired = value;
+		return DependentRequired ?? Get(culture);
 	}
 }

--- a/JsonSchema/DependentSchemasKeyword.cs
+++ b/JsonSchema/DependentSchemasKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -85,7 +86,7 @@ public class DependentSchemasKeyword : IJsonSchemaKeyword, IKeyedSchemaCollector
 		evaluation.Results.SetAnnotation(Name, evaluation.ChildEvaluations.Select(x => (JsonNode)x.Results.EvaluationPath.Segments.Last().Value!).ToJsonArray());
 		
 		if (failedProperties.Length != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.DependentSchemas, ("failed", failedProperties));
+			evaluation.Results.Fail(Name, ErrorMessages.GetDependentSchemas(context.Options.Culture), ("failed", failedProperties));
 	}
 }
 
@@ -114,8 +115,6 @@ internal class DependentSchemasKeywordJsonConverter : JsonConverter<DependentSch
 
 public static partial class ErrorMessages
 {
-	private static string? _dependentSchemas;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="DependentSchemasKeyword"/>.
 	/// </summary>
@@ -123,9 +122,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[value]] - the value in the schema
 	/// </remarks>
-	public static string DependentSchemas
+	public static string? DependentSchemas { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="DependentSchemasKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[value]] - the value in the schema
+	/// </remarks>
+	public static string GetDependentSchemas(CultureInfo? culture)
 	{
-		get => _dependentSchemas ?? Get();
-		set => _dependentSchemas = value;
+		return DependentSchemas ?? Get(culture);
 	}
 }

--- a/JsonSchema/EnumKeyword.cs
+++ b/JsonSchema/EnumKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -93,7 +94,7 @@ public class EnumKeyword : IJsonSchemaKeyword
 	private void Evaluator(KeywordEvaluation evaluation, EvaluationContext context)
 	{
 		if (!Values.Contains(evaluation.LocalInstance, JsonNodeEqualityComparer.Instance))
-			evaluation.Results.Fail(Name, ErrorMessages.Enum, ("received", evaluation.LocalInstance), ("values", Values));
+			evaluation.Results.Fail(Name, ErrorMessages.GetEnum(context.Options.Culture), ("received", evaluation.LocalInstance), ("values", Values));
 	}
 }
 
@@ -121,8 +122,6 @@ internal class EnumKeywordJsonConverter : JsonConverter<EnumKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _enum;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="EnumKeyword"/>.
 	/// </summary>
@@ -135,9 +134,23 @@ public static partial class ErrorMessages
 	/// may be any JSON type and could be quite large.  They are provided to support
 	/// custom messages.
 	/// </remarks>
-	public static string Enum
+	public static string? Enum { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="EnumKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[values]] - the available values in the schema
+	///
+	/// The default messages are static and do not use these tokens as enum values
+	/// may be any JSON type and could be quite large.  They are provided to support
+	/// custom messages.
+	/// </remarks>
+	public static string GetEnum(CultureInfo? culture)
 	{
-		get => _enum ?? Get();
-		set => _enum = value;
+		return Enum ?? Get(culture);
 	}
 }

--- a/JsonSchema/ErrorMessages.cs
+++ b/JsonSchema/ErrorMessages.cs
@@ -26,11 +26,14 @@ public static partial class ErrorMessages
 	/// </summary>
 	public static CultureInfo? Culture { get; set; }
 
-	private static string Get([CallerMemberName] string? key = null)
+	private static string Get(CultureInfo? culture = null, [CallerMemberName] string? key = null)
 	{
 		if (key == null) throw new ArgumentNullException(nameof(key), "Cannot get a null-keyed resource");
 
-		return _resourceManager.GetString($"Error_{key}", Culture ?? CultureInfo.CurrentCulture) ??
+		if (key.StartsWith("Get"))
+			key = key.Substring(3);
+
+		return _resourceManager.GetString($"Error_{key}", culture ?? Culture ?? CultureInfo.CurrentCulture) ??
 			   throw new KeyNotFoundException($"Could not find error message with key '{key}'");
 	}
 

--- a/JsonSchema/EvaluationOptions.cs
+++ b/JsonSchema/EvaluationOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Json.Schema;
@@ -81,6 +82,11 @@ public class EvaluationOptions
 	/// </summary>
 	public IEnumerable<Type>? IgnoredAnnotations => _ignoredAnnotationTypes;
 
+	/// <summary>
+	/// Gets or sets the culture for error messages.  Overrides <see cref="ErrorMessages.Culture"/>.
+	/// </summary>
+	public CultureInfo? Culture { get; set; }
+
 	internal SpecVersion EvaluatingAs { get; set; }
 
 	static EvaluationOptions()
@@ -114,6 +120,7 @@ public class EvaluationOptions
 			ProcessCustomKeywords = other.ProcessCustomKeywords,
 			OnlyKnownFormats = other.OnlyKnownFormats,
 			PreserveDroppedAnnotations = other.PreserveDroppedAnnotations,
+			Culture = other.Culture,
 			_ignoredAnnotationTypes = other._ignoredAnnotationTypes == null
 				? null
 				: new HashSet<Type>(other._ignoredAnnotationTypes)

--- a/JsonSchema/ExclusiveMaximumKeyword.cs
+++ b/JsonSchema/ExclusiveMaximumKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.More;
@@ -64,7 +65,7 @@ public class ExclusiveMaximumKeyword : IJsonSchemaKeyword
 
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 		if (Value <= number)
-			evaluation.Results.Fail(Name, ErrorMessages.ExclusiveMaximum, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMaximum(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -87,8 +88,6 @@ internal class ExclusiveMaximumKeywordJsonConverter : JsonConverter<ExclusiveMax
 
 public static partial class ErrorMessages
 {
-	private static string? _exclusiveMaximum;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="ExclusiveMaximumKeyword"/>.
 	/// </summary>
@@ -97,9 +96,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the value provided in the JSON instance
 	///   - [[limit]] - the upper limit in the schema
 	/// </remarks>
-	public static string ExclusiveMaximum
+	public static string? ExclusiveMaximum { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="ExclusiveMaximumKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[limit]] - the upper limit in the schema
+	/// </remarks>
+	public static string GetExclusiveMaximum(CultureInfo? culture)
 	{
-		get => _exclusiveMaximum ?? Get();
-		set => _exclusiveMaximum = value;
+		return ExclusiveMaximum ?? Get(culture);
 	}
 }

--- a/JsonSchema/ExclusiveMinimumKeyword.cs
+++ b/JsonSchema/ExclusiveMinimumKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.More;
@@ -64,7 +65,7 @@ public class ExclusiveMinimumKeyword : IJsonSchemaKeyword
 
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 		if (Value >= number)
-			evaluation.Results.Fail(Name, ErrorMessages.ExclusiveMinimum, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMinimum(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -87,8 +88,6 @@ internal class ExclusiveMinimumKeywordJsonConverter : JsonConverter<ExclusiveMin
 
 public static partial class ErrorMessages
 {
-	private static string? _exclusiveMinimum;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="ExclusiveMinimumKeyword"/>.
 	/// </summary>
@@ -97,9 +96,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the value provided in the JSON instance
 	///   - [[limit]] - the lower limit in the schema
 	/// </remarks>
-	public static string ExclusiveMinimum
+	public static string? ExclusiveMinimum { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="ExclusiveMinimumKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[limit]] - the lower limit in the schema
+	/// </remarks>
+	public static string GetExclusiveMinimum(CultureInfo? culture)
 	{
-		get => _exclusiveMinimum ?? Get();
-		set => _exclusiveMinimum = value;
+		return ExclusiveMinimum ?? Get(culture);
 	}
 }

--- a/JsonSchema/FormatKeyword.cs
+++ b/JsonSchema/FormatKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -63,7 +64,7 @@ public class FormatKeyword : IJsonSchemaKeyword
 		EvaluationContext context)
 	{
 		if (Value is UnknownFormat && context.Options.OnlyKnownFormats)
-			return new KeywordConstraint(Name, (e, _) => e.Results.Fail(Name, ErrorMessages.UnknownFormat, ("format", Value.Key)));
+			return new KeywordConstraint(Name, (e, _) => e.Results.Fail(Name, ErrorMessages.GetUnknownFormat(context.Options.Culture), ("format", Value.Key)));
 
 		var requireValidation = context.Options.RequireFormatValidation;
 
@@ -98,9 +99,9 @@ public class FormatKeyword : IJsonSchemaKeyword
 		if (Value is UnknownFormat)
 			evaluation.Results.Fail(Name, errorMessage);
 		else if (errorMessage == null)
-			evaluation.Results.Fail(Name, ErrorMessages.Format, ("format", Value.Key));
+			evaluation.Results.Fail(Name, ErrorMessages.GetFormat(context.Options.Culture), ("format", Value.Key));
 		else
-			evaluation.Results.Fail(Name, ErrorMessages.FormatWithDetail, ("format", Value.Key), ("detail", errorMessage));
+			evaluation.Results.Fail(Name, ErrorMessages.GetFormatWithDetail(context.Options.Culture), ("format", Value.Key), ("detail", errorMessage));
 	}
 }
 
@@ -124,8 +125,6 @@ internal class FormatKeywordJsonConverter : JsonConverter<FormatKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _unknownFormat;
-
 	/// <summary>
 	/// Gets or sets the error message for an unknown format.
 	/// </summary>
@@ -133,13 +132,20 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[format]] - the format key
 	/// </remarks>
-	public static string UnknownFormat
-	{
-		get => _unknownFormat ?? Get();
-		set => _unknownFormat = value;
-	}
+	public static string? UnknownFormat { get; set; }
 
-	private static string? _format;
+	/// <summary>
+	/// Gets the error message for an unknown format.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[format]] - the format key
+	/// </remarks>
+	public static string GetUnknownFormat(CultureInfo? culture)
+	{
+		return UnknownFormat ?? Get(culture);
+	}
 
 	/// <summary>
 	/// Gets or sets the error message for the <see cref="FormatKeyword"/>.
@@ -148,13 +154,20 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[format]] - the format key
 	/// </remarks>
-	public static string Format
-	{
-		get => _format ?? Get();
-		set => _format = value;
-	}
+	public static string? Format { get; set; }
 
-	private static string? _formatWithDetail;
+	/// <summary>
+	/// Gets the error message for <see cref="FormatKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[format]] - the format key
+	/// </remarks>
+	public static string GetFormat(CultureInfo? culture)
+	{
+		return Format ?? Get(culture);
+	}
 
 	/// <summary>
 	/// Gets or sets the error message for the <see cref="FormatKeyword"/> with
@@ -163,11 +176,21 @@ public static partial class ErrorMessages
 	/// <remarks>
 	///	Available tokens are:
 	///   - [[format]] - the format key
-	///   - [[detail]] - the format key
+	///   - [[detail]] - the detail
 	/// </remarks>
-	public static string FormatWithDetail
+	public static string? FormatWithDetail { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="FormatKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[format]] - the format key
+	///   - [[detail]] - the detail
+	/// </remarks>
+	public static string GetFormatWithDetail(CultureInfo? culture)
 	{
-		get => _formatWithDetail ?? Get();
-		set => _formatWithDetail = value;
+		return FormatWithDetail ?? Get(culture);
 	}
 }

--- a/JsonSchema/ItemsKeyword.cs
+++ b/JsonSchema/ItemsKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -186,6 +187,7 @@ public static partial class ErrorMessages
 	/// with an array of schemas in a draft 2020-12 or later schema.
 	/// </summary>
 	/// <remarks>No tokens are supported.</remarks>
+	[Obsolete("Invalid use of array-form `items` will result in an exception now.")]
 	public static string InvalidItemsForm
 	{
 		get => _invalidItemsForm ?? Get();

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -553,7 +553,7 @@ public class JsonSchema : IBaseDocument
 	private string ToDebugString()
 	{
 		if (BoolValue.HasValue) return BoolValue.Value ? "true" : "false";
-		var idKeyword = Keywords!.OfType<IdKeyword>().SingleOrDefault();
+		var idKeyword = Keywords!.OfType<IIdKeyword>().SingleOrDefault();
 		return idKeyword?.Id.OriginalString ?? BaseUri.OriginalString;
 	}
 }

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -16,8 +16,8 @@
     <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
     <RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
     <PackageTags>json-schema validation schema json</PackageTags>
-    <Version>5.0.0</Version>
-    <FileVersion>5.0.0.0</FileVersion>
+    <Version>5.1.0</Version>
+    <FileVersion>5.1.0.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyName>JsonSchema.Net</AssemblyName>

--- a/JsonSchema/MaxItemsKeyword.cs
+++ b/JsonSchema/MaxItemsKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -67,7 +68,7 @@ public class MaxItemsKeyword : IJsonSchemaKeyword
 
 		var number = array.Count;
 		if (Value < number)
-			evaluation.Results.Fail(Name, ErrorMessages.MaxItems, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMaxItems(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -94,8 +95,6 @@ internal class MaxItemsKeywordJsonConverter : JsonConverter<MaxItemsKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _maxItems;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MaxItemsKeyword"/>.
 	/// </summary>
@@ -104,9 +103,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of items provided in the JSON instance
 	///   - [[limit]] - the upper limit specified in the schema
 	/// </remarks>
-	public static string MaxItems
+	public static string? MaxItems { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MaxItemsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of items provided in the JSON instance
+	///   - [[limit]] - the upper limit specified in the schema
+	/// </remarks>
+	public static string GetMaxItems(CultureInfo? culture)
 	{
-		get => _maxItems ?? Get();
-		set => _maxItems = value;
+		return MaxItems ?? Get(culture);
 	}
 }

--- a/JsonSchema/MaxLengthKeyword.cs
+++ b/JsonSchema/MaxLengthKeyword.cs
@@ -69,7 +69,7 @@ public class MaxLengthKeyword : IJsonSchemaKeyword
 		var str = evaluation.LocalInstance!.GetValue<string>();
 		var length = new StringInfo(str).LengthInTextElements;
 		if (Value < length)
-			evaluation.Results.Fail(Name, ErrorMessages.MaxLength, ("received", length), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMaxLength(context.Options.Culture), ("received", length), ("limit", Value));
 	}
 }
 
@@ -96,8 +96,6 @@ internal class MaxLengthKeywordJsonConverter : JsonConverter<MaxLengthKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _maxLength;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MaxLengthKeyword"/>.
 	/// </summary>
@@ -106,9 +104,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the length of the JSON string
 	///   - [[limit]] - the upper limit specified in the schema
 	/// </remarks>
-	public static string MaxLength
+	public static string? MaxLength { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MaxLengthKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the length of the JSON string
+	///   - [[limit]] - the upper limit specified in the schema
+	/// </remarks>
+	public static string GetMaxLength(CultureInfo? culture)
 	{
-		get => _maxLength ?? Get();
-		set => _maxLength = value;
+		return MaxLength ?? Get(culture);
 	}
 }

--- a/JsonSchema/MaxPropertiesKeyword.cs
+++ b/JsonSchema/MaxPropertiesKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -67,7 +68,7 @@ public class MaxPropertiesKeyword : IJsonSchemaKeyword
 
 		var number = obj.Count;
 		if (Value < number)
-			evaluation.Results.Fail(Name, ErrorMessages.MaxProperties, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMaxProperties(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -94,8 +95,6 @@ internal class MaxPropertiesKeywordJsonConverter : JsonConverter<MaxPropertiesKe
 
 public static partial class ErrorMessages
 {
-	private static string? _maxProperties;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MaxPropertiesKeyword"/>.
 	/// </summary>
@@ -104,9 +103,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of properties provided in the JSON instance
 	///   - [[limit]] - the upper limit specified in the schema
 	/// </remarks>
-	public static string MaxProperties
+	public static string? MaxProperties { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MaxPropertiesKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of properties provided in the JSON instance
+	///   - [[limit]] - the upper limit specified in the schema
+	/// </remarks>
+	public static string GetMaxProperties(CultureInfo? culture)
 	{
-		get => _maxProperties ?? Get();
-		set => _maxProperties = value;
+		return MaxProperties ?? Get(culture);
 	}
 }

--- a/JsonSchema/MaximumKeyword.cs
+++ b/JsonSchema/MaximumKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.More;
@@ -68,7 +69,7 @@ public class MaximumKeyword : IJsonSchemaKeyword
 
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 		if (Value < number)
-			evaluation.Results.Fail(Name, ErrorMessages.Maximum, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMaximum(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -91,8 +92,6 @@ internal class MaximumKeywordJsonConverter : JsonConverter<MaximumKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _maximum;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MinimumKeyword"/>.
 	/// </summary>
@@ -101,9 +100,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the value provided in the JSON instance
 	///   - [[limit]] - the upper limit in the schema
 	/// </remarks>
-	public static string Maximum
+	public static string? Maximum { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MinimumKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[limit]] - the upper limit in the schema
+	/// </remarks>
+	public static string GetMaximum(CultureInfo? culture)
 	{
-		get => _maximum ?? Get();
-		set => _maximum = value;
+		return Maximum ?? Get(culture);
 	}
 }

--- a/JsonSchema/MinItemsKeyword.cs
+++ b/JsonSchema/MinItemsKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -67,7 +68,7 @@ public class MinItemsKeyword : IJsonSchemaKeyword
 
 		var number = array.Count;
 		if (Value > number)
-			evaluation.Results.Fail(Name, ErrorMessages.MaxItems, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMaxItems(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -94,8 +95,6 @@ internal class MinItemsKeywordJsonConverter : JsonConverter<MinItemsKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _minItems;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MinItemsKeyword"/>.
 	/// </summary>
@@ -104,9 +103,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of items provided in the JSON instance
 	///   - [[limit]] - the lower limit specified in the schema
 	/// </remarks>
-	public static string MinItems
+	public static string? MinItems { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MinItemsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of items provided in the JSON instance
+	///   - [[limit]] - the lower limit specified in the schema
+	/// </remarks>
+	public static string GetMinItems(CultureInfo? culture)
 	{
-		get => _minItems ?? Get();
-		set => _minItems = value;
+		return MinItems ?? Get(culture);
 	}
 }

--- a/JsonSchema/MinLengthKeyword.cs
+++ b/JsonSchema/MinLengthKeyword.cs
@@ -69,7 +69,7 @@ public class MinLengthKeyword : IJsonSchemaKeyword
 		var str = evaluation.LocalInstance!.GetValue<string>();
 		var length = new StringInfo(str).LengthInTextElements;
 		if (Value > length)
-			evaluation.Results.Fail(Name, ErrorMessages.MinLength, ("received", length), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMinLength(context.Options.Culture), ("received", length), ("limit", Value));
 	}
 }
 
@@ -96,8 +96,6 @@ internal class MinLengthKeywordJsonConverter : JsonConverter<MinLengthKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _minLength;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MinLengthKeyword"/>.
 	/// </summary>
@@ -106,9 +104,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the length of the JSON string
 	///   - [[limit]] - the lower limit specified in the schema
 	/// </remarks>
-	public static string MinLength
+	public static string? MinLength { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MinLengthKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the length of the JSON string
+	///   - [[limit]] - the lower limit specified in the schema
+	/// </remarks>
+	public static string GetMinLength(CultureInfo? culture)
 	{
-		get => _minLength ?? Get();
-		set => _minLength = value;
+		return MinLength ?? Get(culture);
 	}
 }

--- a/JsonSchema/MinPropertiesKeyword.cs
+++ b/JsonSchema/MinPropertiesKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -67,7 +68,7 @@ public class MinPropertiesKeyword : IJsonSchemaKeyword
 
 		var number = obj.Count;
 		if (Value > number)
-			evaluation.Results.Fail(Name, ErrorMessages.MinProperties, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMinProperties(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -94,8 +95,6 @@ internal class MinPropertiesKeywordJsonConverter : JsonConverter<MinPropertiesKe
 
 public static partial class ErrorMessages
 {
-	private static string? _minProperties;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MinPropertiesKeyword"/>.
 	/// </summary>
@@ -104,9 +103,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the number of properties provided in the JSON instance
 	///   - [[limit]] - the lower limit specified in the schema
 	/// </remarks>
-	public static string MinProperties
+	public static string? MinProperties { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MinPropertiesKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the number of properties provided in the JSON instance
+	///   - [[limit]] - the lower limit specified in the schema
+	/// </remarks>
+	public static string GetMinProperties(CultureInfo? culture)
 	{
-		get => _minProperties ?? Get();
-		set => _minProperties = value;
+		return MinProperties ?? Get(culture);
 	}
 }

--- a/JsonSchema/MinimumKeyword.cs
+++ b/JsonSchema/MinimumKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.More;
@@ -68,7 +69,7 @@ public class MinimumKeyword : IJsonSchemaKeyword
 
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 		if (Value > number)
-			evaluation.Results.Fail(Name, ErrorMessages.Minimum, ("received", number), ("limit", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMinimum(context.Options.Culture), ("received", number), ("limit", Value));
 	}
 }
 
@@ -91,8 +92,6 @@ internal class MinimumKeywordJsonConverter : JsonConverter<MinimumKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _minimum;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MinimumKeyword"/>.
 	/// </summary>
@@ -101,9 +100,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the value provided in the JSON instance
 	///   - [[limit]] - the lower limit in the schema
 	/// </remarks>
-	public static string Minimum
+	public static string? Minimum { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MinimumKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture"></param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[limit]] - the lower limit in the schema
+	/// </remarks>
+	public static string GetMinimum(CultureInfo? culture)
 	{
-		get => _minimum ?? Get();
-		set => _minimum = value;
+		return Minimum ?? Get(culture);
 	}
 }

--- a/JsonSchema/MultipleOfKeyword.cs
+++ b/JsonSchema/MultipleOfKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.More;
@@ -68,7 +69,7 @@ public class MultipleOfKeyword : IJsonSchemaKeyword
 
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 		if (number % Value != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.MultipleOf, ("received", number), ("divisor", Value));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMultipleOf(context.Options.Culture), ("received", number), ("divisor", Value));
 	}
 }
 
@@ -91,8 +92,6 @@ internal class MultipleOfKeywordJsonConverter : JsonConverter<MultipleOfKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _multipleOf;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="MultipleOfKeyword"/>.
 	/// </summary>
@@ -101,9 +100,19 @@ public static partial class ErrorMessages
 	///   - [[received]] - the value provided in the JSON instance
 	///   - [[divisor]] - the required divisor
 	/// </remarks>
-	public static string MultipleOf
+	public static string? MultipleOf { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="MultipleOfKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[received]] - the value provided in the JSON instance
+	///   - [[divisor]] - the required divisor
+	/// </remarks>
+	public static string GetMultipleOf(CultureInfo? culture)
 	{
-		get => _multipleOf ?? Get();
-		set => _multipleOf = value;
+		return MultipleOf ?? Get(culture);
 	}
 }

--- a/JsonSchema/OneOfKeyword.cs
+++ b/JsonSchema/OneOfKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -74,7 +75,7 @@ public class OneOfKeyword : IJsonSchemaKeyword, ISchemaCollector
 	{
 		var actual = evaluation.ChildEvaluations.Count(x => x.Results.IsValid);
 		if (actual != 1)
-			evaluation.Results.Fail(Name, ErrorMessages.OneOf, ("count", actual));
+			evaluation.Results.Fail(Name, ErrorMessages.GetOneOf(context.Options.Culture), ("count", actual));
 	}
 }
 
@@ -105,8 +106,6 @@ internal class OneOfKeywordJsonConverter : JsonConverter<OneOfKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _oneOf;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="OneOfKeyword"/>.
 	/// </summary>
@@ -114,9 +113,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[count]] - the number of subschemas that passed validation
 	/// </remarks>
-	public static string OneOf
+	public static string? OneOf { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="OneOfKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[count]] - the number of subschemas that passed validation
+	/// </remarks>
+	public static string GetOneOf(CultureInfo? culture)
 	{
-		get => _oneOf ?? Get();
-		set => _oneOf = value;
+		return OneOf ?? Get(culture);
 	}
 }

--- a/JsonSchema/PatternKeyword.cs
+++ b/JsonSchema/PatternKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -83,7 +84,7 @@ public class PatternKeyword : IJsonSchemaKeyword
 
 		var str = evaluation.LocalInstance!.GetValue<string>();
 		if (!Value.IsMatch(str))
-			evaluation.Results.Fail(Name, ErrorMessages.Pattern, ("received", str), ("pattern", Value.ToString()));
+			evaluation.Results.Fail(Name, ErrorMessages.GetPattern(context.Options.Culture), ("received", str), ("pattern", Value.ToString()));
 	}
 }
 
@@ -124,28 +125,32 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[pattern]] - the regular expression
 	/// </remarks>
+	[Obsolete("Unsupported patterns will now throw exceptions.")]
 	public static string InvalidPattern
 	{
 		get => _invalidPattern ?? Get();
 		set => _invalidPattern = value;
 	}
 
-	private static string? _pattern;
-
 	/// <summary>
-	/// Gets or sets the error message for <see cref="OneOfKeyword"/>.
+	/// Gets or sets the error message for <see cref="PatternKeyword"/>.
 	/// </summary>
 	/// <remarks>
 	///	Available tokens are:
-	///   - [[received]] - the value provided in the JSON instance
-	///   - [[pattern]] - the number of subschemas that passed validation
-	///
-	/// The default messages are static and do not use these tokens as string values
-	/// could be quite large.  They are provided to support custom messages.
+	///   - [[pattern]] - the regular expression
 	/// </remarks>
-	public static string Pattern
+	public static string? Pattern { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="PatternKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[pattern]] - the regular expression
+	/// </remarks>
+	public static string GetPattern(CultureInfo? culture)
 	{
-		get => _pattern ?? Get();
-		set => _pattern = value;
+		return Pattern ?? Get(culture);
 	}
 }

--- a/JsonSchema/PropertyDependenciesKeyword.cs
+++ b/JsonSchema/PropertyDependenciesKeyword.cs
@@ -88,7 +88,7 @@ public class PropertyDependenciesKeyword : IJsonSchemaKeyword, ICustomSchemaColl
 		evaluation.Results.SetAnnotation(Name, evaluation.ChildEvaluations.Select(x => (JsonNode)x.Results.EvaluationPath.Segments.Last().Value!).ToJsonArray());
 		
 		if (failedProperties.Length != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.DependentSchemas, ("failed", failedProperties));
+			evaluation.Results.Fail(Name, ErrorMessages.GetDependentSchemas(context.Options.Culture), ("failed", failedProperties));
 	}
 
 	(JsonSchema?, int) ICustomSchemaCollector.FindSubschema(IReadOnlyList<PointerSegment> segments)

--- a/JsonSchema/RequiredKeyword.cs
+++ b/JsonSchema/RequiredKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -73,7 +74,7 @@ public class RequiredKeyword : IJsonSchemaKeyword
 
 		var missing = Properties.Except(obj.Select(x => x.Key)).ToArray();
 		if (missing.Length != 0)
-			evaluation.Results.Fail(Name, ErrorMessages.Required, ("missing", missing));
+			evaluation.Results.Fail(Name, ErrorMessages.GetRequired(context.Options.Culture), ("missing", missing));
 	}
 }
 
@@ -103,8 +104,6 @@ internal class RequiredKeywordJsonConverter : JsonConverter<RequiredKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _required;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="RequiredKeyword"/>.
 	/// </summary>
@@ -112,9 +111,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[missing]] - the properties missing from the JSON instance
 	/// </remarks>
-	public static string Required
+	public static string? Required { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="RequiredKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[missing]] - the properties missing from the JSON instance
+	/// </remarks>
+	public static string GetRequired(CultureInfo? culture)
 	{
-		get => _required ?? Get();
-		set => _required = value;
+		return Required ?? Get(culture);
 	}
 }

--- a/JsonSchema/SchemaKeyword.cs
+++ b/JsonSchema/SchemaKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Json.Pointer;
@@ -74,7 +75,7 @@ public class SchemaKeyword : IJsonSchemaKeyword
 	private void Evaluator(KeywordEvaluation evaluation, EvaluationContext context)
 	{
 		if (!evaluation.ChildEvaluations[0].Results.IsValid)
-			evaluation.Results.Fail(Name, ErrorMessages.MetaSchemaValidation, ("uri", Schema.OriginalString));
+			evaluation.Results.Fail(Name, ErrorMessages.GetMetaSchemaValidation(context.Options.Culture), ("uri", Schema.OriginalString));
 	}
 }
 
@@ -100,8 +101,6 @@ internal class SchemaKeywordJsonConverter : JsonConverter<SchemaKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _metaSchemaValidation;
-
 	/// <summary>
 	/// Gets or sets the error message for when the schema cannot be validated
 	/// against the meta-schema.
@@ -110,9 +109,19 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[uri]] - the URI of the meta-schema
 	/// </remarks>
-	public static string MetaSchemaValidation
+	public static string? MetaSchemaValidation { get; set; }
+
+	/// <summary>
+	/// Gets or sets the error message for when the schema cannot be validated
+	/// against the meta-schema.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[uri]] - the URI of the meta-schema
+	/// </remarks>
+	public static string GetMetaSchemaValidation(CultureInfo? culture)
 	{
-		get => _metaSchemaValidation ?? Get();
-		set => _metaSchemaValidation = value;
+		return MetaSchemaValidation ?? Get(culture);
 	}
 }

--- a/JsonSchema/UniqueItemsKeyword.cs
+++ b/JsonSchema/UniqueItemsKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -78,7 +79,7 @@ public class UniqueItemsKeyword : IJsonSchemaKeyword
 		if (duplicates.Any())
 		{
 			var pairs = string.Join(", ", duplicates.Select(d => $"({d.Item1}, {d.Item2})"));
-			evaluation.Results.Fail(Name, ErrorMessages.UniqueItems, ("duplicates", pairs));
+			evaluation.Results.Fail(Name, ErrorMessages.GetUniqueItems(context.Options.Culture), ("duplicates", pairs));
 		}
 	}
 }
@@ -102,8 +103,6 @@ internal class UniqueItemsKeywordJsonConverter : JsonConverter<UniqueItemsKeywor
 
 public static partial class ErrorMessages
 {
-	private static string? _uniqueItems;
-
 	/// <summary>
 	/// Gets or sets the error message for <see cref="UniqueItemsKeyword"/>.
 	/// </summary>
@@ -111,9 +110,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[duplicates]] - the indices of duplicate pairs as a comma-delimited list of "(x, y)" items
 	/// </remarks>
-	public static string UniqueItems
+	public static string? UniqueItems { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="UniqueItemsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[duplicates]] - the indices of duplicate pairs as a comma-delimited list of "(x, y)" items
+	/// </remarks>
+	public static string GetUniqueItems(CultureInfo? culture)
 	{
-		get => _uniqueItems ?? Get();
-		set => _uniqueItems = value;
+		return UniqueItems ?? Get(culture);
 	}
 }

--- a/JsonSchema/VocabularyKeyword.cs
+++ b/JsonSchema/VocabularyKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -88,7 +89,7 @@ public class VocabularyKeyword : IJsonSchemaKeyword
 		}
 
 		if (!overallResult)
-			evaluation.Results.Fail(Name, ErrorMessages.UnknownVocabularies, ("vocabs", $"[{string.Join(", ", violations)}]"));
+			evaluation.Results.Fail(Name, ErrorMessages.GetUnknownVocabularies(context.Options.Culture), ("vocabs", $"[{string.Join(", ", violations)}]"));
 	}
 }
 
@@ -117,8 +118,6 @@ internal class VocabularyKeywordJsonConverter : JsonConverter<VocabularyKeyword>
 
 public static partial class ErrorMessages
 {
-	private static string? _unknownVocabularies;
-
 	/// <summary>
 	/// Gets or sets the error message for when a vocabulary is unknown but required.
 	/// </summary>
@@ -126,9 +125,18 @@ public static partial class ErrorMessages
 	///	Available tokens are:
 	///   - [[vocabs]] - the URI IDs of the missing vocabularies as a comma-delimited list
 	/// </remarks>
-	public static string UnknownVocabularies
+	public static string? UnknownVocabularies { get; set; }
+
+	/// <summary>
+	/// Gets or sets the error message for when a vocabulary is unknown but required.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[vocabs]] - the URI IDs of the missing vocabularies as a comma-delimited list
+	/// </remarks>
+	public static string GetUnknownVocabularies(CultureInfo? culture)
 	{
-		get => _unknownVocabularies ?? Get();
-		set => _unknownVocabularies = value;
+		return UnknownVocabularies ?? Get(culture);
 	}
 }

--- a/Yaml2JsonNode.Tests/ClientTests.cs
+++ b/Yaml2JsonNode.Tests/ClientTests.cs
@@ -19,7 +19,7 @@ public class ClientTests
 		var yamlText = YamlSerializer.Serialize(yaml: yaml);
 
 		var jsonRoundTripped = YamlSerializer.Parse(yamlText).Single().ToJsonNode();
-		var jsonRoundText = jsonRoundTripp!ed.ToJsonString();
+		var jsonRoundText = jsonRoundTripped!.ToJsonString();
 
 		Console.WriteLine("# jsonText:");
 		Console.WriteLine(jsonText);

--- a/Yaml2JsonNode.Tests/ClientTests.cs
+++ b/Yaml2JsonNode.Tests/ClientTests.cs
@@ -19,7 +19,7 @@ public class ClientTests
 		var yamlText = YamlSerializer.Serialize(yaml: yaml);
 
 		var jsonRoundTripped = YamlSerializer.Parse(yamlText).Single().ToJsonNode();
-		var jsonRoundText = jsonRoundTripped.ToJsonString();
+		var jsonRoundText = jsonRoundTripp!ed.ToJsonString();
 
 		Console.WriteLine("# jsonText:");
 		Console.WriteLine(jsonText);

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-unique-keys.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-unique-keys.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net.UniqueKeys
 icon: fas fa-tag
 order: "8.05"
 ---
+# [3.0.1](https://github.com/gregsdennis/json-everything/pull/499) {#release-schemadata-3.0.1}
+
+Update error message usage IAW JsonSchema.Net v5.1.0.
+
 # [3.0.0](https://github.com/gregsdennis/json-everything/pull/316) {#release-schemadata-3.0.0}
 
 Updated in accordance with JsonSchema.Net v5.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "8.01"
 ---
+# [5.1.0](https://github.com/gregsdennis/json-everything/pull/499) {#release-schema-5.1.0}
+
+[#493](https://github.com/gregsdennis/json-everything/issues/493) - Add support for reporting error messages in multiple cultures in parallel.  Thanks to [@m-adamkiewicz](https://github.com/m-adamkiewicz) for the suggestion.
+
 # [5.0.0](https://github.com/gregsdennis/json-everything/pull/494) {#release-schema-5.0.0}
 
 New architecture for keyword evaluation that uses static analysis to save some evaluation work, thus reducing execution times and memory allocations significantly.


### PR DESCRIPTION
Resolves #493

@m-adamkiewicz, this should resolve you.  I don't think there are any breaking changes as the significant stuff is internal.  Basically it adds `EvaluationOptions.Culture` that you can set instead of `ErrorMessages.Culture`.  It will fall back to the static setting when the option isn't set.