### PR TITLE
Fix validation error message for non-string values

### DIFF
--- a/src/JsonSchema/Keywords/PatternKeyword.cs
+++ b/src/JsonSchema/Keywords/PatternKeyword.cs
@@ -36,7 +36,7 @@ public class PatternKeyword : IKeywordHandler
 	public virtual object? ValidateKeywordValue(JsonElement value)
 	{
 		if (value.ValueKind is not JsonValueKind.String)
-			throw new JsonSchemaException($"'{Name}' value must be a number, found {value.ValueKind}");
+			throw new JsonSchemaException($"'{Name}' value must be a string, found {value.ValueKind}");
 
 		var regex = new Regex(value.GetString()!, RegexOptions.ECMAScript | RegexOptions.Compiled);
 


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

Fix on the exception message in `PatternKeyword.ValidateKeywordValue` to indicate `string` is expected rather than `number`.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
N/A

### Organization

<!-- 
Are you submitting this change on behalf of an organization?  If so, who?
-->
- [ ] Organization: ___
- [x] Independent

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
