### PR TITLE
Address AOT Trim warning in JsonPath

### DIFF
--- a/src/JsonPath/FunctionRepository.cs
+++ b/src/JsonPath/FunctionRepository.cs
@@ -88,9 +88,10 @@ public static class FunctionRepository
 		return _functions.TryGetValue(name, out function);
 	}
 
-	private static void FindEvaluationMethods(IReflectiveFunctionDefinition function, Type returnType)
+	private static void FindEvaluationMethods<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TFunction>(
+		TFunction function, Type returnType) where TFunction : IReflectiveFunctionDefinition
 	{
-		var functionType = function.GetType();
+		var functionType = typeof(TFunction);
 		var methods = functionType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
 			.Where(m => m.Name == "Evaluate" && m.ReturnType == returnType)
 			.ToList();


### PR DESCRIPTION
### Description

Fix AOT trim warning from JsonPath (`'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The return value of method 'System.Object.GetType()' does not have matching annotations.`).

* Added annotations to FindEvaluationMethods (internal method)
* Added new public APIs with overloads that have the appropriate AOT annotations.

### Links

I didn't file a separate issue to report this.

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/gregsdennis/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/gregsdennis/json-everything/blob/master/CONTRIBUTING.md).

### Details:

I was trying out JsonPath in an AOT project and hit a trim warning during publish:

```
src\JsonPath\FunctionRepository.cs(94,17,94,85): warning IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

That was caught by the NAOT trimmer that wasn't seen by the static analyzer for .NET 8. Luckily, this static analysis bug is fixed in .NET 9, so added "net9" as a TargetFramework in the csproj and the warning shows up.

I rewrote the code slightly to carry the annotation along per https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings#dynamicallyaccessedmembers.