### PR TITLE
obsolete 2020 output converter

### DIFF
--- a/JsonSchema/EvaluationResults.cs
+++ b/JsonSchema/EvaluationResults.cs
@@ -374,6 +374,7 @@ public class EvaluationResultsJsonConverter : WeaklyTypedJsonConverter<Evaluatio
 /// <summary>
 /// Produces output formats specified by 2019-09 and 2020-12.
 /// </summary>
+[Obsolete("This doesn't work right, and the architecture of EvaluationResults makes it difficult to fix.  Recommendation is to use the draft-next structure via EvaluationResultsJsonConverter (which is the default).")]
 public class Pre202012EvaluationResultsJsonConverter : WeaklyTypedJsonConverter<EvaluationResults>
 {
 	/// <summary>

--- a/JsonSchema/JsonSchema.csproj
+++ b/JsonSchema/JsonSchema.csproj
@@ -16,8 +16,8 @@
     <PackageProjectUrl>https://github.com/gregsdennis/json-everything</PackageProjectUrl>
     <RepositoryUrl>https://github.com/gregsdennis/json-everything</RepositoryUrl>
     <PackageTags>json-schema validation schema json</PackageTags>
-    <Version>6.0.5</Version>
-    <FileVersion>6.0.5.0</FileVersion>
+    <Version>6.0.6</Version>
+    <FileVersion>6.0.6.0</FileVersion>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <AssemblyName>JsonSchema.Net</AssemblyName>

--- a/json-everything.net/Pages/Schema.razor
+++ b/json-everything.net/Pages/Schema.razor
@@ -95,20 +95,6 @@
 										</InputSelect>
 									</label>
 									<label class="my-2">
-										Output structure
-										<span class="tooltip-icon">
-											ⓘ
-											<span class="tooltip-text">
-												<MarkdownSpan Content="@HelpContent.SchemaOutputStructure"></MarkdownSpan>
-											</span>
-										</span>
-										<br />
-										<InputSelect @bind-Value="_options.OutputStructure" DisplayName="Spec version" class="form-control">
-											<option value="@SpecVersion.Draft202012">Draft 2020-12</option>
-											<option value="@SpecVersion.DraftNext">Draft-Next (preview)</option>
-										</InputSelect>
-									</label>
-									<label class="my-2">
 										<InputCheckbox @bind-Value="_options.IncludeDroppedAnnotations" DisplayName="Preserve dropped annotations"/>
 										Preserve dropped annotations
 										<span class="tooltip-icon">
@@ -219,7 +205,6 @@
 	{
 		public OutputFormat OutputFormat { get; set; } = OutputFormat.Hierarchical;
 		public SpecVersion Version { get; set; } = SpecVersion.Draft202012;
-		public SpecVersion OutputStructure { get; set; } = SpecVersion.DraftNext;
 		public bool ValidateFormat { get; set; }
 		public bool IncludeDroppedAnnotations { get; set; }
 		public bool AddAnnotationForUnknownKeywords { get; set; }
@@ -387,8 +372,6 @@
 				WriteIndented = true,
 				Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
 			};
-			if (_options.OutputStructure == SpecVersion.Draft202012)
-				serializerOptions.Converters.Add(new Pre202012EvaluationResultsJsonConverter());
 			var resultText = JsonSerializer.Serialize(results, serializerOptions);
 
 			await _outputEditor.SetValue(resultText);

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,7 +4,11 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
-# [6.0.4](https://github.com/gregsdennis/json-everything/pull/678) {#release-schema-6.0.4}
+# [6.0.6](https://github.com/gregsdennis/json-everything/pull/695) {#release-schema-6.0.6}
+
+Marked `Pre202012EvaluationResultsJsonConverter` as obsolete.  The 2019-09/2020-12 output structure isn't very well specified, and making the current `EvaluationResults` architecture serialize to these formats isn't worth the effort.
+
+# [6.0.5](https://github.com/gregsdennis/json-everything/pull/691) {#release-schema-6.0.5}
 
 [#690](https://github.com/gregsdennis/json-everything/issues/690) - Fixes an issue with `$anchor` validation in 2020-12.  Thanks to [@Era-cell](https://github.com/Era-cell) for reporting this.
 


### PR DESCRIPTION
Closes #694 

I've opted to just obsolete the converter.  There are a number of technical issues that make fixing this more effort than it's worth.  The 2019-09/2020-12 output is poorly specified anyway.