### PR TITLE
Native aot type safe read

### DIFF
--- a/Json.More/JsonSerializerOptionsExtensions.cs
+++ b/Json.More/JsonSerializerOptionsExtensions.cs
@@ -38,7 +38,7 @@ public static class JsonSerializerOptionsExtensions
 	/// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
 	/// <param name="typeInfo">An explicit typeInfo to use for looking up the Converter. If not provided, options.GetTypeInfo will be used.</param>
 	/// <returns>The value that was converted.</returns>
-	public static T? Read<T>(this JsonSerializerOptions options, ref Utf8JsonReader reader, JsonTypeInfo? typeInfo = null)
+	public static T? Read<T>(this JsonSerializerOptions options, ref Utf8JsonReader reader, JsonTypeInfo<T>? typeInfo = null)
 	{
 		return options.GetConverter<T>(typeInfo).Read(ref reader, typeof(T), options);
 	}

--- a/JsonSchema/AdditionalItemsKeyword.cs
+++ b/JsonSchema/AdditionalItemsKeyword.cs
@@ -100,7 +100,7 @@ public sealed class AdditionalItemsKeywordJsonConverter : Json.More.AotCompatibl
 	/// <returns>The converted value.</returns>
 	public override AdditionalItemsKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new AdditionalItemsKeyword(schema);
 	}

--- a/JsonSchema/AdditionalPropertiesKeyword.cs
+++ b/JsonSchema/AdditionalPropertiesKeyword.cs
@@ -107,7 +107,7 @@ public sealed class AdditionalPropertiesKeywordJsonConverter : Json.More.AotComp
 	/// <returns>The converted value.</returns>
 	public override AdditionalPropertiesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new AdditionalPropertiesKeyword(schema);
 	}

--- a/JsonSchema/AllOfKeyword.cs
+++ b/JsonSchema/AllOfKeyword.cs
@@ -93,7 +93,7 @@ public sealed class AllOfKeywordJsonConverter : Json.More.AotCompatibleJsonConve
 		if (reader.TokenType != JsonTokenType.StartArray)
 			throw new JsonException("Expected array");
 
-		var schemas = options.Read<List<JsonSchema>>(ref reader)!;
+		var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.ListJsonSchema)!;
 		return new AllOfKeyword(schemas);
 	}
 

--- a/JsonSchema/AnyOfKeyword.cs
+++ b/JsonSchema/AnyOfKeyword.cs
@@ -93,7 +93,7 @@ public sealed class AnyOfKeywordJsonConverter : Json.More.AotCompatibleJsonConve
 		if (reader.TokenType != JsonTokenType.StartArray)
 			throw new JsonException("Expected array");
 
-		var schemas = options.Read<List<JsonSchema>>(ref reader)!;
+		var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.ListJsonSchema)!;
 		return new AnyOfKeyword(schemas);
 	}
 

--- a/JsonSchema/ConstKeyword.cs
+++ b/JsonSchema/ConstKeyword.cs
@@ -78,7 +78,7 @@ public sealed class ConstKeywordJsonConverter : Json.More.AotCompatibleJsonConve
 	/// <returns>The converted value.</returns>
 	public override ConstKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var node = options.Read<JsonNode>(ref reader);
+		var node = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonNode);
 
 		return new ConstKeyword(node);
 	}

--- a/JsonSchema/ContainsKeyword.cs
+++ b/JsonSchema/ContainsKeyword.cs
@@ -122,7 +122,7 @@ public sealed class ContainsKeywordJsonConverter : Json.More.AotCompatibleJsonCo
 	/// <returns>The converted value.</returns>
 	public override ContainsKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new ContainsKeyword(schema);
 	}

--- a/JsonSchema/ContentSchemaKeyword.cs
+++ b/JsonSchema/ContentSchemaKeyword.cs
@@ -68,7 +68,7 @@ public sealed class ContentSchemaKeywordJsonConverter : Json.More.AotCompatibleJ
 	/// <returns>The converted value.</returns>
 	public override ContentSchemaKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new ContentSchemaKeyword(schema);
 	}

--- a/JsonSchema/DefaultKeyword.cs
+++ b/JsonSchema/DefaultKeyword.cs
@@ -71,7 +71,7 @@ public sealed class DefaultKeywordJsonConverter : Json.More.AotCompatibleJsonCon
 	/// <returns>The converted value.</returns>
 	public override DefaultKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var node = options.Read<JsonNode>(ref reader);
+		var node = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonNode);
 
 		return new DefaultKeyword(node);
 	}

--- a/JsonSchema/DefinitionsKeyword.cs
+++ b/JsonSchema/DefinitionsKeyword.cs
@@ -69,7 +69,7 @@ public sealed class DefinitionsKeywordJsonConverter : Json.More.AotCompatibleJso
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var schema = options.Read<Dictionary<string, JsonSchema>>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema)!;
 		return new DefinitionsKeyword(schema);
 	}
 

--- a/JsonSchema/DefsKeyword.cs
+++ b/JsonSchema/DefsKeyword.cs
@@ -73,7 +73,7 @@ public sealed class DefsKeywordJsonConverter : Json.More.AotCompatibleJsonConver
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var schema = options.Read<Dictionary<string, JsonSchema>>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema)!;
 		return new DefsKeyword(schema);
 	}
 

--- a/JsonSchema/DependenciesKeyword.cs
+++ b/JsonSchema/DependenciesKeyword.cs
@@ -129,7 +129,7 @@ public sealed class DependenciesKeywordJsonConverter : Json.More.AotCompatibleJs
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var dependencies = options.Read<Dictionary<string, SchemaOrPropertyList>>(ref reader)!;
+		var dependencies = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringSchemaOrPropertyList)!;
 		return new DependenciesKeyword(dependencies);
 	}
 
@@ -220,9 +220,9 @@ public sealed class SchemaOrPropertyListJsonConverter : Json.More.AotCompatibleJ
 	public override SchemaOrPropertyList Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
 		if (reader.TokenType == JsonTokenType.StartArray)
-			return new SchemaOrPropertyList(options.Read<List<string>>(ref reader)!);
+			return new SchemaOrPropertyList(options.Read(ref reader, JsonSchemaSerializerContext.Default.ListString)!);
 
-		return new SchemaOrPropertyList(options.Read<JsonSchema>(ref reader)!);
+		return new SchemaOrPropertyList(options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!);
 	}
 
 	/// <summary>Writes a specified value as JSON.</summary>

--- a/JsonSchema/DependentRequiredKeyword.cs
+++ b/JsonSchema/DependentRequiredKeyword.cs
@@ -98,7 +98,7 @@ public sealed class DependentRequiredKeywordJsonConverter : Json.More.AotCompati
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var requirements = options.Read<Dictionary<string, List<string>>>(ref reader);
+		var requirements = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringListString);
 		return new DependentRequiredKeyword(requirements!.ToDictionary(x => x.Key, x => (IReadOnlyList<string>)x.Value));
 	}
 

--- a/JsonSchema/DependentSchemasKeyword.cs
+++ b/JsonSchema/DependentSchemasKeyword.cs
@@ -105,7 +105,7 @@ public sealed class DependentSchemasKeywordJsonConverter : Json.More.AotCompatib
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var schema = options.Read<Dictionary<string, JsonSchema>>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema)!;
 		return new DependentSchemasKeyword(schema);
 	}
 

--- a/JsonSchema/ElseKeyword.cs
+++ b/JsonSchema/ElseKeyword.cs
@@ -93,7 +93,7 @@ public sealed class ElseKeywordJsonConverter : Json.More.AotCompatibleJsonConver
 	/// <returns>The converted value.</returns>
 	public override ElseKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new ElseKeyword(schema);
 	}

--- a/JsonSchema/EnumKeyword.cs
+++ b/JsonSchema/EnumKeyword.cs
@@ -110,7 +110,7 @@ public sealed class EnumKeywordJsonConverter : Json.More.AotCompatibleJsonConver
 	/// <returns>The converted value.</returns>
 	public override EnumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var array = options.Read<JsonArray>(ref reader);
+		var array = options.Read(ref reader,  JsonSchemaSerializerContext.Default.JsonArray);
 		if (array is null)
 			throw new JsonException("Expected an array, but received null");
 

--- a/JsonSchema/ExamplesKeyword.cs
+++ b/JsonSchema/ExamplesKeyword.cs
@@ -80,7 +80,8 @@ public sealed class ExamplesKeywordJsonConverter : Json.More.AotCompatibleJsonCo
 	/// <returns>The converted value.</returns>
 	public override ExamplesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var array = options.Read<JsonArray>(ref reader) ?? throw new JsonException("Expected an array, but received null");
+		var array = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonArray) ??
+		            throw new JsonException("Expected an array, but received null");
 
 		return new ExamplesKeyword((IEnumerable<JsonNode>)array!);
 	}

--- a/JsonSchema/IfKeyword.cs
+++ b/JsonSchema/IfKeyword.cs
@@ -81,7 +81,7 @@ public sealed class IfKeywordJsonConverter : Json.More.AotCompatibleJsonConverte
 	/// <returns>The converted value.</returns>
 	public override IfKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new IfKeyword(schema);
 	}

--- a/JsonSchema/ItemsKeyword.cs
+++ b/JsonSchema/ItemsKeyword.cs
@@ -162,11 +162,11 @@ public sealed class ItemsKeywordJsonConverter : Json.More.AotCompatibleJsonConve
 	{
 		if (reader.TokenType == JsonTokenType.StartArray)
 		{
-			var schemas = options.Read<List<JsonSchema>>(ref reader)!;
+			var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.ListJsonSchema)!;
 			return new ItemsKeyword(schemas);
 		}
 
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 		return new ItemsKeyword(schema);
 	}
 

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -763,7 +763,7 @@ public sealed class SchemaJsonConverter : Json.More.AotCompatibleJsonConverter<J
 					var keywordType = SchemaKeywordRegistry.GetImplementationType(keyword);
 					if (keywordType == null)
 					{
-						var node = options.Read<JsonNode>(ref reader);
+						var node = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonNode);
 						var unrecognizedKeyword = new UnrecognizedKeyword(keyword, node);
 						keywords.Add(unrecognizedKeyword);
 						break;

--- a/JsonSchema/NotKeyword.cs
+++ b/JsonSchema/NotKeyword.cs
@@ -80,7 +80,7 @@ public sealed class NotKeywordJsonConverter : Json.More.AotCompatibleJsonConvert
 	/// <returns>The converted value.</returns>
 	public override NotKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new NotKeyword(schema);
 	}

--- a/JsonSchema/OneOfKeyword.cs
+++ b/JsonSchema/OneOfKeyword.cs
@@ -98,7 +98,7 @@ public sealed class OneOfKeywordJsonConverter : Json.More.AotCompatibleJsonConve
 		if (reader.TokenType != JsonTokenType.StartArray)
 			throw new JsonException("Expected array");
 
-		var schemas = options.Read<List<JsonSchema>>(ref reader)!;
+		var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.ListJsonSchema)!;
 		return new OneOfKeyword(schemas);
 	}
 

--- a/JsonSchema/PatternPropertiesKeyword.cs
+++ b/JsonSchema/PatternPropertiesKeyword.cs
@@ -115,7 +115,7 @@ public sealed class PatternPropertiesKeywordJsonConverter : Json.More.AotCompati
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var patternProps = options.Read<Dictionary<string, JsonSchema>>(ref reader)!;
+		var patternProps = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema)!;
 		var schemas = new Dictionary<Regex, JsonSchema>();
 		var invalidProps = new List<string>();
 		foreach (var prop in patternProps)

--- a/JsonSchema/PrefixItemsKeyword.cs
+++ b/JsonSchema/PrefixItemsKeyword.cs
@@ -109,7 +109,7 @@ public sealed class PrefixItemsKeywordJsonConverter : Json.More.AotCompatibleJso
 		if (reader.TokenType != JsonTokenType.StartArray)
 			throw new JsonException("Expected array");
 
-		var schemas = options.Read<List<JsonSchema>>(ref reader)!;
+		var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.ListJsonSchema)!;
 		return new PrefixItemsKeyword(schemas);
 	}
 

--- a/JsonSchema/PropertiesKeyword.cs
+++ b/JsonSchema/PropertiesKeyword.cs
@@ -89,7 +89,7 @@ public sealed class PropertiesKeywordJsonConverter : Json.More.AotCompatibleJson
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var schema = options.Read<Dictionary<string, JsonSchema>>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema)!;
 		return new PropertiesKeyword(schema);
 	}
 

--- a/JsonSchema/PropertyDependenciesKeyword.cs
+++ b/JsonSchema/PropertyDependenciesKeyword.cs
@@ -113,7 +113,7 @@ public sealed class PropertyDependenciesKeywordJsonConverter : Json.More.AotComp
 	/// <returns>The converted value.</returns>
 	public override PropertyDependenciesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var dependencies = options.Read<Dictionary<string, PropertyDependency>>(ref reader);
+		var dependencies = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringPropertyDependency);
 
 		return new PropertyDependenciesKeyword(dependencies!);
 	}

--- a/JsonSchema/PropertyDependency.cs
+++ b/JsonSchema/PropertyDependency.cs
@@ -109,7 +109,7 @@ public sealed class PropertyDependencyJsonConverter : Json.More.AotCompatibleJso
 	/// <returns>The converted value.</returns>
 	public override PropertyDependency Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schemas = options.Read<Dictionary<string, JsonSchema>>(ref reader);
+		var schemas = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringJsonSchema);
 
 		return new PropertyDependency(schemas!);
 	}

--- a/JsonSchema/PropertyNamesKeyword.cs
+++ b/JsonSchema/PropertyNamesKeyword.cs
@@ -91,7 +91,7 @@ public sealed class PropertyNamesKeywordJsonConverter : Json.More.AotCompatibleJ
 	/// <returns>The converted value.</returns>
 	public override PropertyNamesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new PropertyNamesKeyword(schema);
 	}

--- a/JsonSchema/RequiredKeyword.cs
+++ b/JsonSchema/RequiredKeyword.cs
@@ -91,7 +91,8 @@ public sealed class RequiredKeywordJsonConverter : Json.More.AotCompatibleJsonCo
 	/// <returns>The converted value.</returns>
 	public override RequiredKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		return new RequiredKeyword(options.Read<string[]>(ref reader) ?? throw new JsonException("Expected array"));
+		return new RequiredKeyword(options.Read(ref reader, JsonSchemaSerializerContext.Default.StringArray) ??
+		                           throw new JsonException("Expected array"));
 	}
 
 	/// <summary>Writes a specified value as JSON.</summary>

--- a/JsonSchema/Serialization/ValidatingJsonConverter.cs
+++ b/JsonSchema/Serialization/ValidatingJsonConverter.cs
@@ -136,7 +136,7 @@ internal class ValidatingJsonConverter<T> : AotCompatibleJsonConverter<T>, IVali
 #pragma warning restore IL2046, IL3051
 	{
 		var readerCopy = reader;
-		var node = options.Read<JsonNode?>(ref readerCopy);
+		var node = options.Read(ref readerCopy, JsonSchemaSerializerContext.Default.JsonNode);
 		
 		var validation = _schema.Evaluate(node, new EvaluationOptions
 		{

--- a/JsonSchema/ThenKeyword.cs
+++ b/JsonSchema/ThenKeyword.cs
@@ -93,7 +93,7 @@ public sealed class ThenKeywordJsonConverter : Json.More.AotCompatibleJsonConver
 	/// <returns>The converted value.</returns>
 	public override ThenKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new ThenKeyword(schema);
 	}

--- a/JsonSchema/TypeKeyword.cs
+++ b/JsonSchema/TypeKeyword.cs
@@ -107,7 +107,7 @@ public sealed class TypeKeywordJsonConverter : Json.More.AotCompatibleJsonConver
 	/// <returns>The converted value.</returns>
 	public override TypeKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var type = options.Read<SchemaValueType>(ref reader);
+		var type = options.Read(ref reader, JsonSchemaSerializerContext.Default.SchemaValueType);
 
 		return new TypeKeyword(type);
 	}

--- a/JsonSchema/UnevaluatedItemsKeyword.cs
+++ b/JsonSchema/UnevaluatedItemsKeyword.cs
@@ -145,7 +145,7 @@ public sealed class UnevaluatedItemsKeywordJsonConverter : Json.More.AotCompatib
 	/// <returns>The converted value.</returns>
 	public override UnevaluatedItemsKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new UnevaluatedItemsKeyword(schema);
 	}

--- a/JsonSchema/UnevaluatedPropertiesKeyword.cs
+++ b/JsonSchema/UnevaluatedPropertiesKeyword.cs
@@ -126,7 +126,7 @@ public sealed class UnevaluatedPropertiesKeywordJsonConverter : Json.More.AotCom
 	/// <returns>The converted value.</returns>
 	public override UnevaluatedPropertiesKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var schema = options.Read<JsonSchema>(ref reader)!;
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.JsonSchema)!;
 
 		return new UnevaluatedPropertiesKeyword(schema);
 	}

--- a/JsonSchema/VocabularyKeyword.cs
+++ b/JsonSchema/VocabularyKeyword.cs
@@ -109,7 +109,7 @@ public sealed class VocabularyKeywordJsonConverter : Json.More.AotCompatibleJson
 		if (reader.TokenType != JsonTokenType.StartObject)
 			throw new JsonException("Expected object");
 
-		var schema = options.Read<Dictionary<string, bool>>(ref reader);
+		var schema = options.Read(ref reader, JsonSchemaSerializerContext.Default.DictionaryStringBoolean);
 		var withUris = schema!.ToDictionary(kvp => new Uri(kvp.Key), kvp => kvp.Value);
 		return new VocabularyKeyword(withUris);
 	}


### PR DESCRIPTION
Updated the `options.Read<T>()` extension to take a `JsonTypeInfo<T>` instead of the non-generic one.

This change infers the type parameter when a JTI is passed, which improves readability while also allowing us to explicitly use our serializer context.  Additionally, it adds a compiler check to ensure that we're generating a JTI for every type that we explicitly deserialize.