### PR TITLE
Make schema registry thread safe

### DIFF
--- a/src/JsonSchema/SchemaRegistry.cs
+++ b/src/JsonSchema/SchemaRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,7 +24,7 @@ public class SchemaRegistry
 
 	private static readonly Uri _empty = new("https://json-everything.lib/");
 
-	private readonly Dictionary<Uri, Registration> _registered = [];
+	private readonly ConcurrentDictionary<Uri, Registration> _registered = [];
 	private Func<Uri, SchemaRegistry, IBaseDocument?>? _fetch;
 
 	/// <summary>


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

This PR makes `SchemaRegistry` thread-safe by using `ConcurrentDictionary`.
Tests have been added for concurrent deseralization of multiple JSON schemas.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #999      <!-- Use if these changes completely resolve the issue -->

### Organization

<!-- 
Are you submitting this change on behalf of an organization?  If so, who?
-->
- [x] Organization: Galileo Group AG [galileo-group](https://github.com/galileo-group)
- [ ] Independent

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
