### PR TITLE
Add support for .NET Standard 2.0 for JsonPath.Net

### DIFF
--- a/JsonPath.Tests/JsonPath.Tests.csproj
+++ b/JsonPath.Tests/JsonPath.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0;net481</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 
 		<IsPackable>false</IsPackable>

--- a/JsonPath.Tests/JsonPath.Tests.csproj
+++ b/JsonPath.Tests/JsonPath.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;net481</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 
 		<IsPackable>false</IsPackable>

--- a/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
+++ b/JsonPath.Tests/Suite/CburgmerFeatureValidationTests.cs
@@ -136,7 +136,7 @@ public class CburgmerFeatureValidationTests
 	{
 		get
 		{
-			static bool TryMatch(string line, Regex pattern, [NotNullWhen(true)] out string? value)
+			static bool TryMatch(string line, Regex pattern, out string? value)
 			{
 				var match = pattern.Match(line);
 				if (!match.Success)

--- a/JsonPath/Expressions/FunctionBooleanExpressionNode.cs
+++ b/JsonPath/Expressions/FunctionBooleanExpressionNode.cs
@@ -53,7 +53,7 @@ internal class FunctionBooleanExpressionNode : LogicalExpressionNode
 
 	public override string ToString()
 	{
-		return $"{Function.Name}({string.Join(',', (IEnumerable<ValueExpressionNode>)Parameters)})";
+		return $"{Function.Name}({string.Join(",", (IEnumerable<ValueExpressionNode>)Parameters)})";
 	}
 }
 

--- a/JsonPath/Expressions/FunctionValueExpressionNode.cs
+++ b/JsonPath/Expressions/FunctionValueExpressionNode.cs
@@ -59,7 +59,7 @@ internal class FunctionValueExpressionNode : ValueExpressionNode
 
 	public override string ToString()
 	{
-		return $"{Function.Name}({string.Join(',', (IEnumerable<ValueExpressionNode>)_parameters)})";
+		return $"{Function.Name}({string.Join(",", (IEnumerable<ValueExpressionNode>)_parameters)})";
 	}
 }
 

--- a/JsonPath/Expressions/Operators.cs
+++ b/JsonPath/Expressions/Operators.cs
@@ -83,22 +83,22 @@ internal static class BinaryComparativeOperatorParser
 
 		var portion = source[index..(index + 2)];
 
-		if (portion.Equals("==", StringComparison.Ordinal))
+		if (portion.Equals("==".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.EqualTo;
 			index += 2;
 		}
-		else if (portion.Equals("!=", StringComparison.Ordinal))
+		else if (portion.Equals("!=".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.NotEqualTo;
 			index += 2;
 		}
-		else if (portion.Equals("<=", StringComparison.Ordinal))
+		else if (portion.Equals("<=".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.LessThanOrEqualTo;
 			index += 2;
 		}
-		else if (portion.Equals(">=", StringComparison.Ordinal))
+		else if (portion.Equals(">=".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.GreaterThanOrEqualTo;
 			index += 2;
@@ -113,7 +113,7 @@ internal static class BinaryComparativeOperatorParser
 			op = Operators.GreaterThan;
 			index++;
 		}
-		else if (portion.Equals("in", StringComparison.Ordinal))
+		else if (portion.Equals("in".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.In;
 			index += 2;
@@ -146,12 +146,12 @@ internal static class BinaryLogicalOperatorParser
 
 		var portion = source[index..(index + 2)];
 
-		if (portion.Equals("&&", StringComparison.Ordinal))
+		if (portion.Equals("&&".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.And;
 			index += 2;
 		}
-		else if (portion.Equals("||", StringComparison.Ordinal))
+		else if (portion.Equals("||".AsSpan(), StringComparison.Ordinal))
 		{
 			op = Operators.Or;
 			index += 2;

--- a/JsonPath/Expressions/Operators.cs
+++ b/JsonPath/Expressions/Operators.cs
@@ -83,37 +83,37 @@ internal static class BinaryComparativeOperatorParser
 
 		var portion = source[index..(index + 2)];
 
-		if (portion.Equals("==".AsSpan(), StringComparison.Ordinal))
+		if (portion.Equals(OperatorSymbols.EqualTo, StringComparison.Ordinal))
 		{
 			op = Operators.EqualTo;
 			index += 2;
 		}
-		else if (portion.Equals("!=".AsSpan(), StringComparison.Ordinal))
+		else if (portion.Equals(OperatorSymbols.NotEqualTo, StringComparison.Ordinal))
 		{
 			op = Operators.NotEqualTo;
 			index += 2;
 		}
-		else if (portion.Equals("<=".AsSpan(), StringComparison.Ordinal))
+		else if (portion.Equals(OperatorSymbols.LessThanOrEqualTo, StringComparison.Ordinal))
 		{
 			op = Operators.LessThanOrEqualTo;
 			index += 2;
 		}
-		else if (portion.Equals(">=".AsSpan(), StringComparison.Ordinal))
+		else if (portion.Equals(OperatorSymbols.GreaterThanOrEqualTo, StringComparison.Ordinal))
 		{
 			op = Operators.GreaterThanOrEqualTo;
 			index += 2;
 		}
-		else if (source[index] == '<')
+		else if (source[index] == OperatorSymbols.LessThan)
 		{
 			op = Operators.LessThan;
 			index++;
 		}
-		else if (source[index] == '>')
+		else if (source[index] == OperatorSymbols.GreaterThan)
 		{
 			op = Operators.GreaterThan;
 			index++;
 		}
-		else if (portion.Equals("in".AsSpan(), StringComparison.Ordinal))
+		else if (portion.Equals(OperatorSymbols.In, StringComparison.Ordinal))
 		{
 			op = Operators.In;
 			index += 2;
@@ -125,6 +125,23 @@ internal static class BinaryComparativeOperatorParser
 		}
 
 		return true;
+	}
+
+	private static class OperatorSymbols
+	{
+		internal static char[] EqualTo { get; } = "==".ToCharArray();
+
+		internal static char[] NotEqualTo { get; } = "!=".ToCharArray();
+
+		internal static char[] LessThanOrEqualTo { get; } = "<=".ToCharArray();
+
+		internal static char[] GreaterThanOrEqualTo { get; } = ">=".ToCharArray();
+
+		internal static char LessThan => '<';
+
+		internal static char GreaterThan => '>';
+
+		internal static char[] In { get; } = "in".ToCharArray();
 	}
 }
 

--- a/JsonPath/JsonPath.cs
+++ b/JsonPath/JsonPath.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -70,7 +71,7 @@ public class JsonPath
 			source = source.Trim();
 
 		int index = 0;
-		return PathParser.Parse(source, ref index, options, !options.AllowRelativePathStart);
+		return PathParser.Parse(source.AsSpan(), ref index, options, !options.AllowRelativePathStart);
 	}
 
 	/// <summary>
@@ -98,7 +99,7 @@ public class JsonPath
 		source = source.Trim();
 
 		int index = 0;
-		if (!PathParser.TryParse(source, ref index, out path, options, true)) return false;
+		if (!PathParser.TryParse(source.AsSpan(), ref index, out path, options, true)) return false;
 		if (index != source.Length)
 		{
 			path = null;

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net8.0;netstandard2.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>Json.Path</RootNamespace>
 		<AssemblyName>JsonPath.Net</AssemblyName>

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net8.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>Json.Path</RootNamespace>
 		<AssemblyName>JsonPath.Net</AssemblyName>

--- a/JsonPath/PathSegment.cs
+++ b/JsonPath/PathSegment.cs
@@ -88,7 +88,6 @@ public class PathSegment
 		if (IsShorthand)
 			return $"{((IHaveShorthand)Selectors[0]).ToShorthandString()}";
 		
-
 		return $"[{string.Join(",", Selectors.Select(x => x.ToString()))}]";
 	}
 

--- a/JsonPath/PathSegment.cs
+++ b/JsonPath/PathSegment.cs
@@ -74,7 +74,7 @@ public class PathSegment
 	/// <returns>A string that represents the current object.</returns>
 	public override string ToString()
 	{
-		string GetNormalized() => $"[{string.Join(',', Selectors.Select(x => x.ToString()))}]";
+		string GetNormalized() => $"[{string.Join(",", Selectors.Select(x => x.ToString()))}]";
 		string GetShorthand() => $"{((IHaveShorthand)Selectors[0]).ToShorthandString()}";
 
 		if (IsRecursive)
@@ -88,7 +88,8 @@ public class PathSegment
 		if (IsShorthand)
 			return $"{((IHaveShorthand)Selectors[0]).ToShorthandString()}";
 		
-		return $"[{string.Join(',', Selectors.Select(x => x.ToString()))}]";
+
+		return $"[{string.Join(",", Selectors.Select(x => x.ToString()))}]";
 	}
 
 	/// <summary>


### PR DESCRIPTION
Resolves https://github.com/gregsdennis/json-everything/issues/652

Adds target framework for netstandard2.0 for JsonPath.Net