### PR TITLE
adjust sourcegen to produce one class; fix format references

### DIFF
--- a/src/JsonSchema.Generation.Tests/SourceGeneration/AlternateModels.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/AlternateModels.cs
@@ -1,0 +1,13 @@
+using Json.Schema.Generation.Serialization;
+
+namespace Json.Schema.Generation.Tests.SourceGeneration.AlternateNamespace;
+
+public class AlternateModels
+{
+	[GenerateJsonSchema]
+	public class CrossNamespacePerson
+	{
+		public string Name { get; set; } = string.Empty;
+		public int Age { get; set; }
+	}
+}

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
@@ -431,6 +431,42 @@ public class SourceGeneratorTests
 	}
 
 	[Test]
+	public void BuildForType_UsesSchemaForGeneratedTypeInAnotherNamespace()
+	{
+		var expectedJson = """
+		{
+		  "$ref": "global::Json.Schema.Generation.Tests.SourceGeneration.AlternateNamespace.AlternateModels.CrossNamespacePerson"
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = new JsonSchemaBuilder()
+			.BuildForType(typeof(AlternateNamespace.AlternateModels.CrossNamespacePerson))
+			.Build();
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void CentralGeneratedSchemasClass_ContainsSchemasFromAnotherNamespace()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.AlternateNamespace.AlternateModels.CrossNamespacePerson",
+		  "type": "object",
+		  "properties": {
+		    "Name": { "type": "string" },
+		    "Age": { "type": "integer" }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.AlternateModels_CrossNamespacePerson;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
 	public void SingleCondition_GeneratesIfThen()
 	{
 		var expectedJson = """

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>7.3.0</Version>
-    <FileVersion>7.3.0</FileVersion>
+    <Version>7.3.1</Version>
+    <FileVersion>7.3.1</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>

--- a/src/JsonSchema.Generation/SourceGeneration/Emitters/DateTimeSchemaEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Emitters/DateTimeSchemaEmitter.cs
@@ -14,6 +14,6 @@ internal class DateTimeSchemaEmitter : ISchemaEmitter
 		else
 			sb.Append($"{indent}.Type(SchemaValueType.String)");
 		sb.AppendLine();
-		sb.Append($"{indent}.Format(Formats.DateTime)");
+		sb.Append($"{indent}.Format(global::Json.Schema.Formats.DateTime)");
 	}
 }

--- a/src/JsonSchema.Generation/SourceGeneration/Emitters/GuidSchemaEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Emitters/GuidSchemaEmitter.cs
@@ -14,6 +14,6 @@ internal class GuidSchemaEmitter : ISchemaEmitter
 		else
 			sb.Append($"{indent}.Type(SchemaValueType.String)");
 		sb.AppendLine();
-		sb.Append($"{indent}.Format(Formats.Uuid)");
+		sb.Append($"{indent}.Format(global::Json.Schema.Formats.Uuid)");
 	}
 }

--- a/src/JsonSchema.Generation/SourceGeneration/Emitters/UriSchemaEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Emitters/UriSchemaEmitter.cs
@@ -14,6 +14,6 @@ internal class UriSchemaEmitter : ISchemaEmitter
 		else
 			sb.Append($"{indent}.Type(SchemaValueType.String)");
 		sb.AppendLine();
-		sb.Append($"{indent}.Format(Formats.Uri)");
+		sb.Append($"{indent}.Format(global::Json.Schema.Formats.Uri)");
 	}
 }

--- a/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
@@ -26,12 +26,17 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 	/// </summary>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
-		// Check if source generation is disabled via MSBuild property
-		var isDisabled = context.AnalyzerConfigOptionsProvider
+		var generationOptions = context.AnalyzerConfigOptionsProvider
 			.Select(static (provider, _) =>
 			{
 				provider.GlobalOptions.TryGetValue("build_property.DisableJsonSchemaSourceGeneration", out var value);
-				return value?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
+				provider.GlobalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace);
+
+				return new GenerationOptions
+				{
+					IsDisabled = value?.Equals("true", StringComparison.OrdinalIgnoreCase) == true,
+					RootNamespace = rootNamespace ?? string.Empty
+				};
 			});
 
 		var typesWithAttribute = context.SyntaxProvider
@@ -41,16 +46,16 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 				static (ctx, _) => GetTypeToGenerate(ctx))
 			.Where(static type => type is not null);
 
-		var compilationAndTypesAndDisabled = context.CompilationProvider
+		var compilationAndTypesAndOptions = context.CompilationProvider
 			.Combine(typesWithAttribute.Collect())
-			.Combine(isDisabled);
+			.Combine(generationOptions);
 
-		context.RegisterSourceOutput(compilationAndTypesAndDisabled, static (spc, source) =>
+		context.RegisterSourceOutput(compilationAndTypesAndOptions, static (spc, source) =>
 		{
-			var isDisabled = source.Right;
-			if (isDisabled) return;
+			var generationOptions = source.Right;
+			if (generationOptions.IsDisabled) return;
 
-			Execute(source.Left.Left, source.Left.Right, spc);
+			Execute(source.Left.Left, source.Left.Right, generationOptions.RootNamespace, spc);
 		});
 	}
 
@@ -64,7 +69,7 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		return new TypeToGenerate(typeSymbol, attributeData);
 	}
 
-	private static void Execute(Compilation compilation, ImmutableArray<TypeToGenerate?> types, SourceProductionContext context)
+	private static void Execute(Compilation compilation, ImmutableArray<TypeToGenerate?> types, string rootNamespace, SourceProductionContext context)
 	{
 		if (types.IsDefaultOrEmpty) return;
 
@@ -101,25 +106,11 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			}
 		}
 
-		var typesByNamespace = allTypeInfos.GroupBy(t => GetNamespace(t.TypeSymbol));
+		var targetNamespace = rootNamespace;
+		var classDeclaration = DetectGeneratedJsonSchemasClass(compilation, targetNamespace, context.ReportDiagnostic);
+		var generatedCode = SchemaCodeEmitter.EmitGeneratedClass(allTypeInfos, targetNamespace, classDeclaration, schemaHandlers);
 
-		foreach (var group in typesByNamespace)
-		{
-			var namespaceName = group.Key;
-			var typesInNamespace = group.ToList();
-
-			// Detect user-defined GeneratedJsonSchemas class
-			var classDeclaration = DetectGeneratedJsonSchemasClass(compilation, namespaceName, context.ReportDiagnostic);
-
-			var generatedCode = SchemaCodeEmitter.EmitGeneratedClass(typesInNamespace, namespaceName, classDeclaration, schemaHandlers);
-
-			var safeName = string.IsNullOrEmpty(namespaceName) 
-				? "GeneratedJsonSchemas" 
-				: namespaceName.Replace(".", "_");
-			var fileName = $"{safeName}.g.cs";
-
-			context.AddSource(fileName, SourceText.From(generatedCode, Encoding.UTF8));
-		}
+		context.AddSource("GeneratedJsonSchemas.g.cs", SourceText.From(generatedCode, Encoding.UTF8));
 	}
 
 	private static List<SchemaHandlerInfo> DiscoverSchemaHandlers(Compilation compilation)
@@ -217,24 +208,6 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		}
 	}
 
-	private static string GetNamespace(ISymbol symbol)
-	{
-		if (symbol.ContainingNamespace == null || symbol.ContainingNamespace.IsGlobalNamespace)
-			return string.Empty;
-
-		var namespaces = new List<string>();
-		var currentNamespace = symbol.ContainingNamespace;
-
-		while (currentNamespace is { IsGlobalNamespace: false })
-		{
-			namespaces.Add(currentNamespace.Name);
-			currentNamespace = currentNamespace.ContainingNamespace;
-		}
-
-		namespaces.Reverse();
-		return string.Join(".", namespaces);
-	}
-
 	private static ClassDeclarationInfo DetectGeneratedJsonSchemasClass(
 		Compilation compilation, 
 		string namespaceName,
@@ -314,5 +287,11 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			TypeSymbol = typeSymbol;
 			AttributeData = attributeData;
 		}
+	}
+
+	private sealed class GenerationOptions
+	{
+		public required bool IsDisabled { get; init; }
+		public required string RootNamespace { get; init; }
 	}
 }

--- a/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
@@ -269,9 +269,9 @@ internal static class SchemaCodeEmitter
 		sb.AppendLine("\t\t	var t when t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) || t == typeof(uint) || t == typeof(long) || t == typeof(ulong) => builder.Type(SchemaValueType.Integer),");
 		sb.AppendLine("\t\t	var t when t == typeof(float) || t == typeof(double) || t == typeof(decimal) => builder.Type(SchemaValueType.Number),");
 		sb.AppendLine("\t\t	var t when t == typeof(string) => builder.Type(SchemaValueType.String),");
-		sb.AppendLine("\t\t	var t when t == typeof(DateTime) || t == typeof(DateTimeOffset) => builder.Type(SchemaValueType.String).Format(Formats.DateTime),");
-		sb.AppendLine("\t\t	var t when t == typeof(Guid) => builder.Type(SchemaValueType.String).Format(Formats.Uuid),");
-		sb.AppendLine("\t\t	var t when t == typeof(Uri) => builder.Type(SchemaValueType.String).Format(Formats.Uri),");
+		sb.AppendLine("\t\t	var t when t == typeof(DateTime) || t == typeof(DateTimeOffset) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.DateTime),");
+		sb.AppendLine("\t\t	var t when t == typeof(Guid) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uuid),");
+		sb.AppendLine("\t\t	var t when t == typeof(Uri) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uri),");
 		sb.AppendLine("\t\t	_ => builder");
 		sb.AppendLine("\t\t};");
 		sb.AppendLine("\t}");

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
+# [7.3.0](https://github.com/gregsdennis/json-everything/pull/1021) {#release-schemagen-7.3.1}
+
+[#1018](https://github.com/gregsdennis/json-everything/issues/1018) - further updates to source generation
+
 # [7.3.0](https://github.com/gregsdennis/json-everything/pull/1020) {#release-schemagen-7.3.0}
 
 [#1018](https://github.com/gregsdennis/json-everything/issues/1018)


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Source-gen a single class that contains all generated schemas.
Fix references to Json.Schema.Formats class.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #1018     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
