### PR TITLE
Add multi-targeting for .NET 8

### DIFF
--- a/Json.More/Json.More.csproj
+++ b/Json.More/Json.More.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <PackageId>Json.More.Net</PackageId>
     <Authors>Greg Dennis</Authors>
     <Version>1.10.1</Version>

--- a/JsonE/JsonE.csproj
+++ b/JsonE/JsonE.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>Json.JsonE</RootNamespace>
 		<AssemblyName>JsonE.Net</AssemblyName>

--- a/JsonPatch/JsonPatch.csproj
+++ b/JsonPatch/JsonPatch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Json.Patch</RootNamespace>
     <Version>2.1.0</Version>

--- a/JsonPointer/JsonPointer.csproj
+++ b/JsonPointer/JsonPointer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Json.Pointer</RootNamespace>
     <Version>3.3.0</Version>

--- a/JsonSchema.ArrayExt/JsonSchema.ArrayExt.csproj
+++ b/JsonSchema.ArrayExt/JsonSchema.ArrayExt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<AssemblyName>JsonSchema.Net.ArrayExt</AssemblyName>
 		<RootNamespace>Json.Schema.ArrayExt</RootNamespace>

--- a/JsonSchema.CodeGeneration/JsonSchema.CodeGeneration.csproj
+++ b/JsonSchema.CodeGeneration/JsonSchema.CodeGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netstandard2.0</TargetFramework>
+      <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 	  <Nullable>enable</Nullable>
 	  <LangVersion>latest</LangVersion>
 	  <RootNamespace>Json.Schema.CodeGeneration</RootNamespace>

--- a/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
+++ b/JsonSchema.DataGeneration/JsonSchema.DataGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 		<AssemblyName>JsonSchema.Net.DataGeneration</AssemblyName>
 		<RootNamespace>Json.Schema.DataGeneration</RootNamespace>
 		<Nullable>enable</Nullable>

--- a/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
 		<AssemblyName>JsonSchema.Net.Generation</AssemblyName>
 		<RootNamespace>Json.Schema.Generation</RootNamespace>
 		<Authors>Greg Dennis</Authors>

--- a/JsonSchema.OpenApi/JsonSchema.OpenApi.csproj
+++ b/JsonSchema.OpenApi/JsonSchema.OpenApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<AssemblyName>JsonSchema.Net.OpenApi</AssemblyName>
 		<RootNamespace>Json.Schema.OpenApi</RootNamespace>

--- a/JsonSchema.Tests/JsonSchema.Tests.csproj
+++ b/JsonSchema.Tests/JsonSchema.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net8</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 
 		<IsPackable>false</IsPackable>

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Json.Schema</RootNamespace>
     <PackageId>JsonSchema.Net</PackageId>

--- a/Yaml2JsonNode/Yaml2JsonNode.csproj
+++ b/Yaml2JsonNode/Yaml2JsonNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
 	  <PackageId>Yaml2JsonNode</PackageId>
 	  <Authors>Greg Dennis</Authors>
 	  <Version>1.2.4</Version>


### PR DESCRIPTION
To enable us to make opportunistic improvements to JsonSchema.NET for .NET 8 customers while keeping support for .NET Standard 2.0, this change adds multi-targeting support to all the projects.

I verified that consuming the new nupkg from a WPF or Net Standard 2.0 project gets the netstandard2.0 dll out of the nupkg, while a NET 8 project picks up the one from the net 8 folder.

Related to #390
Related to #532 (maybe resolves)