### PR TITLE
Better number equality

### DIFF
--- a/Json.More.Tests/DevTest.cs
+++ b/Json.More.Tests/DevTest.cs
@@ -4,7 +4,6 @@ namespace Json.More.Tests;
 
 public class DevTest
 {
-
 	[Test]
 	public void Test()
 	{

--- a/Json.More.Tests/EqualityTests.cs
+++ b/Json.More.Tests/EqualityTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Text.Json.Nodes;
+using NUnit.Framework;
+
+namespace Json.More.Tests;
+
+public class EqualityTests
+{
+	[Test]
+	public void NumbersAreEqualEvenIfOneHasTrailingZero()
+	{
+		JsonNode intFour = 4;
+		JsonNode floatFour = 4.0;
+
+		Assert.IsTrue(intFour.IsEquivalentTo(floatFour));
+	}
+
+	[Test]
+	public void NumbersAreEqualEvenIfOneHasTrailingZero_Decimal()
+	{
+		JsonNode intFour = (decimal) 4;
+		JsonNode floatFour = (decimal) 4.0;
+
+		Assert.IsTrue(intFour.IsEquivalentTo(floatFour));
+	}
+
+	[Test]
+	public void NumbersAreEqualEvenIfOneHasTrailingZero_IntAndDecimal()
+	{
+		JsonNode intFour = 4;
+		JsonNode floatFour = 4.0m;
+
+		Assert.IsTrue(intFour.IsEquivalentTo(floatFour));
+	}
+
+	[Test]
+	public void NumbersAreEqualEvenIfOneHasTrailingZero_Summed()
+	{
+		decimal a = 4;
+		decimal b = (decimal)4.00;
+		JsonNode explicitFour = a;
+		JsonNode summedFour = b;
+
+		Assert.IsTrue(explicitFour.IsEquivalentTo(summedFour));
+	}
+
+	[Test]
+	public void NumbersAreEqualEvenIfOneHasTrailingZero_Parsed()
+	{
+		var intFour = JsonNode.Parse("4");
+		var floatFour = JsonNode.Parse("4.0");
+
+		Assert.IsTrue(intFour.IsEquivalentTo(floatFour));
+	}
+}

--- a/Json.More/Json.More.csproj
+++ b/Json.More/Json.More.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Json.More.Net</PackageId>
     <Authors>Greg Dennis</Authors>
-    <Version>1.9.1</Version>
+    <Version>1.9.2</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.9.1.0</FileVersion>
+    <FileVersion>1.9.2.0</FileVersion>
     <Description>
 		Provides extended functionality for the System.Text.Json namespace.
 	

--- a/Json.More/JsonNodeExtensions.cs
+++ b/Json.More/JsonNodeExtensions.cs
@@ -46,6 +46,11 @@ public static class JsonNodeExtensions
 				if (aValue.GetValue<object>() is JsonElement aElement &&
 					bValue.GetValue<object>() is JsonElement bElement)
 					return aElement.IsEquivalentTo(bElement);
+
+				var aNumber = aValue.GetNumber();
+				var bNumber = bValue.GetNumber();
+				if (aNumber != null) return aNumber == bNumber;
+
 				return a.ToJsonString() == b.ToJsonString();
 			default:
 				return a?.ToJsonString() == b?.ToJsonString();

--- a/tools/ApiDocsGenerator/release-notes/rn-json-more.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-more.md
@@ -4,6 +4,10 @@ title: Json.More.Net
 icon: fas fa-tag
 order: "8.12"
 ---
+# [1.9.2](https://github.com/gregsdennis/json-everything/pull/563) {#release-more-1.9.2}
+
+Fixes an issue with number equality that specifically affects `decimal`s stored in `JsonNode`s.
+
 # [1.9.1](https://github.com/gregsdennis/json-everything/commit/2a1fa87a2a75b56f0b912b70b194f8399acb6d7b) {#release-more-1.9.1}
 
 `JsonNodeExtensions.Copy()` now performs a direct deep copy of the node rather than utilizing the serializer.


### PR DESCRIPTION
Found while implementing json-e.  Apparently `decimal` retains significant digits which becomes apparent when serialized in JSON.  This means that (for the purposes of the equality method) `4m == 4.0m` is false.

This PR updates the equality method to verify value equality for numbers specifically.