### PR TITLE
fixed issue with building boolean expression trees; updated path test suite

### DIFF
--- a/JsonPath.Tests/ExpressionTests.cs
+++ b/JsonPath.Tests/ExpressionTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Text.Json.Nodes;
+using Json.More;
+using NUnit.Framework;
+
+namespace Json.Path.Tests;
+
+public class ExpressionTests
+{
+	[TestCase("$[?(@.foo==(4+5))]", "[{\"foo\": 9}]")]
+	[TestCase("$[?(@.foo==2*(4+5))]", "[{\"foo\": 18}]")]
+	[TestCase("$[?(@.foo==2+(4+5))]", "[{\"foo\": 11}]")]
+	[TestCase("$[?(@.foo==2-(4+5))]", "[{\"foo\": -7}]")]
+	[TestCase("$[?(@.foo==2*4+5)]", "[{\"foo\": 13}]")]
+	[TestCase("$[?(@.foo==2+4*5)]", "[{\"foo\": 22}]")]
+	public void OrderOfOperations(string pathString, string expectedString)
+	{
+		var target = JsonNode.Parse(
+			"""
+			[
+			  {"foo": 9},
+			  {"foo": 18},
+			  {"foo": 11},
+			  {"foo": -7},
+			  {"foo": 13},
+			  {"foo": 22}
+			]
+			""");
+
+		var path = JsonPath.Parse(pathString, new PathParsingOptions { AllowMathOperations = true });
+		var expected = JsonNode.Parse(expectedString);
+
+		var actual = path.Evaluate(target).Matches!.Select(x => x.Value).ToJsonArray();
+
+		Assert.IsTrue(actual.IsEquivalentTo(expected));
+	}
+}

--- a/JsonPath.Tests/ParsingTests.cs
+++ b/JsonPath.Tests/ParsingTests.cs
@@ -53,6 +53,8 @@ public class ParsingTests
 			new TestCaseData("$[?@.foo]"),
 			new TestCaseData("$[?(@.foo)]"),
 			new TestCaseData("$[?(@.foo && @.bar)]"),
+			new TestCaseData("$[?(@.foo && @.bar || @.baz)]"),
+			new TestCaseData("$[?(@.foo || @.bar && @.baz)]"),
 			new TestCaseData("$[?(!@.foo)]"),
 			new TestCaseData("$[?(@.foo && !@.bar)]"),
 			new TestCaseData("$[?!(@.foo == false)]"),
@@ -75,6 +77,7 @@ public class ParsingTests
 			new TestCaseData("$[?(@.foo==2*(4+5))]"),
 			new TestCaseData("$[?(@.foo==2+(4+5))]"),
 			new TestCaseData("$[?(@.foo==2-(4+5))]"),
+			new TestCaseData("$[?(@.foo==2*4+5)]"),
 		};
 
 	[TestCaseSource(nameof(OptionalMathCases))]

--- a/JsonPath/Expressions/ValueExpressionNode.cs
+++ b/JsonPath/Expressions/ValueExpressionNode.cs
@@ -112,13 +112,8 @@ internal static class ValueExpressionParser
 				return false;
 			}
 
-			if (left is BinaryValueExpressionNode bin)
-			{
-				if (bin.Precedence < Precedence(op))
-					bin.Right = new BinaryValueExpressionNode(op, bin.Right, right, nestLevel);
-				else
-					left = new BinaryValueExpressionNode(op, left, right, nestLevel);
-			}
+			if (left is BinaryValueExpressionNode bin && bin.Precedence < Precedence(op))
+				bin.Right = new BinaryValueExpressionNode(op, bin.Right, right, nestLevel);
 			else
 				left = new BinaryValueExpressionNode(op, left, right, nestLevel);
 

--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -20,9 +20,9 @@
 		<PackageIcon>json-logo-256.png</PackageIcon>
 		<PackageTags>json-path jsonpath query path json rfc9535</PackageTags>
 		<PackageReleaseNotes>Release notes can be found at https://docs.json-everything.net/rn-json-path/</PackageReleaseNotes>
-		<Version>1.0.0</Version>
-		<FileVersion>1.0.0.0</FileVersion>
-		<AssemblyVersion>0.8.0.0</AssemblyVersion>
+		<Version>1.0.1</Version>
+		<FileVersion>1.0.1.0</FileVersion>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<DocumentationFile>JsonPath.Net.xml</DocumentationFile>
 		<IncludeSymbols>true</IncludeSymbols>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,6 +4,10 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.07"
 ---
+# [1.0.1](https://github.com/gregsdennis/json-everything/commit/550f4d97d52c90644cf033ae235fa6d80b3fbda3) {#release-path-1.0.1}
+
+Fixed an issue around operator precedence in boolean expressions.
+
 # [1.0.0](https://github.com/gregsdennis/json-everything/commit/550f4d97d52c90644cf033ae235fa6d80b3fbda3) {#release-path-1.0.0}
 
 JSON Path RFC 9535 has been released!  (No functional changes from 0.8.0.)


### PR DESCRIPTION
Relates to https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/64