### PR TITLE
Fix matching on unicode to ignore newlines

### DIFF
--- a/JsonPath/JsonPath.csproj
+++ b/JsonPath/JsonPath.csproj
@@ -14,8 +14,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.1.2</Version>
-    <FileVersion>1.0.1.2</FileVersion>
+    <Version>1.0.2</Version>
+    <FileVersion>1.0.2</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Path (RFC 9535) built on the System.Text.Json namespace</Description>

--- a/JsonPath/UtilityExtensions.cs
+++ b/JsonPath/UtilityExtensions.cs
@@ -81,7 +81,7 @@ internal static class UtilityExtensions
 				// The Regex class doesn't match `.` on non-BMP unicode very well,
 				// so we need to translate that to something it does understand.
 				// Ref: https://github.com/ietf-wg-jsonpath/iregexp/issues/22#issuecomment-1510543510
-				sb.Append(@"(\P{Cs}|\p{Cs}\p{Cs})");
+				sb.Append(@"(?:(?![\r\n])\P{Cs}|\p{Cs}\p{Cs})");
 			}
 			else
 			{

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,6 +4,10 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.08"
 ---
+# [1.0.2](https://github.com/gregsdennis/json-everything/pull/725) {#release-path-1.0.2}
+
+Fixes a rare issue with `match()` and `search()` functions.
+
 # [1.0.1.x](https://github.com/gregsdennis/json-everything/pull/712) {#release-path-1.0.1.x}
 
 [#711](https://github.com/gregsdennis/json-everything/issues/711) - Nuget package meta-data updates; no functional changes from previous version.


### PR DESCRIPTION
Related to https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/35