### PR TITLE
[WIP] Add basic POC to build Expression tree for and/or, variable and literal rules.

### DIFF
--- a/JsonLogic.Tests/StrictEqualsTests.cs
+++ b/JsonLogic.Tests/StrictEqualsTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
 using Json.Logic.Rules;
 using NUnit.Framework;
 
@@ -27,5 +30,52 @@ public class StrictEqualsTests
 		var rule = new StrictEqualsRule(1, "1");
 
 		JsonAssert.IsFalse(rule.Apply());
+	}
+
+
+	[Test]
+	public void BuildExpression()
+	{
+		var parameter = Expression.Parameter(typeof(TestData), "x");
+		var literalRule = new LiteralRule("Hello");
+		var literalExpression = literalRule.BuildExpressionPredicate<TestData>(parameter);
+
+		var variableRule = new VariableRule("Name");
+		var variableExpression = variableRule.BuildExpressionPredicate<TestData>(parameter);
+
+		var rule = new StrictEqualsRule(variableRule, literalRule);
+		var rule2 = new StrictEqualsRule(variableRule, new LiteralRule("Hai"));
+		var rule3 = new StrictEqualsRule(variableRule, new LiteralRule("Hola"));
+
+		var orRule = new OrRule(rule, rule2, rule3);
+
+		var expression = orRule.BuildExpressionPredicate<TestData>(parameter);
+		Console.WriteLine(expression);
+
+		var data = GetData();
+
+		var lambda = Expression.Lambda<Func<TestData, bool>>(expression, parameter);
+		var query = data.Where(lambda);
+		var results = query.ToList();
+
+		Assert.That(results, Has.Count.EqualTo(3));
+		Assert.That(expression.ToString(), Is.EqualTo("(((x.Name == \"Hello\") OrElse (x.Name == \"Hai\")) OrElse (x.Name == \"Hola\"))"));
+	}
+
+	private static IQueryable<TestData> GetData()
+	{
+		return new TestData[]
+		{
+			new TestData() { Name = "Hello" },
+			new TestData() { Name = "Hai" },
+			new TestData() { Name = "Bonjour" },
+			new TestData() { Name = "Hola" },
+			new TestData() { Name = "Buongiorno" },
+		}.AsQueryable();
+	}
+
+	public class TestData
+	{
+		public string Name { get; set; }
 	}
 }

--- a/JsonLogic/Rule.cs
+++ b/JsonLogic/Rule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -26,6 +27,17 @@ public abstract class Rule
 	/// </param>
 	/// <returns>The result of the rule.</returns>
 	public abstract JsonNode? Apply(JsonNode? data, JsonNode? contextData = null);
+
+	/// <summary>
+	/// Build expression trees for LINQ goodness.
+	/// </summary>
+	/// <param name="parameter">The parameter to build the expression for.</param>
+	/// <returns>An expression if it's supported</returns>
+	/// <exception cref="NotImplementedException">If the rule does not support expressions.</exception>
+	public virtual Expression BuildExpressionPredicate<T>(ParameterExpression parameter)
+	{
+		throw new NotImplementedException($"{this.GetType().Name} does not implement Expression building");
+	}
 
 	/// <summary>
 	/// Casts a JSON value to a <see cref="LiteralRule"/>.

--- a/JsonLogic/Rules/AndRule.cs
+++ b/JsonLogic/Rules/AndRule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -50,6 +51,29 @@ public class AndRule : Rule
 		}
 
 		return first;
+	}
+
+	/// <inheritdoc />
+	public override Expression BuildExpressionPredicate<T>(ParameterExpression parameter)
+	{
+		if (this.Items.Count == 0)
+		{
+			throw new NotSupportedException("Need at least 1 clause for `and` rule");
+		}
+
+		if (this.Items.Count == 1)
+		{
+			return this.Items[0].BuildExpressionPredicate<T>(parameter);
+		}
+
+		var firstOr = Expression.AndAlso(this.Items[0].BuildExpressionPredicate<T>(parameter), this.Items[1].BuildExpressionPredicate<T>(parameter));
+
+		foreach (var rule in this.Items.Skip(2))
+		{
+			firstOr = Expression.AndAlso(firstOr, rule.BuildExpressionPredicate<T>(parameter));
+		}
+
+		return firstOr;
 	}
 }
 

--- a/JsonLogic/Rules/LiteralRule.cs
+++ b/JsonLogic/Rules/LiteralRule.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -35,6 +37,13 @@ public class LiteralRule : Rule
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
 		return Value;
+	}
+
+	/// <inheritdoc />
+	public override Expression BuildExpressionPredicate<T>(ParameterExpression parameter)
+	{
+		var value = this.Value?.GetValue<object>();
+		return Expression.Constant(value);
 	}
 }
 

--- a/JsonLogic/Rules/OrRule.cs
+++ b/JsonLogic/Rules/OrRule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -50,6 +51,29 @@ public class OrRule : Rule
 		}
 
 		return first;
+	}
+
+	/// <inheritdoc />
+	public override Expression BuildExpressionPredicate<T>(ParameterExpression parameter)
+	{
+		if (this.Items.Count == 0)
+		{
+			throw new NotSupportedException("Need at least 1 clause for `or` rule");
+		}
+
+		if (this.Items.Count == 1)
+		{
+			return this.Items[0].BuildExpressionPredicate<T>(parameter);
+		}
+
+		var firstOr = Expression.OrElse(this.Items[0].BuildExpressionPredicate<T>(parameter), this.Items[1].BuildExpressionPredicate<T>(parameter));
+
+		foreach (var rule in this.Items.Skip(2))
+		{
+			firstOr = Expression.OrElse(firstOr, rule.BuildExpressionPredicate<T>(parameter));
+		}
+
+		return firstOr;
 	}
 }
 

--- a/JsonLogic/Rules/StrictEqualsRule.cs
+++ b/JsonLogic/Rules/StrictEqualsRule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -45,6 +46,12 @@ public class StrictEqualsRule : Rule
 	public override JsonNode? Apply(JsonNode? data, JsonNode? contextData = null)
 	{
 		return A.Apply(data, contextData).IsEquivalentTo(B.Apply(data, contextData));
+	}
+
+	/// <inheritdoc />
+	public override Expression BuildExpressionPredicate<T>(ParameterExpression parameter)
+	{
+		return Expression.Equal(this.A.BuildExpressionPredicate<T>(parameter), this.B.BuildExpressionPredicate<T>(parameter));
 	}
 }
 


### PR DESCRIPTION
@gregsdennis Here's a quick POC I made late at night, related to issue https://github.com/gregsdennis/json-everything/issues/552 Get the basics across, the best way to actually do that would probably be a visitor, to reduce the code inside each rule and avoid passing the ParameterExpression in all the nodes.

I made this for fun, but it could be practical for someone else!