### PR TITLE
Do not evaluate untaken if and switch branches

### DIFF
--- a/JsonE.Tests/Files/more-tests.yml
+++ b/JsonE.Tests/Files/more-tests.yml
@@ -146,3 +146,13 @@ title:    accessor after function call
 context:  {}
 template: {$eval: 'split("left:right", ":")[1]'}
 result:   right
+---
+title:    if defined check
+context:  {y: 10}
+template: {$if: 'defined("x")', then: {$eval: 'x'}, else: 20}
+result:   20
+---
+title:    switch defined check
+context:  {y: 10}
+template: {$switch: {'defined("x")': {$eval: 'x'}, $default: 20}}
+result:   20

--- a/JsonE/Operators/IfThenElseOperator.cs
+++ b/JsonE/Operators/IfThenElseOperator.cs
@@ -26,11 +26,8 @@ internal class IfThenElseOperator : IOperator
 		var thenPresent = obj.TryGetValue("then", out var thenValue, out _);
 		var elsePresent = obj.TryGetValue("else", out var elseValue, out _);
 
-		thenValue = JsonE.Evaluate(thenValue, context);
-		elseValue = JsonE.Evaluate(elseValue, context);
-
 		return cond.IsTruthy()
-			? thenPresent ? thenValue : JsonE.DeleteMarker
-			: elsePresent ? elseValue : JsonE.DeleteMarker;
+			? thenPresent ? JsonE.Evaluate(thenValue, context) : JsonE.DeleteMarker
+			: elsePresent ? JsonE.Evaluate(elseValue, context) : JsonE.DeleteMarker;
 	}
 }


### PR DESCRIPTION
Resolves #713

The samples for json-e indicate that one can check for an value in an if statement and attempt to use it in the 'then' block.

This change delays evaluating the 'then' and 'else' blocks until they are needed, and a similar change is applied to the 'switch' statement.

The change for `IfThenElseOperator` is fairly straightforward. The `SwitchOperator` one was as well, although it does change the order from:

1. Evaluate parameter dictionary (`JsonE.Evaluate(parameter, context)!.AsObject();`)
2. Check truthiness
3. Copy value

to:

1. Iterate over parameter dictionary (keys have not yet went to `JsonE.Evaluate`! Not sure if this is important. I saw one code path that looked like it might unescape keys or impact it another way. Please review carefully.)
2. Check truthiness
3. Evaluate value (and still copy it since the original code did, I'm new to the codebase so that might not be necessary).

It passed all the tests still, but I am not super comfortable that I changed the order above. I'm hoping you know (or have any easy way to check) if that's problematic.