### PR TITLE
use non-generic attributes internally

### DIFF
--- a/JsonSchema/AdditionalItemsKeyword.cs
+++ b/JsonSchema/AdditionalItemsKeyword.cs
@@ -17,7 +17,7 @@ namespace Json.Schema;
 [SchemaSpecVersion(SpecVersion.Draft7)]
 [SchemaSpecVersion(SpecVersion.Draft201909)]
 [Vocabulary(Vocabularies.Applicator201909Id)]
-[DependsOnAnnotationsFrom<ItemsKeyword>]
+[DependsOnAnnotationsFrom(typeof(ItemsKeyword))]
 [JsonConverter(typeof(AdditionalItemsKeywordJsonConverter))]
 public class AdditionalItemsKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/AdditionalPropertiesKeyword.cs
+++ b/JsonSchema/AdditionalPropertiesKeyword.cs
@@ -21,8 +21,8 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<PropertiesKeyword>]
-[DependsOnAnnotationsFrom<PatternPropertiesKeyword>]
+[DependsOnAnnotationsFrom(typeof(PropertiesKeyword))]
+[DependsOnAnnotationsFrom(typeof(PatternPropertiesKeyword))]
 [JsonConverter(typeof(AdditionalPropertiesKeywordJsonConverter))]
 public class AdditionalPropertiesKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/ContainsKeyword.cs
+++ b/JsonSchema/ContainsKeyword.cs
@@ -22,8 +22,8 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<MinContainsKeyword>]
-[DependsOnAnnotationsFrom<MaxContainsKeyword>]
+[DependsOnAnnotationsFrom(typeof(MinContainsKeyword))]
+[DependsOnAnnotationsFrom(typeof(MaxContainsKeyword))]
 [JsonConverter(typeof(ContainsKeywordJsonConverter))]
 public class ContainsKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/DependsOnAnnotationsFromAttribute.cs
+++ b/JsonSchema/DependsOnAnnotationsFromAttribute.cs
@@ -5,9 +5,9 @@ namespace Json.Schema;
 /// <summary>
 /// Indicates a keyword from which the decorated keyword requires annotations.
 /// </summary>
-/// <summary>
+/// <remarks>
 /// Apply this attribute to your schema keyword to indicate a dependency on another keyword.
-/// </summary>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true)]
 public class DependsOnAnnotationsFromAttribute : Attribute
 {
@@ -29,9 +29,12 @@ public class DependsOnAnnotationsFromAttribute : Attribute
 /// <summary>
 /// Indicates a keyword from which the decorated keyword requires annotations.
 /// </summary>
-/// <summary>
+/// <remarks>
 /// Apply this attribute to your schema keyword to indicate a dependency on another keyword.
-/// </summary>
+///
+/// **Warning**: Generic attributes are not supported in .Net Framework.  If your target
+/// includes .Net Framework, use the non-generic form of this attribute.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true)]
 public class DependsOnAnnotationsFromAttribute<T> : DependsOnAnnotationsFromAttribute
 	where T : IJsonSchemaKeyword

--- a/JsonSchema/ElseKeyword.cs
+++ b/JsonSchema/ElseKeyword.cs
@@ -19,7 +19,7 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<IfKeyword>]
+[DependsOnAnnotationsFrom(typeof(IfKeyword))]
 [JsonConverter(typeof(ElseKeywordJsonConverter))]
 public class ElseKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/ItemsKeyword.cs
+++ b/JsonSchema/ItemsKeyword.cs
@@ -21,7 +21,7 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<PrefixItemsKeyword>]
+[DependsOnAnnotationsFrom(typeof(PrefixItemsKeyword))]
 [JsonConverter(typeof(ItemsKeywordJsonConverter))]
 public class ItemsKeyword : IJsonSchemaKeyword, ISchemaContainer, ISchemaCollector
 {

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -16,8 +16,8 @@
     <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
     <RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
     <PackageTags>json-schema validation schema json</PackageTags>
-    <Version>6.0.1</Version>
-    <FileVersion>6.0.1.0</FileVersion>
+    <Version>6.0.2</Version>
+    <FileVersion>6.0.2.0</FileVersion>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyName>JsonSchema.Net</AssemblyName>

--- a/JsonSchema/ThenKeyword.cs
+++ b/JsonSchema/ThenKeyword.cs
@@ -19,7 +19,7 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<IfKeyword>]
+[DependsOnAnnotationsFrom(typeof(IfKeyword))]
 [JsonConverter(typeof(ThenKeywordJsonConverter))]
 public class ThenKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/UnevaluatedItemsKeyword.cs
+++ b/JsonSchema/UnevaluatedItemsKeyword.cs
@@ -19,11 +19,11 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<PrefixItemsKeyword>]
-[DependsOnAnnotationsFrom<ItemsKeyword>]
-[DependsOnAnnotationsFrom<AdditionalItemsKeyword>]
-[DependsOnAnnotationsFrom<ContainsKeyword>]
-[DependsOnAnnotationsFrom<UnevaluatedItemsKeyword>]
+[DependsOnAnnotationsFrom(typeof(PrefixItemsKeyword))]
+[DependsOnAnnotationsFrom(typeof(ItemsKeyword))]
+[DependsOnAnnotationsFrom(typeof(AdditionalItemsKeyword))]
+[DependsOnAnnotationsFrom(typeof(ContainsKeyword))]
+[DependsOnAnnotationsFrom(typeof(UnevaluatedItemsKeyword))]
 [JsonConverter(typeof(UnevaluatedItemsKeywordJsonConverter))]
 public class UnevaluatedItemsKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/JsonSchema/UnevaluatedPropertiesKeyword.cs
+++ b/JsonSchema/UnevaluatedPropertiesKeyword.cs
@@ -19,11 +19,11 @@ namespace Json.Schema;
 [Vocabulary(Vocabularies.Applicator201909Id)]
 [Vocabulary(Vocabularies.Applicator202012Id)]
 [Vocabulary(Vocabularies.ApplicatorNextId)]
-[DependsOnAnnotationsFrom<PropertiesKeyword>]
-[DependsOnAnnotationsFrom<PatternPropertiesKeyword>]
-[DependsOnAnnotationsFrom<AdditionalPropertiesKeyword>]
-[DependsOnAnnotationsFrom<ContainsKeyword>]
-[DependsOnAnnotationsFrom<UnevaluatedPropertiesKeyword>]
+[DependsOnAnnotationsFrom(typeof(PropertiesKeyword))]
+[DependsOnAnnotationsFrom(typeof(PatternPropertiesKeyword))]
+[DependsOnAnnotationsFrom(typeof(AdditionalPropertiesKeyword))]
+[DependsOnAnnotationsFrom(typeof(ContainsKeyword))]
+[DependsOnAnnotationsFrom(typeof(UnevaluatedPropertiesKeyword))]
 [JsonConverter(typeof(UnevaluatedPropertiesKeywordJsonConverter))]
 public class UnevaluatedPropertiesKeyword : IJsonSchemaKeyword, ISchemaContainer
 {

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,13 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [6.0.2](https://github.com/gregsdennis/json-everything/pull/619) {#release-schema-6.0.2}
+
+Reverted usages of `DependsOnAnnotationsFromAttribute<T>` to non-generic form in order to support .Net Framework, which doesn't support generic attributes.
+
+> The generic attribute is still defined and usable, but only do so if you're not targeting .Net Framework.
+{: .prompt-info }
+
 # [6.0.0 & 6.0.1](https://github.com/gregsdennis/json-everything/pull/619) {#release-schema-6.0.0}
 
 > v6.0.0 is missing an explicit .Net 8 DLL.  The package was repaired and republished as v6.0.1.


### PR DESCRIPTION
Apparently .Net Framework users are having trouble with the use of generic attributes in the library.

This reverts usage, but the generic attribute type is still there for those who want to create their own keywords and aren't using .Net Framework.