### PR TITLE
quote escapes in filter expressions

### DIFF
--- a/src/JsonPath/JsonPath.csproj
+++ b/src/JsonPath/JsonPath.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPath.Net</PackageId>
-    <Version>1.0.3</Version>
-    <FileVersion>1.0.3</FileVersion>
+    <Version>1.0.4</Version>
+    <FileVersion>1.0.4</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Path (RFC 9535) built on the System.Text.Json namespace</Description>

--- a/src/JsonPath/SpanExtensions.cs
+++ b/src/JsonPath/SpanExtensions.cs
@@ -153,7 +153,7 @@ internal static class SpanExtensions
 
 			var block = span[i..end];
 			if (block[0] == '\'' && block[^1] == '\'')
-				block = $"\"{block[1..^1].ToString()}\"".AsSpan();
+				block = $"\"{block[1..^1].ToString().Replace("\"", "\\\"").Replace("\\'", "'")}\"".AsSpan();
 			node = JsonNode.Parse(block.ToString());
 			i = end;
 			return true;

--- a/tools/ApiDocsGenerator/release-notes/rn-json-path.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-path.md
@@ -4,6 +4,10 @@ title: JsonPath.Net
 icon: fas fa-tag
 order: "09.08"
 ---
+# [1.0.4](https://github.com/gregsdennis/json-everything/pull/731) {#release-path-1.0.4}
+
+[#728](https://github.com/gregsdennis/json-everything/issues/728) - Failure to parse escaped single quote in single-quoted string in filter expressions.  Thanks to [@ashek-simeon](https://github.com/ashek-simeon) for reporting this.
+
 # [1.0.3](https://github.com/gregsdennis/json-everything/pull/730) {#release-path-1.0.3}
 
 [Test Suite PR #77](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/77) added some tests to check for a dot `.` inside square brackets, where it should be considered a literal and not transformed.


### PR DESCRIPTION
Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/78
Resolves #728