### PR TITLE
Add missing space to min properties error resx

### DIFF
--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -16,8 +16,8 @@
     <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
     <RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
     <PackageTags>json-schema validation schema json</PackageTags>
-    <Version>5.5.0</Version>
-    <FileVersion>5.5.0.0</FileVersion>
+    <Version>5.5.1</Version>
+    <FileVersion>5.5.1.0</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyName>JsonSchema.Net</AssemblyName>

--- a/JsonSchema/Localization/Resources.resx
+++ b/JsonSchema/Localization/Resources.resx
@@ -184,7 +184,7 @@
     <value>Value should be at least [[limit]] characters</value>
   </data>
   <data name="Error_MinProperties" xml:space="preserve">
-    <value>Value should have at least[[limit]] properties</value>
+    <value>Value should have at least [[limit]] properties</value>
   </data>
   <data name="Error_MultipleOf" xml:space="preserve">
     <value>[[received]] should be a multiple of [[divisor]]</value>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [5.5.1](https://github.com/gregsdennis/json-everything/pull/616) {#release-pointer-5.5.1}
+
+Fix typo in `minProperties` error message.  Thanks to [@ArmaanMcleod](https://github.com/ArmaanMcleod) for submitting this fix.
+
 # [5.5.0](https://github.com/gregsdennis/json-everything/pull/606) {#release-pointer-5.5.0}
 
 [#604](https://github.com/gregsdennis/json-everything/pull/604) - Performance improvements.  Thanks to [@danielstarck](https://github.com/danielstarck) for contributing these.


### PR DESCRIPTION
Added missing space to `minProperties` resource string.

Related to PowerShell/PowerShell#21106.