### PR TITLE
Schema/codegen serialization

### DIFF
--- a/JsonPointer/JsonPointer.cs
+++ b/JsonPointer/JsonPointer.cs
@@ -27,6 +27,9 @@ public class JsonPointer : IEquatable<JsonPointer>
 			Segments = Array.Empty<PointerSegment>()
 		};
 
+	private string? _uriEncoded;
+	private string? _plain;
+
 	/// <summary>
 	/// Gets the collection of pointer segments.
 	/// </summary>
@@ -349,9 +352,9 @@ public class JsonPointer : IEquatable<JsonPointer>
 			return sb.ToString();
 		}
 
-		return BuildString(pointerStyle != JsonPointerStyle.UriEncoded
-			? new StringBuilder()
-			: new StringBuilder("#"));
+		return pointerStyle != JsonPointerStyle.UriEncoded
+			? _plain ??= BuildString(new StringBuilder())
+			: _uriEncoded ??= BuildString(new StringBuilder("#"));
 	}
 
 	/// <summary>Returns the string representation of this instance.</summary>

--- a/JsonPointer/JsonPointer.csproj
+++ b/JsonPointer/JsonPointer.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Json.Pointer</RootNamespace>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.2.0</FileVersion>
+    <FileVersion>3.0.3.0</FileVersion>
     <PackageId>JsonPointer.Net</PackageId>
     <Authors>Greg Dennis</Authors>
     <Product>JsonPointer.Net</Product>

--- a/JsonSchema.CodeGeneration.Tests/AssertHelpers.cs
+++ b/JsonSchema.CodeGeneration.Tests/AssertHelpers.cs
@@ -1,10 +1,20 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.More;
 using Json.Schema.CodeGeneration.Language;
 
 namespace Json.Schema.CodeGeneration.Tests;
 
 public static class AssertHelpers
 {
+	private static readonly JsonSerializerOptions _options =
+		new()
+		{
+			WriteIndented = true,
+			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+		};
+
 	public static string VerifyCSharp(JsonSchema schema, string expected, EvaluationOptions? options = null)
 	{
 		var code = schema.GenerateCode(CodeWriters.CSharp, options);
@@ -23,6 +33,12 @@ public static class AssertHelpers
 		var targetType = assembly!.DefinedTypes.First();
 		var model = JsonSerializer.Deserialize(json, targetType);
 		Assert.NotNull(model);
+
+		var node = JsonNode.Parse(json);
+		var returnToNode = JsonSerializer.SerializeToNode(model);
+
+		Console.WriteLine(returnToNode.AsJsonString(_options));
+		Assert.True(node.IsEquivalentTo(returnToNode));
 	}
 
 	public static void VerifyFailure(JsonSchema schema, EvaluationOptions? options = null)

--- a/JsonSchema.CodeGeneration.Tests/AssertHelpers.cs
+++ b/JsonSchema.CodeGeneration.Tests/AssertHelpers.cs
@@ -1,15 +1,28 @@
+using System.Text.Json;
 using Json.Schema.CodeGeneration.Language;
 
 namespace Json.Schema.CodeGeneration.Tests;
 
 public static class AssertHelpers
 {
-	public static void VerifyCSharp(JsonSchema schema, string expected, EvaluationOptions? options = null)
+	public static string VerifyCSharp(JsonSchema schema, string expected, EvaluationOptions? options = null)
 	{
 		var code = schema.GenerateCode(CodeWriters.CSharp, options);
 
 		Console.WriteLine(code);
 		Assert.AreEqual(expected, code);
+
+		return code;
+	}
+
+	public static void VerifyDeserialization(string code, string json)
+	{
+		var assembly = Compiler.Compile(code);
+		Assert.NotNull(assembly, "Could not compile assembly");
+
+		var targetType = assembly!.DefinedTypes.First();
+		var model = JsonSerializer.Deserialize(json, targetType);
+		Assert.NotNull(model);
 	}
 
 	public static void VerifyFailure(JsonSchema schema, EvaluationOptions? options = null)

--- a/JsonSchema.CodeGeneration.Tests/Compiler.cs
+++ b/JsonSchema.CodeGeneration.Tests/Compiler.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Json.Schema.CodeGeneration.Tests;
+
+public static class Compiler
+{
+	private static readonly List<MetadataReference> _references;
+
+	static Compiler()
+	{
+		var refs = AppDomain.CurrentDomain.GetAssemblies();
+		var references = new List<MetadataReference>();
+
+		foreach (var reference in refs.Where(x => !x.IsDynamic))
+		{
+			var stream = File.Open(reference.Location, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+			references.Add(MetadataReference.CreateFromStream(stream));
+		}
+
+		_references = references;
+	}
+
+
+	public static Assembly? Compile(string source)
+	{
+		var fullSource = $@"
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Json.Schema;
+using Json.Schema.CodeGeneration;
+
+namespace JsonEverythingTest;
+
+{source}
+";
+
+		var syntaxTree = CSharpSyntaxTree.ParseText(fullSource);
+		var assemblyPath = Path.ChangeExtension(Path.GetTempFileName(), "dll");
+
+		var compilation = CSharpCompilation.Create(Path.GetFileName(assemblyPath))
+			.WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+			.AddReferences(_references)
+			.AddSyntaxTrees(syntaxTree);
+
+		using var dllStream = new MemoryStream();
+		using var pdbStream = new MemoryStream();
+		var emitResult = compilation.Emit(dllStream, pdbStream);
+		if (!emitResult.Success)
+		{
+			foreach (var diagnostic in emitResult.Diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error))
+			{
+				Console.WriteLine(JsonSerializer.Serialize(diagnostic, new JsonSerializerOptions { WriteIndented = true }));
+			}
+			return null;
+		}
+
+		var assembly = Assembly.Load(dllStream.ToArray());
+
+		return assembly;
+	}
+}

--- a/JsonSchema.CodeGeneration.Tests/ComplexDeclarationTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/ComplexDeclarationTests.cs
@@ -36,17 +36,19 @@ public class FooBar
 		var code = VerifyCSharp(schema, expected);
 
 		var json = @"{
-  ""Alpha"": {
-    ""Foo"": false,
-    ""Bar"": ""a string""
-  },
-  ""Beta"": {
-    ""Foo"": true,
-    ""Bar"": ""another string""
-  },
-  ""Gamma"": {
-    ""Foo"": false,
-    ""Bar"": ""a different string""
+  ""ObjectDictionary"": {
+    ""Alpha"": {
+      ""Foo"": false,
+      ""Bar"": ""a string""
+    },
+    ""Beta"": {
+      ""Foo"": true,
+      ""Bar"": ""another string""
+    },
+    ""Gamma"": {
+      ""Foo"": false,
+      ""Bar"": ""a different string""
+    }
   }
 }";
 

--- a/JsonSchema.CodeGeneration.Tests/ComplexDeclarationTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/ComplexDeclarationTests.cs
@@ -33,7 +33,24 @@ public class FooBar
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = @"{
+  ""Alpha"": {
+    ""Foo"": false,
+    ""Bar"": ""a string""
+  },
+  ""Beta"": {
+    ""Foo"": true,
+    ""Bar"": ""another string""
+  },
+  ""Gamma"": {
+    ""Foo"": false,
+    ""Bar"": ""a different string""
+  }
+}";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]
@@ -76,7 +93,30 @@ public class FooBar
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = @"{
+  ""ObjectDictionary"": {
+    ""Alpha"": {
+      ""Foo"": false,
+      ""Bar"": ""a string""
+    },
+    ""Beta"": {
+      ""Foo"": true,
+      ""Bar"": ""another string""
+    },
+    ""Gamma"": {
+      ""Foo"": false,
+      ""Bar"": ""a different string""
+    }
+  },
+  ""SingleObject"": {
+    ""Foo"": true,
+    ""Bar"": ""a single object""
+  }
+}";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]

--- a/JsonSchema.CodeGeneration.Tests/JsonSchema.CodeGeneration.Tests.csproj
+++ b/JsonSchema.CodeGeneration.Tests/JsonSchema.CodeGeneration.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/JsonSchema.CodeGeneration.Tests/NamingTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/NamingTests.cs
@@ -16,9 +16,13 @@ public class NamingTests
 			);
 		var expected = @"public class MyObject
 {
+	[JsonProperty(""foo"")]
 	public int Foo { get; set; }
+	[JsonProperty(""foo-bar"")]
 	public int FooBar { get; set; }
+	[JsonProperty(""bar_baz"")]
 	public int BarBaz { get; set; }
+	[JsonProperty(""just-a-letter"")]
 	public int JustALetter { get; set; }
 }
 ";

--- a/JsonSchema.CodeGeneration.Tests/NamingTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/NamingTests.cs
@@ -16,13 +16,13 @@ public class NamingTests
 			);
 		var expected = @"public class MyObject
 {
-	[JsonProperty(""foo"")]
+	[JsonPropertyName(""foo"")]
 	public int Foo { get; set; }
-	[JsonProperty(""foo-bar"")]
+	[JsonPropertyName(""foo-bar"")]
 	public int FooBar { get; set; }
-	[JsonProperty(""bar_baz"")]
+	[JsonPropertyName(""bar_baz"")]
 	public int BarBaz { get; set; }
-	[JsonProperty(""just-a-letter"")]
+	[JsonPropertyName(""just-a-letter"")]
 	public int JustALetter { get; set; }
 }
 ";

--- a/JsonSchema.CodeGeneration.Tests/NamingTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/NamingTests.cs
@@ -27,7 +27,16 @@ public class NamingTests
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = @"{
+  ""foo"": 42,
+  ""foo-bar"": 43,
+  ""bar_baz"": 44,
+  ""just-a-letter"": 45
+}";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]

--- a/JsonSchema.CodeGeneration.Tests/SimpleDeclarationTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/SimpleDeclarationTests.cs
@@ -92,7 +92,11 @@ public class SimpleDeclarationTests
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = "1";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]
@@ -119,7 +123,11 @@ public class SimpleDeclarationTests
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = "[\"one\", \"two\", \"three\"]";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]
@@ -141,7 +149,11 @@ public class SimpleDeclarationTests
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = "{\"Alpha\": 4.2, \"Beta\": 42, \"Gamma\": true }";
+
+		VerifyDeserialization(code, json);
 	}
 
 	[Test]
@@ -210,6 +222,10 @@ public class SimpleDeclarationTests
 }
 ";
 
-		VerifyCSharp(schema, expected);
+		var code = VerifyCSharp(schema, expected);
+
+		var json = "{\"Alpha\": 4.2, \"Beta\": 42, \"Gamma\": 4.5 }";
+
+		VerifyDeserialization(code, json);
 	}
 }

--- a/JsonSchema.CodeGeneration.Tests/SimpleDeclarationTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/SimpleDeclarationTests.cs
@@ -145,6 +145,48 @@ public class SimpleDeclarationTests
 	}
 
 	[Test]
+	public void ObjectWithReadOnlyProp()
+	{
+		var schema = new JsonSchemaBuilder()
+			.Title("MyObject")
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("Alpha", new JsonSchemaBuilder()
+					.Type(SchemaValueType.Number)
+					.ReadOnly(true)
+				)
+			);
+		var expected = @"public class MyObject
+{
+	public double Alpha { get; }
+}
+";
+
+		VerifyCSharp(schema, expected);
+	}
+
+	[Test]
+	public void ObjectWithWriteOnlyProp()
+	{
+		var schema = new JsonSchemaBuilder()
+			.Title("MyObject")
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("Alpha", new JsonSchemaBuilder()
+					.Type(SchemaValueType.Number)
+					.WriteOnly(true)
+				)
+			);
+		var expected = @"public class MyObject
+{
+	public double Alpha { set; }
+}
+";
+
+		VerifyCSharp(schema, expected);
+	}
+
+	[Test]
 	public void NamelessDictionary()
 	{
 		var schema = new JsonSchemaBuilder()

--- a/JsonSchema.CodeGeneration.Tests/UnsupportedTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/UnsupportedTests.cs
@@ -225,4 +225,26 @@ public class UnsupportedTests
 
 		VerifyFailure(schema);
 	}
+
+	[Test]
+	public void ObjectWithBothReadOnlyAndWriteOnlyProp()
+	{
+		var schema = new JsonSchemaBuilder()
+			.Title("MyObject")
+			.Type(SchemaValueType.Object)
+			.Properties(
+				("Alpha", new JsonSchemaBuilder()
+					.Type(SchemaValueType.Number)
+					.ReadOnly(true)
+					.WriteOnly(true)
+				)
+			);
+		var expected = @"public class MyObject
+{
+	public double Alpha { set; }
+}
+";
+
+		VerifyFailure(schema);
+	}
 }

--- a/JsonSchema.CodeGeneration.Tests/UnsupportedTests.cs
+++ b/JsonSchema.CodeGeneration.Tests/UnsupportedTests.cs
@@ -239,11 +239,6 @@ public class UnsupportedTests
 					.WriteOnly(true)
 				)
 			);
-		var expected = @"public class MyObject
-{
-	public double Alpha { set; }
-}
-";
 
 		VerifyFailure(schema);
 	}

--- a/JsonSchema.CodeGeneration/JsonSchema.CodeGeneration.csproj
+++ b/JsonSchema.CodeGeneration/JsonSchema.CodeGeneration.csproj
@@ -18,8 +18,8 @@
 	  <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
 	  <RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
 	  <PackageTags>json-schema schema json code generation codegen</PackageTags>
-	  <Version>0.1.0</Version>
-	  <FileVersion>0.1.0.0</FileVersion>
+	  <Version>0.1.1</Version>
+	  <FileVersion>0.1.1.0</FileVersion>
 	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
 	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	  <PackageIcon>json-logo-256.png</PackageIcon>

--- a/JsonSchema.CodeGeneration/Language/CSharpCodeWriter.cs
+++ b/JsonSchema.CodeGeneration/Language/CSharpCodeWriter.cs
@@ -7,8 +7,6 @@ namespace Json.Schema.CodeGeneration.Language;
 
 internal class CSharpCodeWriter : ICodeWriter
 {
-	public bool IncludeDataAnnotations { get; set; }
-
 	public string? TransformName(string? original) => original?.Underscore().Pascalize();
 
 	public void Write(StringBuilder builder, TypeModel model)

--- a/JsonSchema.CodeGeneration/Language/CSharpCodeWriter.cs
+++ b/JsonSchema.CodeGeneration/Language/CSharpCodeWriter.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Humanizer;
 using Json.Schema.CodeGeneration.Model;
@@ -9,63 +7,16 @@ namespace Json.Schema.CodeGeneration.Language;
 
 internal class CSharpCodeWriter : ICodeWriter
 {
-	private static string? Transform(string? original) => original?.Underscore().Pascalize();
+	public bool IncludeDataAnnotations { get; set; }
+
+	public string? TransformName(string? original) => original?.Underscore().Pascalize();
 
 	public void Write(StringBuilder builder, TypeModel model)
 	{
-		var allModels = CollectModels(model)
-			.Distinct()
-			.GroupBy(x => Transform(x.Name))
-			.ToArray();
-		var duplicateNames = allModels.Where(x => x.Key != null && x.Count() != 1);
-
-		// ReSharper disable PossibleMultipleEnumeration
-		if (duplicateNames.Any())
-		{
-			var names = string.Join(",", duplicateNames.Select(x => x.Key));
-			// ReSharper restore PossibleMultipleEnumeration
-			throw new UnsupportedSchemaException($"Found multiple definitions for the names [{names}]");
-		}
-
-		foreach (var singleModel in allModels.Where(x => x.Key != null))
-		{
-			WriteDeclaration(builder, singleModel.Single());
-		}
+		WriteDeclaration(builder, model);
 	}
 
-	private static IEnumerable<TypeModel> CollectModels(TypeModel model)
-	{
-		var found = new List<TypeModel>();
-		var toCheck = new Queue<TypeModel>();
-		toCheck.Enqueue(model);
-		while (toCheck.Count != 0)
-		{
-			var current = toCheck.Dequeue();
-			if (found.Contains(current)) continue;
-
-			found.Add(current);
-			switch (current)
-			{
-				case ArrayModel arrayModel:
-					toCheck.Enqueue(arrayModel.Items);
-					break;
-				case ObjectModel objectModel:
-					foreach (var propertyModel in objectModel.Properties)
-					{
-						toCheck.Enqueue(propertyModel.Type);
-					}
-					break;
-				case DictionaryModel dictionaryModel:
-					toCheck.Enqueue(dictionaryModel.Keys);
-					toCheck.Enqueue(dictionaryModel.Items); 
-					break;
-			}
-		}
-
-		return found;
-	}
-
-	private static void WriteUsage(StringBuilder builder, TypeModel model)
+	private void WriteUsage(StringBuilder builder, TypeModel model)
 	{
 		if (model.IsSimple)
 		{
@@ -84,7 +35,7 @@ internal class CSharpCodeWriter : ICodeWriter
 
 		if (model.Name != null)
 		{
-			builder.Append(Transform(model.Name));
+			builder.Append(TransformName(model.Name));
 			return;
 		}
 
@@ -102,7 +53,7 @@ internal class CSharpCodeWriter : ICodeWriter
 		}
 	}
 
-	private static void WriteDeclaration(StringBuilder builder, TypeModel model)
+	private void WriteDeclaration(StringBuilder builder, TypeModel model)
 	{
 		if (model.Name == null) return;
 		if (model.IsSimple) return;
@@ -136,18 +87,18 @@ internal class CSharpCodeWriter : ICodeWriter
 		}
 	}
 
-	private static void WriteDeclaration(StringBuilder builder, EnumModel model)
+	private void WriteDeclaration(StringBuilder builder, EnumModel model)
 	{
 		void WriteValue(EnumValue value)
 		{
 			builder.Append("\t");
-			builder.Append(Transform(value.Name));
+			builder.Append(TransformName(value.Name));
 			builder.Append(" = ");
 			builder.Append(value.Value);
 		}
 
 		builder.Append("public enum ");
-		builder.AppendLine(Transform(model.Name));
+		builder.AppendLine(TransformName(model.Name));
 		builder.AppendLine("{");
 		for (var i = 0; i < model.Values.Length - 1; i++)
 		{
@@ -160,16 +111,16 @@ internal class CSharpCodeWriter : ICodeWriter
 		builder.AppendLine("}");
 	}
 
-	private static void WriteUsage(StringBuilder builder, ArrayModel model)
+	private void WriteUsage(StringBuilder builder, ArrayModel model)
 	{
 		WriteUsage(builder, model.Items);
 		builder.Append("[]");
 	}
 
-	private static void WriteDeclaration(StringBuilder builder, ArrayModel model)
+	private void WriteDeclaration(StringBuilder builder, ArrayModel model)
 	{
 		builder.Append("public class ");
-		builder.Append(Transform(model.Name));
+		builder.Append(TransformName(model.Name));
 		builder.Append(" : List<");
 		WriteUsage(builder, model.Items);
 		builder.AppendLine(">");
@@ -177,17 +128,24 @@ internal class CSharpCodeWriter : ICodeWriter
 		builder.AppendLine("}");
 	}
 
-	private static void WriteDeclaration(StringBuilder builder, ObjectModel model)
+	private void WriteDeclaration(StringBuilder builder, ObjectModel model)
 	{
 		builder.Append("public class ");
-		builder.AppendLine(Transform(model.Name));
+		builder.AppendLine(TransformName(model.Name));
 		builder.AppendLine("{");
 		foreach (var property in model.Properties)
 		{
+			var propertyName = TransformName(property.Name);
+			if (propertyName != property.Name)
+			{
+				builder.Append("\t[JsonPropertyName(\"");
+				builder.Append(property.Name);
+				builder.AppendLine("\")]");
+			}
 			builder.Append("\tpublic ");
 			WriteUsage(builder, property.Type);
 			builder.Append(" ");
-			builder.Append(Transform(property.Name));
+			builder.Append(TransformName(property.Name));
 			builder.Append(" { ");
 			if (property.CanRead)
 				builder.Append("get; ");
@@ -198,7 +156,7 @@ internal class CSharpCodeWriter : ICodeWriter
 		builder.AppendLine("}");
 	}
 
-	private static void WriteUsage(StringBuilder builder, DictionaryModel model)
+	private void WriteUsage(StringBuilder builder, DictionaryModel model)
 	{
 		builder.Append("Dictionary<");
 		WriteUsage(builder, model.Keys);
@@ -207,10 +165,10 @@ internal class CSharpCodeWriter : ICodeWriter
 		builder.Append(">");
 	}
 
-	private static void WriteDeclaration(StringBuilder builder, DictionaryModel model)
+	private void WriteDeclaration(StringBuilder builder, DictionaryModel model)
 	{
 		builder.Append("public class ");
-		builder.Append(Transform(model.Name));
+		builder.Append(TransformName(model.Name));
 		builder.Append(" : Dictionary<");
 		WriteUsage(builder, model.Keys);
 		builder.Append(", ");

--- a/JsonSchema.CodeGeneration/Language/ICodeWriter.cs
+++ b/JsonSchema.CodeGeneration/Language/ICodeWriter.cs
@@ -9,11 +9,19 @@ namespace Json.Schema.CodeGeneration.Language;
 public interface ICodeWriter
 {
 	/// <summary>
-	/// Converts the type model into code text.
+	/// Transforms a name as it appears in a JSON string into a language-appropriate type or member name.
+	/// </summary>
+	/// <param name="original">The JSON string.</param>
+	/// <returns>The transformed name, or null if the string is unsupported.</returns>
+	string? TransformName(string? original);
+
+	/// <summary>
+	/// Converts a single type model into code text.
 	/// </summary>
 	/// <param name="builder">A string builder.</param>
 	/// <param name="model">A type model.</param>
 	void Write(StringBuilder builder, TypeModel model);
+
 }
 
 /// <summary>

--- a/JsonSchema.CodeGeneration/Model/ModelGenerator.cs
+++ b/JsonSchema.CodeGeneration/Model/ModelGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Json.More;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,10 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "8.10"
 ---
+# [3.0.3](https://github.com/gregsdennis/json-everything/pull/509) {#release-pointer-3.0.3}
+
+Improved performance for `JsonPointer.ToString()` by caching the string representation so that it's only generated once.
+
 # [3.0.2](https://github.com/gregsdennis/json-everything/pull/492) {#release-pointer-3.0.2}
 
 Memory and performance improvements.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-codegeneration.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-codegeneration.md
@@ -4,6 +4,14 @@ title: JsonSchema.Net.CodeGeneration
 icon: fas fa-tag
 order: "8.03"
 ---
-# [0.1.0](https://github.com/gregsdennis/json-everything/pull/???) {#release-schemacodegen-0.1.0}
+# [0.1.1](https://github.com/gregsdennis/json-everything/pull/509) {#release-schemacodegen-0.1.1}
+
+Added `[JsonPropertyName]` attribute usage to support custom JSON keys during deserialization.
+
+Add support for `readOnly` and `writeOnly` to generate getter/setter-only properties.
+
+Improved testing to ensure code actually compiles and is usable.
+
+# [0.1.0](https://github.com/gregsdennis/json-everything/pull/505) {#release-schemacodegen-0.1.0}
 
 Initial release.


### PR DESCRIPTION
Was planning on adding data-annotations-type validation on this, but it's not going to be in this version.  Need to think a bit more if that's what I want to support.  (The serializer doesn't support it, so why generate it?)