### PR TITLE
fix: make sure the sub schema cache is thread-safe for JsonNodeBaseDocument

### DIFF
--- a/JsonSchema/JsonNodeBaseDocument.cs
+++ b/JsonSchema/JsonNodeBaseDocument.cs
@@ -49,11 +49,9 @@ public class JsonNodeBaseDocument : IBaseDocument
 	{
 		return _foundSubschemas.GetOrAdd(pointer, jsonPointer =>
 		{
-			if (_foundSubschemas.TryGetValue(jsonPointer, out var schema)) return schema;
-
 			if (!jsonPointer.TryEvaluate(_node, out var location)) return null;
 
-			schema = location.Deserialize<JsonSchema>();
+			var schema = location.Deserialize<JsonSchema>();
 			if (schema != null)
 				JsonSchema.Initialize(schema, options.SchemaRegistry, BaseUri);
 

--- a/JsonSchema/JsonNodeBaseDocument.cs
+++ b/JsonSchema/JsonNodeBaseDocument.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Pointer;
@@ -12,7 +12,7 @@ namespace Json.Schema;
 public class JsonNodeBaseDocument : IBaseDocument
 {
 	private readonly JsonNode _node;
-	private readonly Dictionary<JsonPointer, JsonSchema?> _foundSubschemas;
+	private readonly ConcurrentDictionary<JsonPointer, JsonSchema?> _foundSubschemas;
 
 	/// <summary>
 	/// Gets the base URI that applies to this schema.  This may be defined by a parent schema.
@@ -34,7 +34,7 @@ public class JsonNodeBaseDocument : IBaseDocument
 	public JsonNodeBaseDocument(JsonNode node, Uri baseUri)
 	{
 		_node = node;
-		_foundSubschemas = new Dictionary<JsonPointer, JsonSchema?>();
+		_foundSubschemas = new ConcurrentDictionary<JsonPointer, JsonSchema?>();
 
 		BaseUri = baseUri;
 	}
@@ -47,16 +47,17 @@ public class JsonNodeBaseDocument : IBaseDocument
 	/// <returns>A JSON Schema, if found.</returns>
 	public JsonSchema? FindSubschema(JsonPointer pointer, EvaluationOptions options)
 	{
-		if (_foundSubschemas.TryGetValue(pointer, out var schema)) return schema;
+		return _foundSubschemas.GetOrAdd(pointer, jsonPointer =>
+		{
+			if (_foundSubschemas.TryGetValue(jsonPointer, out var schema)) return schema;
 
-		if (!pointer.TryEvaluate(_node, out var location)) return null;
+			if (!jsonPointer.TryEvaluate(_node, out var location)) return null;
 
-		schema = location.Deserialize<JsonSchema>();
-		if (schema != null) 
-			JsonSchema.Initialize(schema, options.SchemaRegistry, BaseUri);
+			schema = location.Deserialize<JsonSchema>();
+			if (schema != null)
+				JsonSchema.Initialize(schema, options.SchemaRegistry, BaseUri);
 
-		_foundSubschemas[pointer] = schema;
-
-		return schema;
+			return schema;
+		});
 	}
 }


### PR DESCRIPTION
We've seen concurrency problems in `JsonNodeBaseDocument` that this should fix.
Example:
```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
     at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
     at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
     at Json.Schema.JsonNodeBaseDocument.FindSubschema(JsonPointer pointer, EvaluationOptions options)
     at Json.Schema.RefKeyword.Evaluate(EvaluationContext context)
     at Json.Schema.EvaluationContext.Evaluate()
```