### PR TITLE
Add type converters for JsonPointer and JsonPath

### DIFF
--- a/JsonPath.Tests/TypeConverterTests.cs
+++ b/JsonPath.Tests/TypeConverterTests.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using NUnit.Framework;
+
+namespace Json.Path.Tests
+{
+	public class TypeConverterTests
+	{
+
+		[Test]
+		public void ConvertFromString()
+		{
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPath));
+			var path = typeConverter.ConvertFromInvariantString("$.store.book[*].author") as JsonPath;
+
+			Assert.IsNotNull(path);
+			Assert.AreEqual("$.store.book[*].author", path!.ToString());
+		}
+
+		[Test]
+		public void ConvertToString()
+		{
+			var path = JsonPath.Parse("$.store.book[*].author");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPath));
+			var pathString = typeConverter.ConvertToInvariantString(path);
+
+			Assert.AreEqual("$.store.book[*].author", pathString);
+		}
+
+	}
+}

--- a/JsonPath.Tests/TypeConverterTests.cs
+++ b/JsonPath.Tests/TypeConverterTests.cs
@@ -26,5 +26,29 @@ namespace Json.Path.Tests
 			Assert.AreEqual("$.store.book[*].author", pathString);
 		}
 
+		[Test]
+		public void ConvertFromJsonPath()
+		{
+			var path = JsonPath.Parse("$.store.book[*].author");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPath));
+			var path2 = typeConverter.ConvertFrom(path) as JsonPath;
+
+			Assert.IsNotNull(path2);
+			Assert.AreNotSame(path, path2);
+			Assert.AreEqual("$.store.book[*].author", path2!.ToString());
+		}
+
+		[Test]
+		public void ConvertToJsonPath()
+		{
+			var path = JsonPath.Parse("$.store.book[*].author");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPath));
+			var path2 = typeConverter.ConvertTo(path, typeof(JsonPath)) as JsonPath;
+
+			Assert.IsNotNull(path2);
+			Assert.AreNotSame(path, path2);
+			Assert.AreEqual("$.store.book[*].author", path2!.ToString());
+		}
+
 	}
 }

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -11,6 +12,7 @@ namespace Json.Path;
 /// Represents a JSON Path.
 /// </summary>
 [JsonConverter(typeof(JsonPathConverter))]
+[TypeConverter(typeof(JsonPathTypeConverter))]
 public class JsonPath
 {
 	/// <summary>

--- a/JsonPath/JsonPathTypeConverter.cs
+++ b/JsonPath/JsonPathTypeConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Json.Path
+{
+	/// <summary>
+	/// <see cref="TypeConverter"/> for <see cref="JsonPath"/>.
+	/// </summary>
+	internal sealed class JsonPathTypeConverter : TypeConverter
+	{
+
+		/// <inheritdoc/>
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string);
+		}
+
+		/// <inheritdoc/>
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+		{
+			return destinationType == typeof(string);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value is string s)
+			{
+				return JsonPath.Parse(s);
+			}
+
+			return base.ConvertFrom(context, culture, value);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (destinationType == typeof(string) && value is JsonPath pointer)
+			{
+				return pointer.ToString();
+			}
+
+			return base.ConvertTo(context, culture, value, destinationType);
+		}
+
+	}
+}

--- a/JsonPath/JsonPathTypeConverter.cs
+++ b/JsonPath/JsonPathTypeConverter.cs
@@ -4,22 +4,30 @@ using System.Globalization;
 
 namespace Json.Path
 {
-	/// <summary>
-	/// <see cref="TypeConverter"/> for <see cref="JsonPath"/>.
-	/// </summary>
-	internal sealed class JsonPathTypeConverter : TypeConverter
+  /// <summary>
+  /// <see cref="TypeConverter"/> for <see cref="JsonPath"/>.
+  /// </summary>
+  internal sealed class JsonPathTypeConverter : TypeConverter
 	{
+
+		/// <summary>
+		/// The standard values used by this converter.
+		/// </summary>
+		/// <remarks>
+		///   This field is initialized using a so-called poor man's lazy in <see cref="GetStandardValues(ITypeDescriptorContext)"/>.
+		/// </remarks>
+		private static StandardValuesCollection? _standardValues;
 
 		/// <inheritdoc/>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string);
+			return sourceType == typeof(string) || sourceType == typeof(JsonPath) || base.CanConvertFrom(context, sourceType);
 		}
 
 		/// <inheritdoc/>
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 		{
-			return destinationType == typeof(string);
+			return destinationType == typeof(string) || destinationType == typeof(JsonPath) || base.CanConvertTo(context, destinationType);
 		}
 
 		/// <inheritdoc/>
@@ -29,19 +37,58 @@ namespace Json.Path
 			{
 				return JsonPath.Parse(s);
 			}
+			else if (value is JsonPath path)
+			{
+				return new JsonPath(path.Scope, path.Segments);
+			}
 
-			return base.ConvertFrom(context, culture, value);
+			throw GetConvertFromException(value);
 		}
 
 		/// <inheritdoc/>
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
-			if (destinationType == typeof(string) && value is JsonPath pointer)
+			if (value is JsonPath path)
 			{
-				return pointer.ToString();
+				if (destinationType == typeof(string))
+				{
+					return path.ToString();
+				}
+				else if (destinationType == typeof(JsonPath))
+				{
+					return new JsonPath(path.Scope, path.Segments);
+				}
 			}
 
-			return base.ConvertTo(context, culture, value, destinationType);
+			throw GetConvertToException(value, destinationType);
+		}
+
+		/// <inheritdoc/>
+		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+		{
+			return true;
+		}
+
+		/// <inheritdoc/>
+		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+		{
+			return false;
+		}
+
+		/// <inheritdoc/>
+		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+		{
+			return _standardValues ??= new StandardValuesCollection(new[] { JsonPath.Root });
+		}
+
+		/// <inheritdoc/>
+		public override bool IsValid(ITypeDescriptorContext context, object value)
+		{
+			if (value is string s)
+			{
+				return JsonPath.TryParse(s, out _);
+			}
+			return value is JsonPath;
 		}
 
 	}

--- a/JsonPointer.Tests/TypeConverterTests.cs
+++ b/JsonPointer.Tests/TypeConverterTests.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using NUnit.Framework;
+
+namespace Json.Pointer.Tests
+{
+  public class TypeConverterTests
+  {
+
+		[Test]
+		public void ConvertFromString()
+		{
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPointer));
+			var pointer = typeConverter.ConvertFromInvariantString("/foo") as JsonPointer;
+
+			Assert.IsNotNull(pointer);
+			Assert.AreEqual("/foo", pointer!.ToString());
+		}
+
+		[Test]
+		public void ConvertToString()
+		{
+			var pointer = JsonPointer.Parse("/foo");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPointer));
+			var pointerString = typeConverter.ConvertToInvariantString(pointer);
+
+			Assert.AreEqual("/foo", pointerString);
+		}
+
+  }
+}

--- a/JsonPointer.Tests/TypeConverterTests.cs
+++ b/JsonPointer.Tests/TypeConverterTests.cs
@@ -26,5 +26,29 @@ namespace Json.Pointer.Tests
 			Assert.AreEqual("/foo", pointerString);
 		}
 
+		[Test]
+		public void ConvertFromJsonPointer()
+		{
+			var pointer = JsonPointer.Parse("/foo");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPointer));
+			var pointer2 = typeConverter.ConvertFrom(pointer) as JsonPointer;
+
+			Assert.IsNotNull(pointer2);
+			Assert.AreNotSame(pointer, pointer2);
+			Assert.AreEqual("/foo", pointer2!.ToString());
+		}
+
+		[Test]
+		public void ConvertToJsonPointer()
+		{
+			var pointer = JsonPointer.Parse("/foo");
+			var typeConverter = TypeDescriptor.GetConverter(typeof(JsonPointer));
+			var pointer2 = typeConverter.ConvertTo(pointer, typeof(JsonPointer)) as JsonPointer;
+
+			Assert.IsNotNull(pointer2);
+			Assert.AreNotSame(pointer, pointer2);
+			Assert.AreEqual("/foo", pointer2!.ToString());
+		}
+
   }
 }

--- a/JsonPointer/JsonPointer.cs
+++ b/JsonPointer/JsonPointer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -16,6 +17,7 @@ namespace Json.Pointer;
 /// Represents a JSON Pointer IAW RFC 6901.
 /// </summary>
 [JsonConverter(typeof(JsonPointerJsonConverter))]
+[TypeConverter(typeof(JsonPointerTypeConverter))]
 public class JsonPointer : IEquatable<JsonPointer>
 {
 	/// <summary>

--- a/JsonPointer/JsonPointerTypeConverter.cs
+++ b/JsonPointer/JsonPointerTypeConverter.cs
@@ -4,22 +4,30 @@ using System.Globalization;
 
 namespace Json.Pointer
 {
-	/// <summary>
-	/// <see cref="TypeConverter"/> for <see cref="JsonPointer"/>.
-	/// </summary>
-	internal sealed class JsonPointerTypeConverter : TypeConverter
+  /// <summary>
+  /// <see cref="TypeConverter"/> for <see cref="JsonPointer"/>.
+  /// </summary>
+  internal sealed class JsonPointerTypeConverter : TypeConverter
 	{
+
+		/// <summary>
+		/// The standard values used by this converter.
+		/// </summary>
+		/// <remarks>
+		///   This field is initialized using a so-called poor man's lazy in <see cref="GetStandardValues(ITypeDescriptorContext)"/>.
+		/// </remarks>
+		private static StandardValuesCollection? _standardValues;
 
 		/// <inheritdoc/>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string);
+			return sourceType == typeof(string) || sourceType == typeof(JsonPointer) || base.CanConvertFrom(context, sourceType);
 		}
 
 		/// <inheritdoc/>
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 		{
-			return destinationType == typeof(string);
+			return destinationType == typeof(string) || destinationType == typeof(JsonPointer) || base.CanConvertTo(context, destinationType);
 		}
 
 		/// <inheritdoc/>
@@ -29,20 +37,59 @@ namespace Json.Pointer
 			{
 				return JsonPointer.Parse(s);
 			}
+			else if (value is JsonPointer pointer)
+			{
+				return JsonPointer.Create(pointer.Segments);
+			}
 
-			return base.ConvertFrom(context, culture, value);
+			throw GetConvertFromException(value);
 		}
 
 		/// <inheritdoc/>
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
-			if (destinationType == typeof(string) && value is JsonPointer pointer)
+			if (value is JsonPointer pointer)
 			{
-				return pointer.ToString();
+				if (destinationType == typeof(string))
+				{
+					return pointer.ToString();
+				}
+				else if (destinationType == typeof(JsonPointer))
+				{
+					return JsonPointer.Create(pointer.Segments);
+				}
 			}
 
-			return base.ConvertTo(context, culture, value, destinationType);
+			throw GetConvertToException(value, destinationType);
 		}
 
-	}
+		/// <inheritdoc/>
+		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+		{
+			return true;
+		}
+
+		/// <inheritdoc/>
+		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+		{
+			return false;
+		}
+
+		/// <inheritdoc/>
+		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+		{
+			return _standardValues ??= new StandardValuesCollection(new[] { JsonPointer.Empty });
+		}
+
+		/// <inheritdoc/>
+		public override bool IsValid(ITypeDescriptorContext context, object value)
+		{
+			if (value is string s)
+			{
+				return JsonPointer.TryParse(s, out _);
+			}
+			return value is JsonPointer;
+		}
+
+  }
 }

--- a/JsonPointer/JsonPointerTypeConverter.cs
+++ b/JsonPointer/JsonPointerTypeConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Json.Pointer
+{
+	/// <summary>
+	/// <see cref="TypeConverter"/> for <see cref="JsonPointer"/>.
+	/// </summary>
+	internal sealed class JsonPointerTypeConverter : TypeConverter
+	{
+
+		/// <inheritdoc/>
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string);
+		}
+
+		/// <inheritdoc/>
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+		{
+			return destinationType == typeof(string);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value is string s)
+			{
+				return JsonPointer.Parse(s);
+			}
+
+			return base.ConvertFrom(context, culture, value);
+		}
+
+		/// <inheritdoc/>
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (destinationType == typeof(string) && value is JsonPointer pointer)
+			{
+				return pointer.ToString();
+			}
+
+			return base.ConvertTo(context, culture, value, destinationType);
+		}
+
+	}
+}


### PR DESCRIPTION
Closes #585

This PR adds `TypeConverter` implementations for `JsonPointer` and `JsonPath` to allow instances of these types to be created via Microsoft's configuration binder.