### PR TITLE
Add [MemberNotNullWhen] to PatchResult

### DIFF
--- a/JsonPatch/PatchResult.cs
+++ b/JsonPatch/PatchResult.cs
@@ -23,6 +23,9 @@ public class PatchResult
 	/// <summary>
 	/// Gets whether there was an error.
 	/// </summary>
+	#if NET5_0_OR_GREATER
+	[System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(Error))]
+	#endif
 	public bool IsSuccess => Error == null;
 
 	internal PatchResult(PatchContext context)


### PR DESCRIPTION
This removes the nullability warning when writing code like 

```C#
if(!result.IsSuccess)
{
   bool testOperationFailed = patchResult.Error.Contains("is not equal to the indicated value.");
}
```

This won't word before the library starts to (multi) target net5 or greater, but I still think it makes sense to have it ready as soon as that happens.