### PR TITLE
support for + in number literals

### DIFF
--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -20,8 +20,8 @@
 		<PackageIcon>json-logo-256.png</PackageIcon>
 		<PackageTags>json-path jsonpath query path json</PackageTags>
 		<PackageReleaseNotes>Release notes can be found at https://docs.json-everything.net/rn-json-path/</PackageReleaseNotes>
-		<Version>0.6.5</Version>
-		<FileVersion>0.6.5.0</FileVersion>
+		<Version>0.6.6</Version>
+		<FileVersion>0.6.6.0</FileVersion>
 		<AssemblyVersion>0.6.0.0</AssemblyVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonPath.Net.xml</DocumentationFile>

--- a/JsonPath/SpanExtensions.cs
+++ b/JsonPath/SpanExtensions.cs
@@ -100,9 +100,9 @@ internal static class SpanExtensions
 					end = i;
 					var allowDash = true;
 					while (end < span.Length && (span[end].In('0'..('9' + 1)) ||
-												 span[end].In('e', '.', '-')))
+												 span[end].In('e', '.', '-', '+')))
 					{
-						if (!allowDash && span[end] == '-') break;
+						if (!allowDash && span[end] is '-' or '+') break;
 						allowDash = span[end] == 'e';
 						end++;
 					}

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,6 +4,10 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "8.08"
 ---
+# [0.6.6](https://github.com/gregsdennis/json-everything/pull/515) {#release-path-0.6.6}
+
+Adds support for `+` in number literals, e.g. `+24` and `1e+5`.
+
 # [0.6.5](https://github.com/gregsdennis/json-everything/pull/515) {#release-path-0.6.5}
 
 Update `.AsJsonPointer()` to allow `$[1,"1"]` pattern discussed in https://blog.json-everything.net/posts/paths-and-pointers-correction/.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,7 +4,7 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "8.08"
 ---
-# [0.6.6](https://github.com/gregsdennis/json-everything/pull/515) {#release-path-0.6.6}
+# [0.6.6](https://github.com/gregsdennis/json-everything/pull/524) {#release-path-0.6.6}
 
 Adds support for `+` in number literals, e.g. `+24` and `1e+5`.
 


### PR DESCRIPTION
Found via https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/50