### PR TITLE
add limited support for pattern data generation

### DIFF
--- a/JsonSchema.DataGeneration.Tests/StringGenerationTests.cs
+++ b/JsonSchema.DataGeneration.Tests/StringGenerationTests.cs
@@ -48,7 +48,6 @@ public class StringGenerationTests
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void ContainsDog()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -59,7 +58,6 @@ public class StringGenerationTests
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void ContainsDogWithSizeConstraints()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -68,22 +66,20 @@ public class StringGenerationTests
 			.MinLength(10)
 			.MaxLength(20);
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void DoesNotContainDog()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
 			.Type(SchemaValueType.String)
 			.Not(new JsonSchemaBuilder().Pattern("dog"));
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void DoesNotContainDogWithSizeConstraints()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -92,11 +88,10 @@ public class StringGenerationTests
 			.MinLength(10)
 			.MaxLength(20);
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]
-	[Ignore("not supported by regex lib")]
 	public void ContainsCatAndDoesNotContainDogWithSizeConstraints()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -106,11 +101,10 @@ public class StringGenerationTests
 			.MinLength(10)
 			.MaxLength(20);
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void ContainsEitherCatOrDog()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -122,11 +116,10 @@ public class StringGenerationTests
 			.MinLength(10)
 			.MaxLength(20);
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]
-	[Ignore("regex not supported")]
 	public void ContainsExclusivelyEitherCatOrDog()
 	{
 		JsonSchema schema = new JsonSchemaBuilder()
@@ -138,7 +131,7 @@ public class StringGenerationTests
 			.MinLength(10)
 			.MaxLength(20);
 
-		Run(schema);
+		Assert.Throws<NotSupportedException>(() => Run(schema));
 	}
 
 	[Test]

--- a/JsonSchema.DataGeneration/Generators/StringGenerator.cs
+++ b/JsonSchema.DataGeneration/Generators/StringGenerator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using Bogus;
 using Bogus.Extensions;
-using Json.More;
+using Fare;
 
 namespace Json.Schema.DataGeneration.Generators;
 
@@ -49,6 +49,30 @@ internal class StringGenerator : IDataGenerator
 
 	public GenerationResult Generate(RequirementsContext context)
 	{
+		if (context.Pattern != null)
+		{
+			if (context.StringLengths != null) throw new NotSupportedException("Cannot generate strings that match regex and also specify string lengths");
+
+			string overallRegex = string.Empty;
+
+			//if (context.Patterns != null)
+			//{
+			//	if (context.Patterns.Count == 1)
+			//		overallRegex = context.Patterns[0].ToString();
+			//	else
+			//		overallRegex += HelperExtensions.Require(context.Patterns.Select(x => x.ToString()));
+			//}
+
+			//if (context.AntiPatterns != null)
+			//	overallRegex += HelperExtensions.Forbid(context.AntiPatterns.Select(x => x.ToString()));
+			if (context.Pattern != null)
+				overallRegex = context.Pattern.ToString();
+
+			Console.WriteLine(overallRegex);
+
+			return GenerationResult.Success(new Xeger(overallRegex).Generate());
+		}
+
 		var ranges = context.StringLengths ?? _defaultRange;
 		var range = JsonSchemaExtensions.Randomizer.ArrayElement(ranges.Ranges.ToArray());
 		var minimum = range.Minimum.Value != NumberRangeSet.MinRangeValue
@@ -57,26 +81,6 @@ internal class StringGenerator : IDataGenerator
 		var maximum = range.Maximum.Value != NumberRangeSet.MaxRangeValue
 			? (uint)Math.Min(_maxStringLength, range.Maximum.Value)
 			: Math.Min(_maxStringLength, DefaultMaxLength);
-
-		//var rangeRegex = $".{{{range.Minimum.Value},{range.Maximum.Value}}}";
-
-		//string overallRegex = string.Empty;
-
-		//if (context.Patterns != null)
-		//{
-		//	if (context.Patterns.Count == 1)
-		//		overallRegex = context.Patterns[0].ToString();
-		//	else
-		//		overallRegex += HelperExtensions.Require(context.Patterns.Select(x => x.ToString()));
-		//}
-
-		//if (context.AntiPatterns != null)
-		//	overallRegex += HelperExtensions.Forbid(context.AntiPatterns.Select(x => x.ToString()));
-
-		//overallRegex += rangeRegex;
-		//overallRegex = $"^{overallRegex}$";
-
-		//Console.WriteLine(overallRegex);
 
 		if (context.Format != null)
 		{

--- a/JsonSchema.DataGeneration/HelperExtensions.cs
+++ b/JsonSchema.DataGeneration/HelperExtensions.cs
@@ -5,8 +5,8 @@ namespace Json.Schema.DataGeneration;
 
 internal static class HelperExtensions
 {
-	public static string RequireOne(string pattern) => $@"(?=.*({pattern}))";
-	private static string ForbidOne(string pattern) => $@"(?!.*({pattern}))";
+	public static string RequireOne(string pattern) => $"(?=.*({pattern}))";
+	public static string ForbidOne(string pattern) => $"((?!{pattern}).)*";
 
 	public static string Require(IEnumerable<string> patterns) => string.Concat(patterns.Select(RequireOne));
 	public static string Forbid(IEnumerable<string> patterns) => string.Concat(patterns.Select(ForbidOne));

--- a/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
+++ b/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
@@ -19,8 +19,8 @@
 		<PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
 		<PackageTags>json-schema schema json generation</PackageTags>
-		<Version>1.1.0</Version>
-		<FileVersion>1.0.4.0</FileVersion>
+		<Version>1.2.0</Version>
+		<FileVersion>1.2.0.0</FileVersion>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageIcon>json-logo-256.png</PackageIcon>
@@ -36,6 +36,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="33.1.1" />
+		<PackageReference Include="Fare" Version="2.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -55,10 +56,8 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Copy SourceFiles="$(TargetDir)$(DocumentationFile)" DestinationFolder="..\json-everything.net\wwwroot\xml\"
-		      SkipUnchangedFiles="True" OverwriteReadOnlyFiles="True" />
-		<Copy SourceFiles="$(TargetDir)$(DocumentationFile)" DestinationFolder="..\doc-tool\xml\"
-		      SkipUnchangedFiles="True" OverwriteReadOnlyFiles="True" />
+		<Copy SourceFiles="$(TargetDir)$(DocumentationFile)" DestinationFolder="..\json-everything.net\wwwroot\xml\" SkipUnchangedFiles="True" OverwriteReadOnlyFiles="True" />
+		<Copy SourceFiles="$(TargetDir)$(DocumentationFile)" DestinationFolder="..\doc-tool\xml\" SkipUnchangedFiles="True" OverwriteReadOnlyFiles="True" />
 	</Target>
 
 </Project>

--- a/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
+++ b/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
@@ -34,7 +34,7 @@ internal class StringRequirementsGatherer : IRequirementsGatherer
 			supportsStrings = true;
 		}
 
-		var pattern = schema.Keywords!.OfType<PatternKeyword>().FirstOrDefault()?.Value;
+		var pattern = schema.Keywords?.OfType<PatternKeyword>().FirstOrDefault()?.Value;
 		if (pattern != null)
 		{
 			//context.Patterns ??= new List<Regex>();

--- a/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
+++ b/JsonSchema.DataGeneration/Requirements/StringRequirementsGatherer.cs
@@ -34,12 +34,13 @@ internal class StringRequirementsGatherer : IRequirementsGatherer
 			supportsStrings = true;
 		}
 
-		//var pattern = schema.Keywords!.OfType<PatternKeyword>().FirstOrDefault()?.Value;
-		//if (pattern != null)
-		//{
-		//	context.Patterns ??= new List<Regex>();
-		//	context.Patterns.Add(pattern);
-		//}
+		var pattern = schema.Keywords!.OfType<PatternKeyword>().FirstOrDefault()?.Value;
+		if (pattern != null)
+		{
+			//context.Patterns ??= new List<Regex>();
+			//context.Patterns.Add(pattern);
+			context.Pattern = pattern;
+		}
 
 		if (context.Format != null)
 			context.HasConflict = true;

--- a/JsonSchema.DataGeneration/RequirementsContext.cs
+++ b/JsonSchema.DataGeneration/RequirementsContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Json.More;
 
 namespace Json.Schema.DataGeneration;
@@ -30,6 +31,7 @@ internal class RequirementsContext
 	// https://www.ocpsoft.org/tutorials/regular-expressions/and-in-regex/
 	//public List<Regex>? Patterns { get; set; }
 	//public List<Regex>? AntiPatterns { get; set; }
+	public Regex? Pattern { get; set; }
 	public string? Format { get; set; }
 
 	public List<RequirementsContext>? SequentialItems { get; set; }
@@ -75,6 +77,8 @@ internal class RequirementsContext
 		//	Patterns = other.Patterns.ToList();
 		//if (other.AntiPatterns != null)
 		//	AntiPatterns = other.AntiPatterns.ToList();
+		if (other.Pattern != null)
+			Pattern = other.Pattern;
 
 		if (other.ItemCounts != null)
 			ItemCounts = new NumberRangeSet(other.ItemCounts);
@@ -168,6 +172,9 @@ internal class RequirementsContext
 			//context.Patterns = AntiPatterns;
 			//context.AntiPatterns = Patterns;
 			//return true;
+			if (Pattern != null)
+				throw new NotSupportedException("Cannot generate string against negative pattern");
+
 			return false;
 		}
 
@@ -242,7 +249,7 @@ internal class RequirementsContext
 			return true;
 		}
 
-		var allBreakers = new Func<RequirementsContext, bool>[]
+		var allBreakers = new[]
 		{
 			BreakType,
 			BreakNumberRange,
@@ -320,6 +327,11 @@ internal class RequirementsContext
 		//	AntiPatterns = other.AntiPatterns;
 		//else if (other.AntiPatterns != null)
 		//	AntiPatterns.AddRange(other.AntiPatterns);
+
+		if (Pattern == null)
+			Pattern = other.Pattern;
+		else if (other.Pattern != null)
+			throw new NotSupportedException("Generator only supports `pattern` on a single branch.");
 
 		if (ItemCounts == null || !ItemCounts.Ranges.Any())
 			ItemCounts = other.ItemCounts;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-datageneration.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-datageneration.md
@@ -4,6 +4,16 @@ title: JsonSchema.Net.DataGeneration
 icon: fas fa-tag
 order: "09.04"
 ---
+# [1.2.0](https://github.com/gregsdennis/json-everything/pull/582) {#release-schemadatagen-1.2.0}
+
+[#580](https://github.com/gregsdennis/json-everything/issues/580) - Add support for `pattern` by incorporating [FARE library](https://github.com/moodmosaic/Fare).
+
+Only simple subschemas with a single, simple `pattern` is supported.
+
+- Combining multiple regular expressions using `allOf`, `anyOf`, or `oneOf` is not supported.
+- Inverting regular expressions using `not` is not supported.
+- Any regular expression not supported by the FARE library is not supported.
+
 # 1.1.0 (no PR) {#release-schemadatagen-1.1.0}
 
 Updated JsonSchema.Net reference to v4.0.0.


### PR DESCRIPTION
Resolves #580 

This adds support for basically a single `pattern` keyword.  Combining `pattern` via `anyOf`/`allOf`/`oneOf` or inverting `pattern` via `not` is not supported.