### PR TITLE
update JSON Path test runner for non-deterministic tests

### DIFF
--- a/JsonPath.Tests/SerializerOptions.cs
+++ b/JsonPath.Tests/SerializerOptions.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Json.Path.Tests;
+
+public static class SerializerOptions
+{
+	public static readonly JsonSerializerOptions Default = new()
+	{
+		AllowTrailingCommas = true,
+		Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+		PropertyNameCaseInsensitive = true
+	};
+}

--- a/JsonPath.Tests/Suite/ComplianceTestCase.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestCase.cs
@@ -13,7 +13,8 @@ public class ComplianceTestCase
 	public string Name { get; set; }
 	public string Selector { get; set; }
 	public JsonNode? Document { get; set; }
-	public List<JsonNode?>? Result { get; set; }
+	public JsonArray? Result { get; set; }
+	public List<JsonArray>? Results { get; set; }
 	[JsonPropertyName("invalid_selector")]
 	public bool InvalidSelector { get; set; }
 
@@ -23,6 +24,7 @@ public class ComplianceTestCase
 			   $"Selector: {Selector}\n" +
 			   $"Document: {JsonSerializer.Serialize(Document, SerializerOptions.Default)}\n" +
 			   $"Result:   {JsonSerializer.Serialize(Result, SerializerOptions.Default)}\n" +
+			   $"Results:   {JsonSerializer.Serialize(Results, SerializerOptions.Default)}\n" +
 			   $"IsValid:  {!InvalidSelector}";
 	}
 }

--- a/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
+++ b/JsonPath.Tests/Suite/ComplianceTestSuiteTests.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Json.More;
 using NUnit.Framework;
 
@@ -81,17 +81,9 @@ public class ComplianceTestSuiteTests
 		if (testCase.InvalidSelector)
 			Assert.Fail($"{testCase.Selector} is not a valid path.");
 
-		var expected = testCase.Result!.ToJsonArray();
-		Assert.IsTrue(expected.IsEquivalentTo(actualValues), "Unexpected results returned");
+		if (testCase.Result is not null)
+			Assert.IsTrue(testCase.Result.IsEquivalentTo(actualValues), "Unexpected results returned");
+		else
+			Assert.That(() => testCase.Results!.Contains(actualValues, JsonNodeEqualityComparer.Instance), "None of the options matched.");
 	}
-}
-
-public static class SerializerOptions
-{
-	public static JsonSerializerOptions Default = new()
-	{
-		AllowTrailingCommas = true,
-		Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-		PropertyNameCaseInsensitive = true
-	};
 }


### PR DESCRIPTION
Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/60