### PR TITLE
Remove Jetbrains dependency from the main library

### DIFF
--- a/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
+++ b/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
@@ -37,6 +37,7 @@
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="33.1.1" />
 		<PackageReference Include="Fare" Version="2.2.1" />
+		<PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/JsonSchema.Generation.Tests/JsonSchema.Generation.Tests.csproj
+++ b/JsonSchema.Generation.Tests/JsonSchema.Generation.Tests.csproj
@@ -14,6 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />

--- a/JsonSchema.Generation/Attributes/PatternAttribute.cs
+++ b/JsonSchema.Generation/Attributes/PatternAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using JetBrains.Annotations;
 using Json.Schema.Generation.Intents;
 
 namespace Json.Schema.Generation;
@@ -21,7 +20,7 @@ public class PatternAttribute : ConditionalAttribute, IAttributeHandler
 	/// Creates a new <see cref="PatternAttribute"/> instance.
 	/// </summary>
 	/// <param name="value">The value.</param>
-	public PatternAttribute([RegexPattern] string value)
+	public PatternAttribute(string value)
 	{
 		Value = value;
 	}

--- a/JsonSchema.Generation/Intents/PatternIntent.cs
+++ b/JsonSchema.Generation/Intents/PatternIntent.cs
@@ -1,6 +1,4 @@
-﻿using JetBrains.Annotations;
-
-namespace Json.Schema.Generation.Intents;
+﻿namespace Json.Schema.Generation.Intents;
 
 /// <summary>
 /// Provides intent to create a `pattern` keyword.
@@ -16,7 +14,7 @@ public class PatternIntent : ISchemaKeywordIntent
 	/// Creates a new <see cref="PatternIntent"/> instance.
 	/// </summary>
 	/// <param name="value">The value.</param>
-	public PatternIntent([RegexPattern] string value)
+	public PatternIntent(string value)
 	{
 		Value = value;
 	}

--- a/JsonSchema.Generation/SchemaGeneratorConfiguration.cs
+++ b/JsonSchema.Generation/SchemaGeneratorConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using JetBrains.Annotations;
 using Json.Schema.Generation.Generators;
 
 namespace Json.Schema.Generation;
@@ -35,12 +34,10 @@ public class SchemaGeneratorConfiguration
 	/// <summary>
 	/// A collection of refiners.
 	/// </summary>
-	[UsedImplicitly]
 	public List<ISchemaRefiner> Refiners { get; } = new();
 	/// <summary>
 	/// A collection of generators in addition to the global set.
 	/// </summary>
-	[UsedImplicitly]
 	public List<ISchemaGenerator> Generators { get; } = new();
 	/// <summary>
 	/// Gets or sets the order in which properties will be listed in the schema.

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -40,7 +40,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/JsonSchema/JsonSchemaBuilderExtensions.cs
+++ b/JsonSchema/JsonSchemaBuilderExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 
 namespace Json.Schema;
 
@@ -696,7 +695,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <param name="builder">The builder.</param>
 	/// <param name="pattern">The pattern to match.</param>
 	/// <returns>The builder.</returns>
-	public static JsonSchemaBuilder Pattern(this JsonSchemaBuilder builder, [RegexPattern] string pattern)
+	public static JsonSchemaBuilder Pattern(this JsonSchemaBuilder builder, string pattern)
 	{
 		builder.Add(new PatternKeyword(new Regex(pattern, RegexOptions.ECMAScript | RegexOptions.Compiled)));
 		return builder;

--- a/JsonSchema/RegexFormat.cs
+++ b/JsonSchema/RegexFormat.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 
 namespace Json.Schema;
 
@@ -16,7 +15,7 @@ public class RegexFormat : Format
 	/// </summary>
 	/// <param name="key">The format key.</param>
 	/// <param name="regex">The regular expression.</param>
-	public RegexFormat(string key, [RegexPattern] string regex)
+	public RegexFormat(string key, string regex)
 		: base(key)
 	{
 		_regex = new Regex(regex, RegexOptions.ECMAScript | RegexOptions.Compiled);


### PR DESCRIPTION
First I'm aware of the: Issue #174 

Althought this dependency don't necessarily needs to be in the main JsonSchema project, can be moved downstream to the projects that really depends on it.

![image](https://github.com/gregsdennis/json-everything/assets/19890735/9dc76ab9-14d4-4c27-ba59-02dba2cb768a)

As a good practice I suggest moving this to analyzers instead of annotations in the code. So this don't add a dependency that is not related to the actual purpose of the code-base.