### PR TITLE
Make `time-offset` required for `date-time`

### DIFF
--- a/JsonSchema.Tests/FormatTests.cs
+++ b/JsonSchema.Tests/FormatTests.cs
@@ -62,7 +62,7 @@ public class FormatTests
 
 		var result = schema.Evaluate(value, new EvaluationOptions { RequireFormatValidation = true });
 
-		Assert.False(result.IsValid);
+		result.AssertInvalid();
 	}
 
 	private static readonly Uri _formatAssertionMetaSchemaId = new("https://json-everything/test/format-assertion");

--- a/JsonSchema.Tests/FormatTests.cs
+++ b/JsonSchema.Tests/FormatTests.cs
@@ -52,6 +52,19 @@ public class FormatTests
 		Assert.True(result.IsValid);
 	}
 
+	[Test]
+	public void DateTime_MissingTimeOffset_Fail()
+	{
+		JsonSchema schema = new JsonSchemaBuilder()
+			.Format(Formats.DateTime);
+
+		var value = JsonNode.Parse("\"2023-04-28T21:51:26\"");
+
+		var result = schema.Evaluate(value, new EvaluationOptions { RequireFormatValidation = true });
+
+		Assert.False(result.IsValid);
+	}
+
 	private static readonly Uri _formatAssertionMetaSchemaId = new("https://json-everything/test/format-assertion");
 	private static readonly JsonSchema _formatAssertionMetaSchema =
 		new JsonSchemaBuilder()

--- a/JsonSchema/Formats.cs
+++ b/JsonSchema/Formats.cs
@@ -272,7 +272,7 @@ public static class Formats
 		//We use a fallback to catch these cases
 
 		//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
-		var regex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2})?)$");
+		var regex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$");
 		var match = regex.Match(dateString);
 		return match.Success;
 


### PR DESCRIPTION
Resolves https://github.com/gregsdennis/json-everything/issues/570.

The capturing group for `time-offset` (`([Zz]|[\+-]\d{2}:\d{2})`) has the quantifier `?` which allows it to occur zero times or once, effectively making it optional. Removing `?` ensures that it must occur exactly once.