### PR TITLE
Trim leading periods from full type name

### DIFF
--- a/src/JsonSchema.Generation/XmlComments/XmlDocId.cs
+++ b/src/JsonSchema.Generation/XmlComments/XmlDocId.cs
@@ -205,7 +205,7 @@ internal static class XmlDocId
 			fullTypeName = $"{typeNamespace}.{type.Name}{outString}";
 		}
 
-		fullTypeName = fullTypeName.Replace("&", "");
+		fullTypeName = fullTypeName.Replace("&", "").TrimStart('.');
 
 		// Multi-dimensional arrays must have 0: for each dimension. Eg. [,,] has to become [0:,0:,0:]
 		while (fullTypeName.Contains("[,"))


### PR DESCRIPTION
### Description

Trim leading periods from the full type name after replacing ampersands.

This is not affecting the public API surface, just improving internal handling. No breaking changes.

### Links

Resolves https://github.com/json-everything/json-everything/issues/946 

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
