### PR TITLE
Schema/lessons from functional

### DIFF
--- a/JsonSchema.Benchmark/Program.cs
+++ b/JsonSchema.Benchmark/Program.cs
@@ -9,9 +9,9 @@ class Program
 	static void Main(string[] args)
 	{
 #if DEBUG
-		IConfig config = new DebugBuildConfig();
-		config.WithOptions(ConfigOptions.DisableOptimizationsValidator);
-		var summary = BenchmarkRunner.Run<TestSuiteRunner>(config);
+		var runner = new TestSuiteRunner();
+		runner.BenchmarkSetup();
+		runner.Legacy(1);
 #else
 		var summary = BenchmarkRunner.Run<TestSuiteRunner>();
 #endif

--- a/JsonSchema.Benchmark/Suite/TestSuiteRunner.cs
+++ b/JsonSchema.Benchmark/Suite/TestSuiteRunner.cs
@@ -12,7 +12,11 @@ namespace Json.Schema.Benchmark.Suite;
 [MemoryDiagnoser]
 public class TestSuiteRunner
 {
+#if DEBUG
+	private const string _benchmarkOffset = @"";
+#else
 	private const string _benchmarkOffset = @"../../../../";
+#endif
 	private const string _testCasesPath = @"../../../../ref-repos/JSON-Schema-Test-Suite/tests";
 	private const string _remoteSchemasPath = @"../../../../ref-repos/JSON-Schema-Test-Suite/remotes";
 
@@ -115,7 +119,8 @@ public class TestSuiteRunner
 	[Benchmark]
 	[Arguments(1)]
 	[Arguments(10)]
-	public int RunSuite_Legacy(int n)
+	[Arguments(50)]
+	public int Legacy(int n)
 	{
 		int i = 0;
 		var collections = GetAllTests();

--- a/JsonSchema.Tests/AutoEvaluationTests.cs
+++ b/JsonSchema.Tests/AutoEvaluationTests.cs
@@ -56,7 +56,7 @@ public class AutoEvaluationTests
 
 		var options = new EvaluationOptions();
 
-		Assert.Throws<ArgumentException>(() => JsonSchema.AutoEvaluate(instance, options));
+		Assert.Throws<SchemaRefResolutionException>(() => JsonSchema.AutoEvaluate(instance, options));
 	}
 
 	[Test]

--- a/JsonSchema.Tests/FetchTests.cs
+++ b/JsonSchema.Tests/FetchTests.cs
@@ -79,7 +79,7 @@ public class FetchTests
 
 		using var json = JsonDocument.Parse("10");
 
-		Assert.Throws<JsonSchemaException>(() => schema.Evaluate(json.RootElement, options));
+		Assert.Throws<SchemaRefResolutionException>(() => schema.Evaluate(json.RootElement, options));
 	}
 
 	[Test]
@@ -101,7 +101,7 @@ public class FetchTests
 
 			using var json = JsonDocument.Parse("10");
 
-			Assert.Throws<JsonSchemaException>(() => schema.Evaluate(json.RootElement, options));
+			Assert.Throws<SchemaRefResolutionException>(() => schema.Evaluate(json.RootElement, options));
 		}
 		finally
 		{

--- a/JsonSchema.Tests/ReferenceTests.cs
+++ b/JsonSchema.Tests/ReferenceTests.cs
@@ -26,14 +26,15 @@ public class ReferenceTests
 
 		var baseData = JsonNode.Parse(GetResource("base_data"));
 
-		SchemaRegistry.Global.Register(refSchema);
-		SchemaRegistry.Global.Register(baseSchema);
-		SchemaRegistry.Global.Register(hashSchema);
+		var options = new EvaluationOptions();
+		options.SchemaRegistry.Register(refSchema);
+		options.SchemaRegistry.Register(baseSchema);
+		options.SchemaRegistry.Register(hashSchema);
 
 		// in previous versions, this would still validate the instance, but since adding
 		// static analysis, the ref with the # in it is checked early
 		// and since it can't resolve, it now throws.
-		Assert.Throws<JsonSchemaException>(() => baseSchema.Evaluate(baseData));
+		Assert.Throws<JsonSchemaException>(() => baseSchema.Evaluate(baseData, options));
 	}
 
 	[Test]
@@ -45,11 +46,12 @@ public class ReferenceTests
 
 		var baseData = JsonNode.Parse(GetResource("base_data_hash_uri"));
 
-		SchemaRegistry.Global.Register(refSchema);
-		SchemaRegistry.Global.Register(baseSchema);
-		SchemaRegistry.Global.Register(hashSchema);
-		
-		Assert.Throws<JsonSchemaException>(()=>baseSchema.Evaluate(baseData));
+		var options = new EvaluationOptions();
+		options.SchemaRegistry.Register(refSchema);
+		options.SchemaRegistry.Register(baseSchema);
+		options.SchemaRegistry.Register(hashSchema);
+
+		Assert.Throws<JsonSchemaException>(()=>baseSchema.Evaluate(baseData, options));
 	}
 
 	[Test]

--- a/JsonSchema.Tests/SelfValidationTest.cs
+++ b/JsonSchema.Tests/SelfValidationTest.cs
@@ -33,6 +33,7 @@ public class SelfValidationTest
 			new TestCaseData(MetaSchemas.Draft202012) { TestName = nameof(MetaSchemas.Draft202012) },
 			new TestCaseData(MetaSchemas.Core202012) { TestName = nameof(MetaSchemas.Core202012) },
 			new TestCaseData(MetaSchemas.Applicator202012) { TestName = nameof(MetaSchemas.Applicator202012) },
+			new TestCaseData(MetaSchemas.Validation202012) { TestName = nameof(MetaSchemas.Validation202012) },
 			new TestCaseData(MetaSchemas.Metadata202012) { TestName = nameof(MetaSchemas.Metadata202012) },
 			new TestCaseData(MetaSchemas.FormatAnnotation202012) { TestName = nameof(MetaSchemas.FormatAnnotation202012) },
 			new TestCaseData(MetaSchemas.FormatAssertion202012) { TestName = nameof(MetaSchemas.FormatAssertion202012) },

--- a/JsonSchema/DynamicRefKeyword.cs
+++ b/JsonSchema/DynamicRefKeyword.cs
@@ -59,7 +59,8 @@ public class DynamicRefKeyword : IJsonSchemaKeyword
 		{
 			var targetBase = context.Options.SchemaRegistry.Get(newBaseUri);
 
-			targetSchema = targetBase.FindSubschema(pointerFragment, context.Options);
+			targetSchema = targetBase.FindSubschema(pointerFragment, context.Options) ??
+			               throw new SchemaRefResolutionException(newBaseUri, pointerFragment);
 		}
 		else
 		{
@@ -69,9 +70,6 @@ public class DynamicRefKeyword : IJsonSchemaKeyword
 
 			targetSchema = context.Options.SchemaRegistry.Get(context.Scope, newBaseUri, anchorFragment, context.EvaluatingAs == SpecVersion.Draft202012);
 		}
-
-		if (targetSchema == null)
-			throw new JsonSchemaException($"Cannot resolve schema `{newUri}`");
 
 		return new KeywordConstraint(Name, (e, c) => Evaluator(e, c, targetSchema));
 	}

--- a/JsonSchema/EvaluationContext.cs
+++ b/JsonSchema/EvaluationContext.cs
@@ -62,7 +62,7 @@ public class EvaluationContext
 		    !TryGetVocab(schema, out var vocab) ||
 		    vocab == null) return schema.Keywords!;
 
-		var vocabKeywordTypes = vocab.SelectMany(x => x?.Keywords ?? Array.Empty<Type>());
+		var vocabKeywordTypes = vocab.SelectMany(x => x?.Keywords ?? []);
 		return schema.Keywords!.Where(x => vocabKeywordTypes.Contains(x.GetType()));
 	}
 

--- a/JsonSchema/EvaluationContext.cs
+++ b/JsonSchema/EvaluationContext.cs
@@ -68,6 +68,12 @@ public class EvaluationContext
 
 	private bool TryGetVocab(JsonSchema schema, out Vocabulary[]? vocab)
 	{
+		if (schema.BaseUri is null)
+		{
+			vocab = null;
+			return false;
+		}
+
 		if (Dialect.TryGetValue(schema.BaseUri, out vocab)) return true;
 
 		Dialect[schema.BaseUri] = null;

--- a/JsonSchema/EvaluationContext.cs
+++ b/JsonSchema/EvaluationContext.cs
@@ -56,9 +56,9 @@ public class EvaluationContext
 		Scope = new DynamicScope(initialScope);
 	}
 
-	internal IEnumerable<IJsonSchemaKeyword> GetKeywordsToProcess(JsonSchema schema, EvaluationOptions options)
+	internal IEnumerable<IJsonSchemaKeyword> GetKeywordsToProcess(JsonSchema schema)
 	{
-		if (options.ProcessCustomKeywords ||
+		if (Options.ProcessCustomKeywords ||
 		    !TryGetVocab(schema, out var vocab) ||
 		    vocab == null) return schema.Keywords!;
 
@@ -75,7 +75,7 @@ public class EvaluationContext
 		var schemaKeyword = (SchemaKeyword?)schema.Keywords?.FirstOrDefault(x => x is SchemaKeyword);
 		if (schemaKeyword == null) return false;
 
-		var metaSchema = (JsonSchema) Options.SchemaRegistry.Get(schemaKeyword.Schema)!;
+		var metaSchema = (JsonSchema) Options.SchemaRegistry.Get(schemaKeyword.Schema);
 		var vocabKeyword = (VocabularyKeyword?)metaSchema.Keywords!.FirstOrDefault(x => x is VocabularyKeyword);
 		if (vocabKeyword == null) return false;
 

--- a/JsonSchema/EvaluationOptions.cs
+++ b/JsonSchema/EvaluationOptions.cs
@@ -217,30 +217,18 @@ public class EvaluationOptions
 
 	internal static IEnumerable<IJsonSchemaKeyword> FilterKeywords(IEnumerable<IJsonSchemaKeyword> keywords, SpecVersion declaredVersion)
 	{
-		if (declaredVersion is SpecVersion.Draft6 or SpecVersion.Draft7)
-			return DisallowSiblingRef(keywords, declaredVersion);
+		if (!Enum.IsDefined(typeof(SpecVersion), declaredVersion) || declaredVersion == SpecVersion.Unspecified)
+		{
+			foreach (var keyword in keywords)
+			{
+				yield return keyword;
+			}
+			yield break;
+		}
 
-		return AllowSiblingRef(keywords, declaredVersion);
-	}
-
-	private static IEnumerable<IJsonSchemaKeyword> DisallowSiblingRef(IEnumerable<IJsonSchemaKeyword> keywords, SpecVersion version)
-	{
-		// ReSharper disable once PossibleMultipleEnumeration
-		var refKeyword = keywords.OfType<RefKeyword>().SingleOrDefault();
-
-		// ReSharper disable once PossibleMultipleEnumeration
-		return refKeyword != null ? new[] { refKeyword } : FilterBySpecVersion(keywords, version);
-	}
-
-	private static IEnumerable<IJsonSchemaKeyword> AllowSiblingRef(IEnumerable<IJsonSchemaKeyword> keywords, SpecVersion version)
-	{
-		return FilterBySpecVersion(keywords, version);
-	}
-
-	private static IEnumerable<IJsonSchemaKeyword> FilterBySpecVersion(IEnumerable<IJsonSchemaKeyword> keywords, SpecVersion version)
-	{
-		if (!Enum.IsDefined(typeof(SpecVersion), version) || version == SpecVersion.Unspecified) return keywords;
-
-		return keywords.Where(k => k.SupportsVersion(version));
+		foreach (var keyword in keywords)
+		{
+			if (keyword.SupportsVersion(declaredVersion)) yield return keyword;
+		}
 	}
 }

--- a/JsonSchema/EvaluationOptions.cs
+++ b/JsonSchema/EvaluationOptions.cs
@@ -144,13 +144,6 @@ public class EvaluationOptions
 
 	internal bool Changed { get; set; }
 
-	static EvaluationOptions()
-	{
-		// It's necessary to call this from here because
-		// SchemaRegistry.Global is defined to look at the default options.
-		Default.SchemaRegistry.InitializeMetaSchemas();
-	}
-
 	/// <summary>
 	/// Create a new instance of the <see cref="EvaluationOptions"/> class.
 	/// </summary>

--- a/JsonSchema/JsonNodeBaseDocument.cs
+++ b/JsonSchema/JsonNodeBaseDocument.cs
@@ -53,8 +53,8 @@ public class JsonNodeBaseDocument : IBaseDocument
 
 			var schema = location.Deserialize(JsonSchemaSerializerContext.Default.JsonSchema);
 			if (schema != null)
-				options.SchemaRegistry.Register(BaseUri, schema);
-
+				options.SchemaRegistry.ForceInitialize(BaseUri, schema);
+			
 			return schema;
 		});
 	}

--- a/JsonSchema/JsonNodeBaseDocument.cs
+++ b/JsonSchema/JsonNodeBaseDocument.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Pointer;
@@ -54,7 +53,7 @@ public class JsonNodeBaseDocument : IBaseDocument
 
 			var schema = location.Deserialize(JsonSchemaSerializerContext.Default.JsonSchema);
 			if (schema != null)
-				JsonSchema.Initialize(schema, options.SchemaRegistry, BaseUri);
+				options.SchemaRegistry.Register(BaseUri, schema);
 
 			return schema;
 		});

--- a/JsonSchema/JsonNodeBaseDocument.cs
+++ b/JsonSchema/JsonNodeBaseDocument.cs
@@ -53,7 +53,7 @@ public class JsonNodeBaseDocument : IBaseDocument
 
 			var schema = location.Deserialize(JsonSchemaSerializerContext.Default.JsonSchema);
 			if (schema != null)
-				options.SchemaRegistry.ForceInitialize(BaseUri, schema);
+				options.SchemaRegistry.ForceInitialize(BaseUri, schema, SpecVersion.Unspecified);
 			
 			return schema;
 		});

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -423,7 +423,7 @@ public class JsonSchema : IBaseDocument
 			}
 			var localConstraints = new List<KeywordConstraint>();
 			var version = SpecVersion == SpecVersion.Unspecified ? context.EvaluatingAs : SpecVersion;
-			var keywords = EvaluationOptions.FilterKeywords(context.GetKeywordsToProcess(this, context.Options), version).ToArray();
+			var keywords = EvaluationOptions.FilterKeywords(context.GetKeywordsToProcess(this), version).ToArray();
 			var unrecognized = Keywords!.OfType<UnrecognizedKeyword>();
 			var unrecognizedButSupported = Keywords!.Except(keywords).ToArray();
 			if (context.Options.AddAnnotationForUnknownKeywords)

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -23,15 +23,6 @@ public class JsonSchema : IBaseDocument
 {
 	private const string _unknownKeywordsAnnotationKey = "$unknownKeywords";
 
-	private static readonly HashSet<SpecVersion> _definedSpecVersions = [.. GetSpecVersions()];
-
-	private static SpecVersion[] GetSpecVersions() =>
-#if NET6_0_OR_GREATER
-		Enum.GetValues<SpecVersion>();
-#else
-		Enum.GetValues(typeof(SpecVersion)).Cast<SpecVersion>().ToArray();
-#endif
-
 	private readonly Dictionary<string, IJsonSchemaKeyword>? _keywords;
 	private readonly List<(DynamicScope Scope, SchemaConstraint Constraint)> _constraints = [];
 
@@ -40,7 +31,7 @@ public class JsonSchema : IBaseDocument
 	/// <summary>
 	/// The empty schema `{}`.  Functionally equivalent to <see cref="True"/>.
 	/// </summary>
-	public static readonly JsonSchema Empty = new(Enumerable.Empty<IJsonSchemaKeyword>());
+	public static readonly JsonSchema Empty = new([]);
 	/// <summary>
 	/// The `true` schema.  Passes all instances.
 	/// </summary>
@@ -80,17 +71,9 @@ public class JsonSchema : IBaseDocument
 	public Uri BaseUri { get; set; } = GenerateBaseUri();
 
 	/// <summary>
-	/// Gets whether the schema defines a new schema resource.  This will only be true if it contains an `$id` keyword.
-	/// </summary>
-	public bool IsResourceRoot { get; private set; }
-
-	/// <summary>
 	/// Gets the specification version as determined by analyzing the `$schema` keyword, if it exists.
 	/// </summary>
-	public SpecVersion DeclaredVersion { get; private set; }
-
-	internal Dictionary<string, (JsonSchema Schema, bool IsDynamic)> Anchors { get; } = [];
-	internal JsonSchema? RecursiveAnchor { get; set; }
+	public SpecVersion SpecVersion { get; internal set; }
 
 	private JsonSchema(bool value)
 	{
@@ -299,9 +282,8 @@ public class JsonSchema : IBaseDocument
 		options = EvaluationOptions.From(options);
 
 		// BaseUri may change if $id is present
-		var evaluatingAs = DetermineSpecVersion(this, options.SchemaRegistry, options.EvaluateAs);
-		PopulateBaseUris(this, this, BaseUri, options.SchemaRegistry, evaluatingAs, true);
-
+		options.SchemaRegistry.Register(this);
+		var evaluatingAs = SpecVersion == SpecVersion.Unspecified ? options.EvaluateAs : SpecVersion;
 
 		var context = new EvaluationContext(options, evaluatingAs, BaseUri);
 		var constraint = BuildConstraint(JsonPointer.Empty, JsonPointer.Empty, JsonPointer.Empty, context.Scope);
@@ -326,6 +308,7 @@ public class JsonSchema : IBaseDocument
 			case OutputFormat.Hierarchical:
 				break;
 			default:
+				// ReSharper disable once NotResolvedInText
 				throw new ArgumentOutOfRangeException("options.OutputFormat");
 		}
 
@@ -420,7 +403,9 @@ public class JsonSchema : IBaseDocument
 				var refKeyword = (RefKeyword?) Keywords!.FirstOrDefault(x => x is RefKeyword);
 				if (refKeyword != null)
 				{
-					var refConstraint = refKeyword.GetConstraint(constraint, Array.Empty<KeywordConstraint>(), context);
+					if (Keywords!.Any(x => x is IdKeyword))
+						constraint.SchemaBaseUri = context.Scope.LocalScope;
+					var refConstraint = refKeyword.GetConstraint(constraint, [], context);
 					constraint.Constraints = [refConstraint];
 					return;
 				}
@@ -431,10 +416,13 @@ public class JsonSchema : IBaseDocument
 			{
 				dynamicScopeChanged = true;
 				context.Scope.Push(BaseUri);
-				context.PushEvaluatingAs(DeclaredVersion);
+				if (SpecVersion == SpecVersion.Unspecified)
+					context.PushEvaluatingAs(context.EvaluatingAs);
+				else
+					context.PushEvaluatingAs(SpecVersion);
 			}
 			var localConstraints = new List<KeywordConstraint>();
-			var version = DeclaredVersion == SpecVersion.Unspecified ? context.EvaluatingAs : DeclaredVersion;
+			var version = SpecVersion == SpecVersion.Unspecified ? context.EvaluatingAs : SpecVersion;
 			var keywords = EvaluationOptions.FilterKeywords(context.GetKeywordsToProcess(this, context.Options), version).ToArray();
 			var unrecognized = Keywords!.OfType<UnrecognizedKeyword>();
 			var unrecognizedButSupported = Keywords!.Except(keywords).ToArray();
@@ -466,122 +454,14 @@ public class JsonSchema : IBaseDocument
 		}
 	}
 
-	internal static void Initialize(JsonSchema schema, SchemaRegistry registry, Uri? baseUri = null)
-	{
-		PopulateBaseUris(schema, schema, baseUri ?? schema.BaseUri, registry, selfRegister: true);
-	}
-
-	private static SpecVersion DetermineSpecVersion(JsonSchema schema, SchemaRegistry registry, SpecVersion desiredDraft)
-	{
-		if (schema.BoolValue.HasValue) return SpecVersion.DraftNext;
-		if (schema.DeclaredVersion != SpecVersion.Unspecified) return schema.DeclaredVersion;
-		if (!_definedSpecVersions.Contains(desiredDraft)) return desiredDraft;
-
-		if (schema.TryGetKeyword<SchemaKeyword>(SchemaKeyword.Name, out var schemaKeyword))
-		{
-			var metaSchemaId = schemaKeyword.Schema;
-			while (metaSchemaId != null)
-			{
-				var version = metaSchemaId.OriginalString switch
-				{
-					MetaSchemas.Draft6IdValue => SpecVersion.Draft6,
-					MetaSchemas.Draft7IdValue => SpecVersion.Draft7,
-					MetaSchemas.Draft201909IdValue => SpecVersion.Draft201909,
-					MetaSchemas.Draft202012IdValue => SpecVersion.Draft202012,
-					MetaSchemas.DraftNextIdValue => SpecVersion.DraftNext,
-					_ => SpecVersion.Unspecified
-				};
-				if (version != SpecVersion.Unspecified)
-				{
-					schema.DeclaredVersion = version;
-					return version;
-				}
-
-				var metaSchema = registry.Get(metaSchemaId) as JsonSchema ??
-					throw new JsonSchemaException("Cannot resolve custom meta-schema.");
-
-				if (metaSchema.TryGetKeyword<SchemaKeyword>(SchemaKeyword.Name, out var newMetaSchemaKeyword) &&
-				    newMetaSchemaKeyword.Schema == metaSchemaId)
-					throw new JsonSchemaException("Custom meta-schema `$schema` keywords must eventually resolve to a meta-schema for a supported specification version.");
-
-				metaSchemaId = newMetaSchemaKeyword?.Schema;
-			}
-		}
-
-		if (desiredDraft != SpecVersion.Unspecified) return desiredDraft;
-
-		var allDraftsArray = GetSpecVersions();
-		var allDrafts = allDraftsArray.Aggregate(SpecVersion.Unspecified, (a, x) => a | x);
-		var commonDrafts = schema.Keywords!.Aggregate(allDrafts, (a, x) => a & x.VersionsSupported());
-		var candidates = allDraftsArray.Where(x => commonDrafts.HasFlag(x)).ToArray();
-
-		return candidates.Length != 0 ? candidates.Max() : SpecVersion.DraftNext;
-	}
-
-	private static void PopulateBaseUris(JsonSchema schema, JsonSchema resourceRoot, Uri currentBaseUri, SchemaRegistry registry, SpecVersion evaluatingAs = SpecVersion.Unspecified, bool selfRegister = false)
-	{
-		if (schema.BoolValue.HasValue) return;
-		evaluatingAs = DetermineSpecVersion(schema, registry, evaluatingAs);
-		if (evaluatingAs is SpecVersion.Draft6 or SpecVersion.Draft7 &&
-			schema.TryGetKeyword<RefKeyword>(RefKeyword.Name, out _))
-		{
-			schema.BaseUri = currentBaseUri;
-			if (selfRegister)
-				registry.RegisterSchema(schema.BaseUri, schema);
-		}
-		else
-		{
-			var idKeyword = (IIdKeyword?)schema.Keywords!.FirstOrDefault(x => x is IIdKeyword);
-			if (idKeyword != null)
-			{
-				if (evaluatingAs <= SpecVersion.Draft7 &&
-				    idKeyword.Id.OriginalString[0] == '#' &&
-				    AnchorKeyword.AnchorPattern201909.IsMatch(idKeyword.Id.OriginalString[1..]))
-				{
-					schema.BaseUri = currentBaseUri;
-					resourceRoot.Anchors[idKeyword.Id.OriginalString[1..]] = (schema, false);
-				}
-				else
-				{
-					schema.IsResourceRoot = true;
-					schema.DeclaredVersion = evaluatingAs;
-					resourceRoot = schema;
-					schema.BaseUri = new Uri(currentBaseUri, idKeyword.Id);
-					registry.RegisterSchema(schema.BaseUri, schema);
-				}
-			}
-			else
-			{
-				schema.BaseUri = currentBaseUri;
-				if (selfRegister)
-					registry.RegisterSchema(schema.BaseUri, schema);
-			}
-
-			if (schema.TryGetKeyword<AnchorKeyword>(AnchorKeyword.Name, out var anchorKeyword)) 
-				resourceRoot.Anchors[anchorKeyword.Anchor] = (schema, false);
-
-			if (schema.TryGetKeyword<DynamicAnchorKeyword>(DynamicAnchorKeyword.Name, out var dynamicAnchorKeyword)) 
-				resourceRoot.Anchors[dynamicAnchorKeyword.Value] = (schema, true);
-
-			schema.TryGetKeyword<RecursiveAnchorKeyword>(RecursiveAnchorKeyword.Name, out var recursiveAnchorKeyword);
-			if (recursiveAnchorKeyword is { Value: true })
-				resourceRoot.RecursiveAnchor = schema;
-		}
-
-		var subschemas = schema.Keywords!.SelectMany(GetSubschemas);
-
-		foreach (var subschema in subschemas)
-		{
-			PopulateBaseUris(subschema, resourceRoot, schema.BaseUri, registry, evaluatingAs);
-		}
-	}
+	internal static IEnumerable<JsonSchema> GetSubschemas(JsonSchema schema) => schema.BoolValue.HasValue ? [] : schema.Keywords!.SelectMany(GetSubschemas);
 
 	internal static IEnumerable<JsonSchema> GetSubschemas(IJsonSchemaKeyword keyword)
 	{
 		switch (keyword)
 		{
 			// ReSharper disable once RedundantAlwaysMatchSubpattern
-			case ISchemaContainer { Schema: { } } container:
+			case ISchemaContainer { Schema: not null } container:
 				yield return container.Schema;
 				break;
 			case ISchemaCollector collector:
@@ -613,7 +493,6 @@ public class JsonSchema : IBaseDocument
 
 			var asSchema = FromText(value?.ToString() ?? "null");
 			asSchema.BaseUri = hostSchema.BaseUri;
-			PopulateBaseUris(asSchema, hostSchema, hostSchema.BaseUri, options.SchemaRegistry);
 			return asSchema;
 		}
 
@@ -703,18 +582,6 @@ public class JsonSchema : IBaseDocument
 		// last segment of the pointer is an ISchemaContainer.
 		return CheckResolvable(resolvable, ref count, null!, ref currentSchema) as JsonSchema;
 	}
-
-	/// <summary>
-	/// Gets a defined anchor.
-	/// </summary>
-	/// <param name="anchorName">The name of the anchor (excluding the `#`)</param>
-	/// <returns>The associated subschema, if the anchor exists, or null.</returns>
-	public JsonSchema? GetAnchor(string anchorName) =>
-		Anchors.TryGetValue(anchorName, out var anchorDefinition)
-			? anchorDefinition.IsDynamic
-				? null
-				: anchorDefinition.Schema
-			: null;
 
 	/// <summary>
 	/// Implicitly converts a boolean value into one of the boolean schemas. 

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -68,7 +68,7 @@ public class JsonSchema : IBaseDocument
 	/// It may change after the initial evaluation based on whether the schema contains an `$id` keyword
 	/// or is a child of another schema.
 	/// </remarks>
-	public Uri BaseUri { get; set; } = GenerateBaseUri();
+	public Uri BaseUri { get; set; } = SchemaRegistry.GenerateBaseUri();
 
 	/// <summary>
 	/// Gets whether the schema defines a new schema resource.  This will only be true if it contains an `$id` keyword.
@@ -215,8 +215,6 @@ public class JsonSchema : IBaseDocument
 
 		return schema.Evaluate(root, options);
 	}
-
-	private static Uri GenerateBaseUri() => new($"https://json-everything.net/{Guid.NewGuid().ToString("N")[..10]}");
 
 	/// <summary>
 	/// Gets a specified keyword if it exists.
@@ -442,7 +440,7 @@ public class JsonSchema : IBaseDocument
 				constraint.UnknownKeywords = new JsonArray(unrecognizedButSupported.Concat(unrecognized)
 					.Select(x => (JsonNode?)x.Keyword())
 					.ToArray());
-			foreach (var keyword in keywords.OrderBy(x => x.Priority()))
+			foreach (var keyword in keywords.OrderBy(x => x.GetType().GetPriority()))
 			{
 				var keywordConstraint = keyword.GetConstraint(constraint, localConstraints, context);
 				localConstraints.Add(keywordConstraint);

--- a/JsonSchema/JsonSchema.cs
+++ b/JsonSchema/JsonSchema.cs
@@ -71,6 +71,18 @@ public class JsonSchema : IBaseDocument
 	public Uri BaseUri { get; set; } = GenerateBaseUri();
 
 	/// <summary>
+	/// Gets whether the schema defines a new schema resource.  This will only be true if it contains an `$id` keyword.
+	/// </summary>
+	[Obsolete("This property is no longer used and will be removed with the next major version.")]
+	public bool IsResourceRoot { get; private set; }
+
+	/// <summary>
+	/// Gets the specification version as determined by analyzing the `$schema` keyword, if it exists.
+	/// </summary>
+	[Obsolete("This property has been replaced by SpecVersion.")]
+	public SpecVersion DeclaredVersion => SpecVersion;
+
+	/// <summary>
 	/// Gets the specification version as determined by analyzing the `$schema` keyword, if it exists.
 	/// </summary>
 	public SpecVersion SpecVersion { get; internal set; }
@@ -582,6 +594,14 @@ public class JsonSchema : IBaseDocument
 		// last segment of the pointer is an ISchemaContainer.
 		return CheckResolvable(resolvable, ref count, null!, ref currentSchema) as JsonSchema;
 	}
+
+	/// <summary>
+	/// Obsolete - returns null.
+	/// </summary>
+	/// <param name="anchorName">The name of the anchor (excluding the `#`)</param>
+	/// <returns>null</returns>
+	[Obsolete("This property is no longer used and will be removed with the next major version.  Updated to simply return null as the infrastructure required to support it has been removed.")]
+	public JsonSchema? GetAnchor(string anchorName) => null;
 
 	/// <summary>
 	/// Implicitly converts a boolean value into one of the boolean schemas. 

--- a/JsonSchema/JsonSchemaExtensions.cs
+++ b/JsonSchema/JsonSchemaExtensions.cs
@@ -48,7 +48,7 @@ public static partial class JsonSchemaExtensions
 	{
 		options = EvaluationOptions.From(options ?? EvaluationOptions.Default);
 
-		JsonSchema.Initialize(jsonSchema, options.SchemaRegistry);
+		options.SchemaRegistry.Register(jsonSchema);
 
 		var schemasToSearch = new List<JsonSchema>();
 		var searchedSchemas = new List<JsonSchema>(); // uses reference equality
@@ -62,12 +62,8 @@ public static partial class JsonSchemaExtensions
 			referencesToCheck.RemoveAt(0);
 
 			var resolved = options.SchemaRegistry.Get(nextReference);
-			if (resolved == null)
-				throw new JsonSchemaException($"Cannot resolve reference: '{nextReference}'");
 			if (resolved is not JsonSchema resolvedSchema)
 				throw new NotSupportedException("Bundling is not supported for non-schema root documents");
-
-			JsonSchema.Initialize(resolvedSchema, options.SchemaRegistry);
 
 			if (!bundledReferences.Contains(nextReference))
 			{

--- a/JsonSchema/KeywordConstraint.cs
+++ b/JsonSchema/KeywordConstraint.cs
@@ -32,7 +32,7 @@ public class KeywordConstraint
 	/// This method takes a <see cref="KeywordEvaluation"/> which contains the local instance being evaluated
 	/// and the local results object.
 	/// </remarks>
-	public Action<KeywordEvaluation, EvaluationContext> Evaluator { get; }
+	public Action<KeywordEvaluation> Evaluator { get; }
 
 	/// <summary>
 	/// Gets or sets the collection of keyword constraints (i.e. sibling keywords) that this keyword is dependent upon.
@@ -50,7 +50,7 @@ public class KeywordConstraint
 	/// </summary>
 	/// <param name="keyword">The keyword name.</param>
 	/// <param name="evaluator">A method that used to apply the actual constraint behavior.</param>
-	public KeywordConstraint(string keyword, Action<KeywordEvaluation, EvaluationContext> evaluator)
+	public KeywordConstraint(string keyword, Action<KeywordEvaluation> evaluator)
 	{
 		Keyword = keyword;
 		Evaluator = evaluator;

--- a/JsonSchema/KeywordConstraint.cs
+++ b/JsonSchema/KeywordConstraint.cs
@@ -32,7 +32,7 @@ public class KeywordConstraint
 	/// This method takes a <see cref="KeywordEvaluation"/> which contains the local instance being evaluated
 	/// and the local results object.
 	/// </remarks>
-	public Action<KeywordEvaluation> Evaluator { get; }
+	public Action<KeywordEvaluation, EvaluationContext> Evaluator { get; }
 
 	/// <summary>
 	/// Gets or sets the collection of keyword constraints (i.e. sibling keywords) that this keyword is dependent upon.
@@ -50,7 +50,7 @@ public class KeywordConstraint
 	/// </summary>
 	/// <param name="keyword">The keyword name.</param>
 	/// <param name="evaluator">A method that used to apply the actual constraint behavior.</param>
-	public KeywordConstraint(string keyword, Action<KeywordEvaluation> evaluator)
+	public KeywordConstraint(string keyword, Action<KeywordEvaluation, EvaluationContext> evaluator)
 	{
 		Keyword = keyword;
 		Evaluator = evaluator;

--- a/JsonSchema/KeywordExtensions.cs
+++ b/JsonSchema/KeywordExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Json.Schema;
 
@@ -10,51 +7,6 @@ namespace Json.Schema;
 /// </summary>
 public static class KeywordExtensions
 {
-	static KeywordExtensions()
-	{
-		_keywordEvaluationGroups = [];
-
-		var allTypes = AllKeywordTypes.ToList();
-
-		var allDependencies = allTypes.ToDictionary(x => x, x => x.GetCustomAttributes<DependsOnAnnotationsFromAttribute>().Select(y => y.DependentType));
-
-		_keywordEvaluationGroups[typeof(SchemaKeyword)] = -2;
-		_keywordEvaluationGroups[typeof(IdKeyword)] = -1;
-		_keywordEvaluationGroups[typeof(UnevaluatedItemsKeyword)] = int.MaxValue;
-		_keywordEvaluationGroups[typeof(UnevaluatedPropertiesKeyword)] = int.MaxValue;
-
-		allTypes.Remove(typeof(SchemaKeyword));
-		allTypes.Remove(typeof(IdKeyword));
-		allTypes.Remove(typeof(UnevaluatedItemsKeyword));
-		allTypes.Remove(typeof(UnevaluatedPropertiesKeyword));
-
-		allTypes.Remove(typeof(UnrecognizedKeyword));
-
-		var groupId = 0;
-		while (allTypes.Count != 0)
-		{
-			var groupKeywords = allTypes.Where(x => allDependencies[x].All(d => !allTypes.Contains(d))).ToArray();
-
-			foreach (var groupKeyword in groupKeywords)
-			{
-				_keywordEvaluationGroups[groupKeyword] = groupId;
-				allTypes.Remove(groupKeyword);
-			}
-
-			groupId++;
-		}
-	}
-
-	private static IEnumerable<Type> AllKeywordTypes { get; } = 
-		SchemaKeywordRegistry.KeywordTypes
-			.Where(t => typeof(IJsonSchemaKeyword).IsAssignableFrom(t) &&
-			            t is { IsAbstract: false, IsInterface: false }).ToList();
-
-	private static readonly Dictionary<Type, string> _keywordNames =
-		AllKeywordTypes
-			.Where(t => t != typeof(UnrecognizedKeyword))
-			.ToDictionary(t => t, t => t.GetCustomAttribute<SchemaKeywordAttribute>()!.Name);
-
 	/// <summary>
 	/// Gets the keyword string.
 	/// </summary>
@@ -62,23 +14,8 @@ public static class KeywordExtensions
 	/// <returns>The keyword string.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="keyword"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">The keyword does not carry the <see cref="SchemaKeywordAttribute"/>.</exception>
-	public static string Keyword(this IJsonSchemaKeyword keyword)
-	{
-		if (keyword == null) throw new ArgumentNullException(nameof(keyword));
-
-		if (keyword is UnrecognizedKeyword unrecognized) return unrecognized.Name;
-
-		var keywordType = keyword.GetType();
-		if (!_keywordNames.TryGetValue(keywordType, out var name))
-		{
-			name = keywordType.GetCustomAttribute<SchemaKeywordAttribute>()?.Name;
-
-			_keywordNames[keywordType] = name ??
-				throw new InvalidOperationException($"Type {keywordType.Name} must be decorated with {nameof(SchemaKeywordAttribute)}");
-		}
-
-		return name;
-	}
+	[Obsolete("This method has been replaced by SchemaKeywordRegistry.Keyword(IJsonSchemaKeyword).")]
+	public static string Keyword(IJsonSchemaKeyword keyword) => keyword.Keyword();
 
 	/// <summary>
 	/// Gets the keyword string.
@@ -87,54 +24,16 @@ public static class KeywordExtensions
 	/// <returns>The keyword string.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="keywordType"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">The keyword does not carry the <see cref="SchemaKeywordAttribute"/>.</exception>
-	public static string Keyword(this Type keywordType)
-	{
-		if (keywordType == null) throw new ArgumentNullException(nameof(keywordType));
-
-		if (!_keywordNames.TryGetValue(keywordType, out var name))
-		{
-			name = keywordType.GetCustomAttribute<SchemaKeywordAttribute>()?.Name;
-
-			_keywordNames[keywordType] = name ??
-				throw new InvalidOperationException($"Type {keywordType.Name} must be decorated with {nameof(SchemaKeywordAttribute)}");
-		}
-
-		return name;
-	}
-
-	private static readonly Dictionary<Type, int> _keywordEvaluationGroups;
+	[Obsolete("This method has been replaced by SchemaKeywordRegistry.Keyword(Type).")]
+	public static string Keyword(Type keywordType) => keywordType.Keyword();
 
 	/// <summary>
 	/// Gets the keyword priority.
 	/// </summary>
 	/// <param name="keyword">The keyword.</param>
 	/// <returns>The priority.</returns>
-	public static long Priority(this IJsonSchemaKeyword keyword)
-	{
-		if (keyword == null) throw new ArgumentNullException(nameof(keyword));
-
-		var keywordType = keyword.GetType();
-
-		if (!_keywordEvaluationGroups.TryGetValue(keywordType, out var priority))
-		{
-			var keywordDependencies = keywordType.GetCustomAttributes<DependsOnAnnotationsFromAttribute>().Select(x => x.DependentType);
-			var dependencyPriorities = _keywordEvaluationGroups.Join(keywordDependencies,
-				eg => eg.Key,
-				kd => kd,
-				(eg, _) => eg)
-				.ToArray();
-			priority = dependencyPriorities.Length == 0
-				? 0
-				: dependencyPriorities.Max(x => x.Value);
-		}
-
-		return priority;
-	}
-
-	private static readonly Dictionary<Type, SpecVersion> _versionDeclarations =
-		AllKeywordTypes
-			.ToDictionary(t => t, t => t.GetCustomAttributes<SchemaSpecVersionAttribute>()
-				.Aggregate(SpecVersion.Unspecified, (c, x) => c | x.Version));
+	[Obsolete("This method has been replaced by SchemaKeywordRegistry.GetPriority().")]
+	public static long Priority(this IJsonSchemaKeyword keyword) => keyword.GetType().GetPriority();
 
 	/// <summary>
 	/// Determines if a keyword is declared by a given version of the JSON Schema specification.
@@ -144,23 +43,8 @@ public static class KeywordExtensions
 	/// <returns>true if the keyword is supported by the version; false otherwise</returns>
 	/// <exception cref="ArgumentNullException">Thrown if <paramref name="keyword"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">Thrown if the keyword has no <see cref="SchemaSpecVersionAttribute"/> declarations.</exception>
-	public static bool SupportsVersion(this IJsonSchemaKeyword keyword, SpecVersion version)
-	{
-		if (keyword == null) throw new ArgumentNullException(nameof(keyword));
-
-		var keywordType = keyword.GetType();
-		if (!_versionDeclarations.TryGetValue(keywordType, out var supportedVersions))
-		{
-			supportedVersions = keywordType.GetCustomAttributes<SchemaSpecVersionAttribute>()
-				.Aggregate(SpecVersion.Unspecified, (c, x) => c | x.Version);
-			if (supportedVersions == SpecVersion.Unspecified)
-				throw new InvalidOperationException($"Type {keywordType.Name} must be decorated with {nameof(SchemaSpecVersionAttribute)}");
-
-			_versionDeclarations[keywordType] = supportedVersions;
-		}
-
-		return supportedVersions.HasFlag(version);
-	}
+	[Obsolete("This method has been replaced by SchemaKeywordRegistry.SupportsVersion().")]
+	public static bool SupportsVersion(IJsonSchemaKeyword keyword, SpecVersion version) => keyword.SupportsVersion(version);
 
 	/// <summary>
 	/// Gets the specification versions supported by a keyword.
@@ -170,28 +54,5 @@ public static class KeywordExtensions
 	/// <exception cref="ArgumentNullException">Thrown if <paramref name="keyword"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">Thrown if the keyword has no <see cref="SchemaSpecVersionAttribute"/> declarations.</exception>
 	[Obsolete("This method is no longer used and will be removed with the next major version.")]
-	public static SpecVersion VersionsSupported(this IJsonSchemaKeyword keyword)
-	{
-		if (keyword == null) throw new ArgumentNullException(nameof(keyword));
-
-		var keywordType = keyword.GetType();
-		if (!_versionDeclarations.TryGetValue(keywordType, out var supportedVersions))
-		{
-			supportedVersions = keywordType.GetCustomAttributes<SchemaSpecVersionAttribute>()
-				.Aggregate(SpecVersion.Unspecified, (c, x) => c | x.Version);
-			if (supportedVersions == SpecVersion.Unspecified)
-				throw new InvalidOperationException($"Type {keywordType.Name} must be decorated with {nameof(SchemaSpecVersionAttribute)}");
-
-			_versionDeclarations[keywordType] = supportedVersions;
-		}
-
-		return supportedVersions;
-	}
-
-	internal static bool ProducesDependentAnnotations(this Type keywordType)
-	{
-		if (keywordType == null) throw new ArgumentNullException(nameof(keywordType));
-
-		return _keywordEvaluationGroups.Where(x => x.Value > 0).Any(x => x.Key == keywordType);
-	}
+	public static SpecVersion VersionsSupported(this IJsonSchemaKeyword keyword) => SpecVersion.Unspecified;
 }

--- a/JsonSchema/KeywordExtensions.cs
+++ b/JsonSchema/KeywordExtensions.cs
@@ -62,7 +62,6 @@ public static class KeywordExtensions
 	/// <returns>The keyword string.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="keyword"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">The keyword does not carry the <see cref="SchemaKeywordAttribute"/>.</exception>
-	// TODO: Reflection can be replaced with static members when moving to .Net 7
 	public static string Keyword(this IJsonSchemaKeyword keyword)
 	{
 		if (keyword == null) throw new ArgumentNullException(nameof(keyword));
@@ -88,7 +87,6 @@ public static class KeywordExtensions
 	/// <returns>The keyword string.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="keywordType"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">The keyword does not carry the <see cref="SchemaKeywordAttribute"/>.</exception>
-	// TODO: Reflection can be replaced with static members when moving to .Net 7
 	public static string Keyword(this Type keywordType)
 	{
 		if (keywordType == null) throw new ArgumentNullException(nameof(keywordType));
@@ -171,6 +169,7 @@ public static class KeywordExtensions
 	/// <returns>The specification versions as a single flags value.</returns>
 	/// <exception cref="ArgumentNullException">Thrown if <paramref name="keyword"/> is null.</exception>
 	/// <exception cref="InvalidOperationException">Thrown if the keyword has no <see cref="SchemaSpecVersionAttribute"/> declarations.</exception>
+	[Obsolete("This method is no longer used and will be removed with the next major version.")]
 	public static SpecVersion VersionsSupported(this IJsonSchemaKeyword keyword)
 	{
 		if (keyword == null) throw new ArgumentNullException(nameof(keyword));

--- a/JsonSchema/MetaSchemas.cs
+++ b/JsonSchema/MetaSchemas.cs
@@ -3,4 +3,40 @@
 /// <summary>
 /// Exposes the meta-schemas for the supported drafts.
 /// </summary>
-public static partial class MetaSchemas;
+public static partial class MetaSchemas
+{
+	static MetaSchemas()
+	{
+		SchemaRegistry.Global.Register(Draft6Id, Draft6);
+
+		SchemaRegistry.Global.Register(Draft7Id, Draft7);
+
+		SchemaRegistry.Global.Register(Draft201909Id, Draft201909);
+		SchemaRegistry.Global.Register(Core201909Id, Core201909);
+		SchemaRegistry.Global.Register(Applicator201909Id, Applicator201909);
+		SchemaRegistry.Global.Register(Validation201909Id, Validation201909);
+		SchemaRegistry.Global.Register(Metadata201909Id, Metadata201909);
+		SchemaRegistry.Global.Register(Format201909Id, Format201909);
+		SchemaRegistry.Global.Register(Content201909Id, Content201909);
+
+		SchemaRegistry.Global.Register(Draft202012Id, Draft202012);
+		SchemaRegistry.Global.Register(Core202012Id, Core202012);
+		SchemaRegistry.Global.Register(Unevaluated202012Id, Unevaluated202012);
+		SchemaRegistry.Global.Register(Applicator202012Id, Applicator202012);
+		SchemaRegistry.Global.Register(Validation202012Id, Validation202012);
+		SchemaRegistry.Global.Register(Metadata202012Id, Metadata202012);
+		SchemaRegistry.Global.Register(FormatAnnotation202012Id, FormatAnnotation202012);
+		SchemaRegistry.Global.Register(FormatAssertion202012Id, FormatAssertion202012);
+		SchemaRegistry.Global.Register(Content202012Id, Content202012);
+
+		SchemaRegistry.Global.Register(DraftNextId, DraftNext);
+		SchemaRegistry.Global.Register(CoreNextId, CoreNext);
+		SchemaRegistry.Global.Register(UnevaluatedNextId, UnevaluatedNext);
+		SchemaRegistry.Global.Register(ApplicatorNextId, ApplicatorNext);
+		SchemaRegistry.Global.Register(ValidationNextId, ValidationNext);
+		SchemaRegistry.Global.Register(MetadataNextId, MetadataNext);
+		SchemaRegistry.Global.Register(FormatAnnotationNextId, FormatAnnotationNext);
+		SchemaRegistry.Global.Register(FormatAssertionNextId, FormatAssertionNext);
+		SchemaRegistry.Global.Register(ContentNextId, ContentNext);
+	}
+}

--- a/JsonSchema/Net8Extensions.cs
+++ b/JsonSchema/Net8Extensions.cs
@@ -1,0 +1,15 @@
+﻿#if NETSTANDARD2_0
+
+using System.Collections.Generic;
+
+namespace Json.Schema;
+
+internal static class Net8Extensions
+{
+	public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+	{
+		return dictionary.TryGetValue(key, out var value) ? value : default;
+	}
+}
+
+#endif

--- a/JsonSchema/RefKeyword.cs
+++ b/JsonSchema/RefKeyword.cs
@@ -68,7 +68,8 @@ public class RefKeyword : IJsonSchemaKeyword
 		var targetBase = context.Options.SchemaRegistry.Get(newBaseUri);
 
 		if (JsonPointer.TryParse(fragment, out var pointerFragment))
-			targetSchema = targetBase.FindSubschema(pointerFragment, context.Options);
+			targetSchema = targetBase.FindSubschema(pointerFragment, context.Options) ??
+			               throw new SchemaRefResolutionException(newBaseUri, pointerFragment);
 		else
 		{
 			var anchorFragment = fragment[1..];
@@ -78,9 +79,6 @@ public class RefKeyword : IJsonSchemaKeyword
 
 			targetSchema = (JsonSchema) context.Options.SchemaRegistry.Get(newBaseUri, anchorFragment, context.EvaluatingAs is SpecVersion.Draft6 or SpecVersion.Draft7);
 		}
-
-		if (targetSchema == null)
-			throw new JsonSchemaException($"Cannot resolve schema `{newUri}`");
 
 		context.NavigatedReferences.Push(navigation);
 		var subschemaConstraint = targetSchema.GetConstraint(JsonPointer.Create(Name), schemaConstraint.BaseInstanceLocation, JsonPointer.Empty, context);

--- a/JsonSchema/RefResolutionException.cs
+++ b/JsonSchema/RefResolutionException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Json.Pointer;
+
+namespace Json.Schema;
+
+public class SchemaRefResolutionException : Exception
+{
+	public Uri BaseUri { get; }
+	public string? Anchor { get; }
+	public bool IsDynamic { get; }
+	public JsonPointer? Location { get; }
+
+	// isDynamic true and anchor null means recursive
+	public SchemaRefResolutionException(Uri baseUri, string? anchor = null, bool isDynamic = false)
+		: base($"Could not resolve {Format(baseUri, anchor, isDynamic)}")
+	{
+		BaseUri = baseUri;
+		Anchor = anchor;
+		IsDynamic = isDynamic;
+	}
+
+	public SchemaRefResolutionException(Uri baseUri, JsonPointer location)
+		: base($"Could not resolve schema '{baseUri}#{location}'")
+	{
+		BaseUri = baseUri;
+		Location = location;
+	}
+
+	private static string Format(Uri baseUri, string? anchor, bool isDynamic)
+	{
+		return anchor is null
+			? (isDynamic ? $"recursive reference in '{baseUri}'" : $"'{baseUri}'")
+			: $"{(isDynamic ? "dynamic " : string.Empty)}anchor '{anchor}' in schema '{baseUri}'";
+	}
+}

--- a/JsonSchema/RefResolutionException.cs
+++ b/JsonSchema/RefResolutionException.cs
@@ -3,15 +3,30 @@ using Json.Pointer;
 
 namespace Json.Schema;
 
+/// <summary>
+/// Thrown when an attempt to resolve a URI reference fails.
+/// </summary>
 public class SchemaRefResolutionException : Exception
 {
+	/// <summary>
+	/// Gets the base URI.
+	/// </summary>
 	public Uri BaseUri { get; }
+	/// <summary>
+	/// Gets an anchor fragment, if applicable.
+	/// </summary>
 	public string? Anchor { get; }
+	/// <summary>
+	/// Gets whether the reference was dynamic, i.e. `$dynamicRef`.
+	/// </summary>
 	public bool IsDynamic { get; }
+	/// <summary>
+	/// Gets a JSON Pointer fragment, if applicable.
+	/// </summary>
 	public JsonPointer? Location { get; }
 
 	// isDynamic true and anchor null means recursive
-	public SchemaRefResolutionException(Uri baseUri, string? anchor = null, bool isDynamic = false)
+	internal SchemaRefResolutionException(Uri baseUri, string? anchor = null, bool isDynamic = false)
 		: base($"Could not resolve {Format(baseUri, anchor, isDynamic)}")
 	{
 		BaseUri = baseUri;
@@ -19,7 +34,7 @@ public class SchemaRefResolutionException : Exception
 		IsDynamic = isDynamic;
 	}
 
-	public SchemaRefResolutionException(Uri baseUri, JsonPointer location)
+	internal SchemaRefResolutionException(Uri baseUri, JsonPointer location)
 		: base($"Could not resolve schema '{baseUri}#{location}'")
 	{
 		BaseUri = baseUri;

--- a/JsonSchema/SchemaConstraint.cs
+++ b/JsonSchema/SchemaConstraint.cs
@@ -19,7 +19,7 @@ public class SchemaConstraint
 	/// <summary>
 	/// Gets the schema's base URI.
 	/// </summary>
-	public Uri SchemaBaseUri { get; }
+	public Uri SchemaBaseUri { get; internal set; }
 
 	/// <summary>
 	/// Gets the base location within the instance that is being evaluated.

--- a/JsonSchema/SchemaKeywordRegistry.cs
+++ b/JsonSchema/SchemaKeywordRegistry.cs
@@ -107,6 +107,9 @@ public static class SchemaKeywordRegistry
 			[typeof(ConstKeyword)] = new ConstKeyword(null),
 			[typeof(DefaultKeyword)] = new DefaultKeyword(null)
 		};
+
+		// HACK - need to touch the meta-schemas to initialize the type and register them
+		_ = MetaSchemas.Draft7Id;
 	}
 
 	/// <summary>

--- a/JsonSchema/SchemaKeywordRegistry.cs
+++ b/JsonSchema/SchemaKeywordRegistry.cs
@@ -108,8 +108,9 @@ public static class SchemaKeywordRegistry
 			[typeof(DefaultKeyword)] = new DefaultKeyword(null)
 		};
 
-		// HACK - need to touch the meta-schemas to initialize the type and register them
-		_ = MetaSchemas.Draft7Id;
+		// HACK - need to touch these to initialize the type and register them
+		_ = MetaSchemas.Draft6Id;
+		_ = Vocabularies.Core201909;
 	}
 
 	/// <summary>

--- a/JsonSchema/SchemaRefResolutionException.cs
+++ b/JsonSchema/SchemaRefResolutionException.cs
@@ -6,7 +6,7 @@ namespace Json.Schema;
 /// <summary>
 /// Thrown when an attempt to resolve a URI reference fails.
 /// </summary>
-public class SchemaRefResolutionException : Exception
+public class SchemaRefResolutionException : JsonSchemaException
 {
 	/// <summary>
 	/// Gets the base URI.

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -138,6 +138,17 @@ public class SchemaRegistry
 		}
 	}
 
+	/// <summary>
+	/// Gets a schema by URI ID and/or anchor.
+	/// </summary>
+	/// <param name="baseUri">The URI ID.</param>
+	/// <param name="anchor">An anchor, if applicable.</param>
+	/// <param name="allowLegacy">Specifies whether `$id` is allowed to contain anchors (drafts 6/7 only).</param>
+	/// <returns>
+	/// The schema, if registered in either this or the global registry; otherwise null.
+	/// </returns>
+	// For URI equality see https://docs.microsoft.com/en-us/dotnet/api/system.uri.op_equality?view=netcore-3.1
+	// tl;dr - URI equality doesn't consider fragments
 	public IBaseDocument Get(Uri baseUri, string? anchor = null, bool allowLegacy = false)
 	{
 		return GetAnchor(baseUri, anchor, false, allowLegacy) ?? throw new SchemaRefResolutionException(baseUri, anchor);

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -273,7 +273,7 @@ public class SchemaRegistry
 				};
 
 			var idText = id?.OriginalString;
-			if (!string.IsNullOrEmpty(idText) && idText![0] == '#' && AnchorKeyword.AnchorPattern201909.IsMatch(idText[1..]))
+			if (!string.IsNullOrEmpty(idText) && idText[0] == '#' && AnchorKeyword.AnchorPattern201909.IsMatch(idText[1..]))
 				registration.LegacyAnchors[idText[1..]] = currentSchema;
 
 			var dynamicAnchor = currentSchema.GetDynamicAnchor();

--- a/JsonSchema/SchemaRegistry.cs
+++ b/JsonSchema/SchemaRegistry.cs
@@ -228,12 +228,16 @@ public class SchemaRegistry
 			if (id is not null && (currentSchema.GetRef() is null || currentVersion is not (SpecVersion.Draft6 or SpecVersion.Draft7)))
 			{
 				currentUri = new Uri(currentUri, id);
+			}
+
+			currentSchema.BaseUri = currentUri;
+
+			if (id is not null || ReferenceEquals(currentSchema, baseDocument))
+			{
 				var metaschema = currentSchema.GetSchema();
 				if (metaschema is not null)
 					currentSchema.SpecVersion = currentVersion = GetMetaschemaVersion(currentSchema);
 			}
-
-			currentSchema.BaseUri = currentUri;
 
 			if (!registrations.TryGetValue(currentUri, out var registration))
 				registrations[currentUri] = registration = new Registration

--- a/JsonSchema/Vocabularies.cs
+++ b/JsonSchema/Vocabularies.cs
@@ -21,92 +21,114 @@ public static partial class Vocabularies
 		Core201909 = new Vocabulary(
 			Core201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Core201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Core201909);
 		Applicator201909 = new Vocabulary(
 			Applicator201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Applicator201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Applicator201909);
 		Validation201909 = new Vocabulary(
 			Validation201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Validation201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Validation201909);
 		Metadata201909 = new Vocabulary(
 			Metadata201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Metadata201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Metadata201909);
 		Format201909 = new Vocabulary(
 			Format201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Format201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Format201909);
 		Content201909 = new Vocabulary(
 			Content201909Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Content201909Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Content201909);
 
 		Core202012 = new Vocabulary(
 			Core202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Core202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Core202012);
 		Unevaluated202012 = new Vocabulary(
 			Unevaluated202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Unevaluated202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Unevaluated202012);
 		Applicator202012 = new Vocabulary(
 			Applicator202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Applicator202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Applicator202012);
 		Validation202012 = new Vocabulary(
 			Validation202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Validation202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Validation202012);
 		Metadata202012 = new Vocabulary(
 			Metadata202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Metadata202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Metadata202012);
 		FormatAnnotation202012 = new Vocabulary(
 			FormatAnnotation202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == FormatAnnotation202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.FormatAnnotation202012);
 		FormatAssertion202012 = new Vocabulary(
 			FormatAssertion202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == FormatAssertion202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.FormatAssertion202012);
 		Content202012 = new Vocabulary(
 			Content202012Id,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == Content202012Id))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.Content202012);
 
 		CoreNext = new Vocabulary(
 			CoreNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == CoreNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.CoreNext);
 		UnevaluatedNext = new Vocabulary(
 			UnevaluatedNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == UnevaluatedNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.UnevaluatedNext);
 		ApplicatorNext = new Vocabulary(
 			ApplicatorNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == ApplicatorNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.ApplicatorNext);
 		ValidationNext = new Vocabulary(
 			ValidationNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == ValidationNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.ValidationNext);
 		MetadataNext = new Vocabulary(
 			MetadataNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == MetadataNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.MetadataNext);
 		FormatAnnotationNext = new Vocabulary(
 			FormatAnnotationNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == FormatAnnotationNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.FormatAnnotationNext);
 		FormatAssertionNext = new Vocabulary(
 			FormatAssertionNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == FormatAssertionNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.FormatAssertionNext);
 		ContentNext = new Vocabulary(
 			ContentNextId,
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == ContentNextId))
-				.Select(k => k.Type));
+				.Select(k => k.Type),
+			MetaSchemas.ContentNext);
 	}
 }

--- a/JsonSchema/Vocabularies.cs
+++ b/JsonSchema/Vocabularies.cs
@@ -130,5 +130,31 @@ public static partial class Vocabularies
 			keywords.Where(k => k.Vocabularies.Any(v => v.Id.OriginalString == ContentNextId))
 				.Select(k => k.Type),
 			MetaSchemas.ContentNext);
+
+		VocabularyRegistry.Global.Register(Core201909);
+		VocabularyRegistry.Global.Register(Applicator201909);
+		VocabularyRegistry.Global.Register(Validation201909);
+		VocabularyRegistry.Global.Register(Metadata201909);
+		VocabularyRegistry.Global.Register(Format201909);
+		VocabularyRegistry.Global.Register(Content201909);
+		
+		VocabularyRegistry.Global.Register(Core202012);
+		VocabularyRegistry.Global.Register(Applicator202012);
+		VocabularyRegistry.Global.Register(Validation202012);
+		VocabularyRegistry.Global.Register(Metadata202012);
+		VocabularyRegistry.Global.Register(Unevaluated202012);
+		VocabularyRegistry.Global.Register(FormatAnnotation202012);
+		VocabularyRegistry.Global.Register(FormatAssertion202012);
+		VocabularyRegistry.Global.Register(Content202012);
+		
+		VocabularyRegistry.Global.Register(CoreNext);
+		VocabularyRegistry.Global.Register(ApplicatorNext);
+		VocabularyRegistry.Global.Register(ValidationNext);
+		VocabularyRegistry.Global.Register(MetadataNext);
+		VocabularyRegistry.Global.Register(UnevaluatedNext);
+		VocabularyRegistry.Global.Register(FormatAnnotationNext);
+		VocabularyRegistry.Global.Register(FormatAssertionNext);
+		VocabularyRegistry.Global.Register(ContentNext);
+
 	}
 }

--- a/JsonSchema/Vocabularies.cs
+++ b/JsonSchema/Vocabularies.cs
@@ -155,6 +155,5 @@ public static partial class Vocabularies
 		VocabularyRegistry.Global.Register(FormatAnnotationNext);
 		VocabularyRegistry.Global.Register(FormatAssertionNext);
 		VocabularyRegistry.Global.Register(ContentNext);
-
 	}
 }

--- a/JsonSchema/Vocabulary.cs
+++ b/JsonSchema/Vocabulary.cs
@@ -17,6 +17,9 @@ public class Vocabulary
 	/// </summary>
 	public IReadOnlyCollection<Type> Keywords { get; }
 
+	/// <summary>
+	/// Identifies a meta-schema, if there is one for the vocabulary.
+	/// </summary>
 	public JsonSchema? MetaSchema { get; }
 
 	/// <summary>
@@ -35,6 +38,7 @@ public class Vocabulary
 	/// </summary>
 	/// <param name="id">The vocabulary ID.</param>
 	/// <param name="keywords">The types of the keywords that are defined by the vocabulary.</param>
+	/// <param name="metaSchema">The meta-schema, if there is one for the vocabulary</param>
 	public Vocabulary(string id, IEnumerable<Type> keywords, JsonSchema? metaSchema = null)
 	{
 		MetaSchema = metaSchema;

--- a/JsonSchema/Vocabulary.cs
+++ b/JsonSchema/Vocabulary.cs
@@ -17,6 +17,8 @@ public class Vocabulary
 	/// </summary>
 	public IReadOnlyCollection<Type> Keywords { get; }
 
+	public JsonSchema? MetaSchema { get; }
+
 	/// <summary>
 	/// Creates a new <see cref="Vocabulary"/>.
 	/// </summary>
@@ -33,8 +35,9 @@ public class Vocabulary
 	/// </summary>
 	/// <param name="id">The vocabulary ID.</param>
 	/// <param name="keywords">The types of the keywords that are defined by the vocabulary.</param>
-	public Vocabulary(string id, IEnumerable<Type> keywords)
+	public Vocabulary(string id, IEnumerable<Type> keywords, JsonSchema? metaSchema = null)
 	{
+		MetaSchema = metaSchema;
 		Id = new Uri(id, UriKind.Absolute);
 		Keywords = keywords.ToReadOnlyList();
 	}

--- a/JsonSchema/VocabularyRegistry.cs
+++ b/JsonSchema/VocabularyRegistry.cs
@@ -13,37 +13,7 @@ public class VocabularyRegistry
 	/// <summary>
 	/// The global registry.
 	/// </summary>
-	public static VocabularyRegistry Global { get; }
-
-	static VocabularyRegistry()
-	{
-		Global = new VocabularyRegistry();
-
-		Global.Register(Vocabularies.Core201909);
-		Global.Register(Vocabularies.Applicator201909);
-		Global.Register(Vocabularies.Validation201909);
-		Global.Register(Vocabularies.Metadata201909);
-		Global.Register(Vocabularies.Format201909);
-		Global.Register(Vocabularies.Content201909);
-
-		Global.Register(Vocabularies.Core202012);
-		Global.Register(Vocabularies.Applicator202012);
-		Global.Register(Vocabularies.Validation202012);
-		Global.Register(Vocabularies.Metadata202012);
-		Global.Register(Vocabularies.Unevaluated202012);
-		Global.Register(Vocabularies.FormatAnnotation202012);
-		Global.Register(Vocabularies.FormatAssertion202012);
-		Global.Register(Vocabularies.Content202012);
-
-		Global.Register(Vocabularies.CoreNext);
-		Global.Register(Vocabularies.ApplicatorNext);
-		Global.Register(Vocabularies.ValidationNext);
-		Global.Register(Vocabularies.MetadataNext);
-		Global.Register(Vocabularies.UnevaluatedNext);
-		Global.Register(Vocabularies.FormatAnnotationNext);
-		Global.Register(Vocabularies.FormatAssertionNext);
-		Global.Register(Vocabularies.ContentNext);
-	}
+	public static VocabularyRegistry Global { get; } = new();
 
 	/// <summary>
 	/// Registers a vocabulary.  This does not register the vocabulary's


### PR DESCRIPTION
Importing some improvements found while attempting a new architecture (that didn't work out).

Primarily, schema registration now scans the schema and stores identifier information while also setting base URIs and spec versions.  With all of the identifer info stored in the schema registry, the reference keywords just need to go there.