### PR TITLE
Performance improvement

### DIFF
--- a/JsonSchema/ErrorMessages.cs
+++ b/JsonSchema/ErrorMessages.cs
@@ -20,6 +20,7 @@ namespace Json.Schema;
 public static partial class ErrorMessages
 {
 	private static readonly ResourceManager _resourceManager = new("Json.Schema.Localization.Resources", typeof(ErrorMessages).Assembly);
+	private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
 	/// <summary>
 	/// Gets or sets a culture to use for error messages.  Default is <see cref="CultureInfo.CurrentCulture"/>.
@@ -52,7 +53,7 @@ public static partial class ErrorMessages
 		for (var i = 0; i < parameters.Length; i++)
 		{
 			var parameter = parameters[i];
-			values[i] = JsonSerializer.Serialize(parameter.value, new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+			values[i] = JsonSerializer.Serialize(parameter.value, _jsonSerializerOptions);
 			current = current.Replace($"[[{parameter.token}]]", $"{{{i}}}");
 		}
 

--- a/JsonSchema/Formats.cs
+++ b/JsonSchema/Formats.cs
@@ -26,6 +26,8 @@ public static class Formats
 		"HH':'mm':'ssK",
 		"HH':'mm':'ss"
 	};
+	
+	//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
 	private static readonly Regex _dateTimeRegex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$");
 
 	/// <summary>
@@ -272,7 +274,6 @@ public static class Formats
 		//date-times with very high precision don't get matched by TryParseExact but are still actually parsable.
 		//We use a fallback to catch these cases
 
-		//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
 		var match = _dateTimeRegex.Match(dateString);
 		return match.Success;
 

--- a/JsonSchema/Formats.cs
+++ b/JsonSchema/Formats.cs
@@ -26,6 +26,7 @@ public static class Formats
 		"HH':'mm':'ssK",
 		"HH':'mm':'ss"
 	};
+	private static readonly Regex _dateTimeRegex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$");
 
 	/// <summary>
 	/// Defines the `date` format.
@@ -272,8 +273,7 @@ public static class Formats
 		//We use a fallback to catch these cases
 
 		//from built from https://regex101.com/r/qH0sU7/1, edited to support all date+time examples in https://ijmacd.github.io/rfc3339-iso8601/
-		var regex = new Regex(@"^((?:(\d{4}-\d{2}-\d{2})([Tt_]| )(\d{2}:\d{2}:\d{2}(?:\.\d+)?))([Zz]|[\+-]\d{2}:\d{2}))$");
-		var match = regex.Match(dateString);
+		var match = _dateTimeRegex.Match(dateString);
 		return match.Success;
 
 	}

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -21,7 +21,7 @@ public class JsonSchema : IBaseDocument
 {
 	private const string _unknownKeywordsAnnotationKey = "$unknownKeywords";
 
-	private static readonly HashSet<SpecVersion> _specVersions = new HashSet<SpecVersion>(Enum.GetValues(typeof(SpecVersion)).Cast<SpecVersion>());
+	private static readonly HashSet<SpecVersion> _definedSpecVersions = new HashSet<SpecVersion>(Enum.GetValues(typeof(SpecVersion)).Cast<SpecVersion>());
 
 	private readonly Dictionary<string, IJsonSchemaKeyword>? _keywords;
 	private readonly List<(DynamicScope Scope, SchemaConstraint Constraint)> _constraints = new();
@@ -407,7 +407,7 @@ public class JsonSchema : IBaseDocument
 	{
 		if (schema.BoolValue.HasValue) return SpecVersion.DraftNext;
 		if (schema.DeclaredVersion != SpecVersion.Unspecified) return schema.DeclaredVersion;
-		if (!_specVersions.Contains(desiredDraft)) return desiredDraft;
+		if (!_definedSpecVersions.Contains(desiredDraft)) return desiredDraft;
 
 		if (schema.TryGetKeyword<SchemaKeyword>(SchemaKeyword.Name, out var schemaKeyword))
 		{

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -20,7 +20,9 @@ namespace Json.Schema;
 public class JsonSchema : IBaseDocument
 {
 	private const string _unknownKeywordsAnnotationKey = "$unknownKeywords";
-	
+
+	private static readonly HashSet<SpecVersion> _specVersions = new HashSet<SpecVersion>(Enum.GetValues(typeof(SpecVersion)).Cast<SpecVersion>());
+
 	private readonly Dictionary<string, IJsonSchemaKeyword>? _keywords;
 	private readonly List<(DynamicScope Scope, SchemaConstraint Constraint)> _constraints = new();
 
@@ -405,7 +407,7 @@ public class JsonSchema : IBaseDocument
 	{
 		if (schema.BoolValue.HasValue) return SpecVersion.DraftNext;
 		if (schema.DeclaredVersion != SpecVersion.Unspecified) return schema.DeclaredVersion;
-		if (!Enum.IsDefined(typeof(SpecVersion), desiredDraft)) return desiredDraft;
+		if (!IsDefinedSpecVersion(desiredDraft)) return desiredDraft;
 
 		if (schema.TryGetKeyword<SchemaKeyword>(SchemaKeyword.Name, out var schemaKeyword))
 		{
@@ -509,6 +511,8 @@ public class JsonSchema : IBaseDocument
 			PopulateBaseUris(subschema, resourceRoot, schema.BaseUri, registry, evaluatingAs);
 		}
 	}
+
+	private static bool IsDefinedSpecVersion(SpecVersion specVersion) => _specVersions.Contains(specVersion);
 
 	internal static IEnumerable<JsonSchema> GetSubschemas(IJsonSchemaKeyword keyword)
 	{

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -407,7 +407,7 @@ public class JsonSchema : IBaseDocument
 	{
 		if (schema.BoolValue.HasValue) return SpecVersion.DraftNext;
 		if (schema.DeclaredVersion != SpecVersion.Unspecified) return schema.DeclaredVersion;
-		if (!IsDefinedSpecVersion(desiredDraft)) return desiredDraft;
+		if (!_specVersions.Contains(desiredDraft)) return desiredDraft;
 
 		if (schema.TryGetKeyword<SchemaKeyword>(SchemaKeyword.Name, out var schemaKeyword))
 		{
@@ -511,8 +511,6 @@ public class JsonSchema : IBaseDocument
 			PopulateBaseUris(subschema, resourceRoot, schema.BaseUri, registry, evaluatingAs);
 		}
 	}
-
-	private static bool IsDefinedSpecVersion(SpecVersion specVersion) => _specVersions.Contains(specVersion);
 
 	internal static IEnumerable<JsonSchema> GetSubschemas(IJsonSchemaKeyword keyword)
 	{


### PR DESCRIPTION
I was looking into improving the performance of my application so I set up a scenario with `BenchmarkDotNet` which, using that particular schema, evaluated 1000 json documents. These changes reduce the time from 465 ms to 220 ms.

Here are the results from running `JsonSchema.Benchmark` on my machine.

Before:
```
|          Method |  n |       Mean |   Error |  StdDev |       Gen0 |       Gen1 | Allocated |
|---------------- |--- |-----------:|--------:|--------:|-----------:|-----------:|----------:|
| RunSuite_Legacy |  1 |   523.1 ms | 5.43 ms | 4.82 ms | 10000.0000 |  5000.0000 |  127.6 MB |
| RunSuite_Legacy | 10 | 1,249.4 ms | 6.08 ms | 5.08 ms | 63000.0000 | 16000.0000 | 754.56 MB |
```

After:
```
|          Method |  n |     Mean |   Error |  StdDev |       Gen0 |      Gen1 | Allocated |
|---------------- |--- |---------:|--------:|--------:|-----------:|----------:|----------:|
| RunSuite_Legacy |  1 | 481.6 ms | 3.95 ms | 3.69 ms |  8000.0000 | 4000.0000 | 101.88 MB |
| RunSuite_Legacy | 10 | 793.2 ms | 5.69 ms | 5.33 ms | 42000.0000 | 5000.0000 | 506.87 MB |
```