### PR TITLE
many source generation fixes

### DIFF
--- a/src/JsonSchema.Api/JsonSchema.Api.csproj
+++ b/src/JsonSchema.Api/JsonSchema.Api.csproj
@@ -15,8 +15,8 @@
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <IncludeSymbols>true</IncludeSymbols>
 	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	  <Version>1.1.0</Version>
-	  <FileVersion>1.1.0</FileVersion>
+	  <Version>1.1.1</Version>
+	  <FileVersion>1.1.1</FileVersion>
 	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
 	  <Authors>Greg Dennis</Authors>
 	  <Description>Extends JsonSchema.Net to provide API-centric functionality like automatic request validation</Description>

--- a/src/JsonSchema.Api/ValidatingJsonModelBinder.cs
+++ b/src/JsonSchema.Api/ValidatingJsonModelBinder.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 #pragma warning disable IL2026
 #pragma warning disable IL3050
@@ -55,6 +56,8 @@ public class ValidatingJsonModelBinder : IModelBinder
 
             if (string.IsNullOrEmpty(body)) return;
 
+            var logger = bindingContext.HttpContext.RequestServices.GetService<ILogger<ValidatingJsonModelBinder>>();
+
             try
             {
                 var options = bindingContext.HttpContext.RequestServices.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
@@ -66,7 +69,10 @@ public class ValidatingJsonModelBinder : IModelBinder
                 if (jsonException.Data.Contains("validation") && 
                     jsonException.Data["validation"] is EvaluationResults { IsValid: false } validationResults)
                 {
-                    var errors = ExtractValidationErrors(validationResults);
+	                var resultsLog = JsonSerializer.Serialize(validationResults);
+	                logger?.LogDebug(resultsLog);
+
+	                var errors = ExtractValidationErrors(validationResults);
                     if (errors.Count != 0)
                     {
                         foreach (var error in errors)

--- a/src/JsonSchema.Generation.Tests/JsonSchema.Generation.Tests.csproj
+++ b/src/JsonSchema.Generation.Tests/JsonSchema.Generation.Tests.csproj
@@ -30,4 +30,9 @@
 		<ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<CompilerVisibleProperty Include="JsonSchemaDefaultPropertyNaming" />
+		<CompilerVisibleProperty Include="JsonSchemaDefaultPropertyOrder" />
+	</ItemGroup>
+
 </Project>

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using NUnit.Framework;
 using static Json.Schema.Generation.Tests.AssertionExtensions;
@@ -45,6 +46,26 @@ public class SourceGeneratorTests
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
 		var actual = GeneratedJsonSchemas.TestModels_CamelCasePerson;
 		
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void SecondaryTypeOfCamelCaseModel_UsesCamelCase()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.SecondaryType",
+		  "type": "object",
+		  "properties": {
+		    "candidateId": { "type": "string" },
+		    "sourceSystem": { "type": "string" }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_SecondaryType;
+
 		AssertEqual(expected, actual);
 	}
 
@@ -113,6 +134,30 @@ public class SourceGeneratorTests
 	}
 
 	[Test]
+	public void ModelWithNullableEnumArray_AllowsNull()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithNullableEnumArray",
+		  "type": "object",
+		  "properties": {
+		    "styles": {
+		      "type": ["null", "array"],
+		      "items": {
+		        "enum": ["Confident", "Passionate", "Engaging", "Practical", "Humorous"]
+		      }
+		    }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithNullableEnumArray;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
 	public void PersonWithDescription_HasDescriptions()
 	{
 		var expectedJson = """
@@ -165,6 +210,33 @@ public class SourceGeneratorTests
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
 		var actual = GeneratedJsonSchemas.TestModels_ProductWithCustomAttributes;
 		
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void ModelWithGuidArrayAndMinItems_EmitsArrayOfUuid()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithGuidArrayAndMinItems",
+		  "type": "object",
+		  "properties": {
+		    "recipientIds": {
+		      "type": "array",
+		      "items": {
+		        "type": "string",
+		        "format": "uuid"
+		      },
+		      "minItems": 1
+		    }
+		  },
+		  "required": ["recipientIds"]
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithGuidArrayAndMinItems;
+
 		AssertEqual(expected, actual);
 	}
 
@@ -432,6 +504,23 @@ public class SourceGeneratorTests
 	}
 
 	[Test]
+	public void BuildForType_NullableGuid_EmitsNullableStringUuid()
+	{
+		var expectedJson = """
+		{
+		  "type": ["null", "string"],
+		  "format": "uuid"
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = new JsonSchemaBuilder()
+			.BuildForType(typeof(Guid?))
+			.Build();
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
 	public void BuildForType_UsesSchemaForGeneratedTypeInAnotherNamespace()
 	{
 		var expectedJson = """
@@ -526,6 +615,25 @@ public class SourceGeneratorTests
 		""";
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
 		var actual = GeneratedJsonSchemas.TestModels_ModelWithNullableOverrides;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void DuplicateMappedPropertyNames_DoNotBreakSchemaGeneration()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithDuplicateSchemaPropertyNames",
+		  "type": "object",
+		  "properties": {
+		    "foo": { "type": "integer" }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithDuplicateSchemaPropertyNames;
 
 		AssertEqual(expected, actual);
 	}
@@ -666,6 +774,100 @@ public class SourceGeneratorTests
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
 		var actual = GeneratedJsonSchemas.TestModels_MultipleTriggersInSameGroup;
 		
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void MultipleIfsSamePropertyAndGroup_CombinesToSinglePropertyTrigger()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.MultipleIfsSamePropertyAndGroup",
+		  "type": "object",
+		  "properties": {
+		    "Status": {
+		      "enum": ["Active", "Inactive", "Pending"]
+		    },
+		    "Note": {
+		      "type": ["null", "string"]
+		    }
+		  },
+		  "required": ["Status"],
+		  "if": {
+		    "properties": {
+		      "Status": {
+		        "enum": ["Active", "Pending"]
+		      }
+		    },
+		    "required": ["Status"]
+		  },
+		  "then": {
+		    "required": ["Note"]
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_MultipleIfsSamePropertyAndGroup;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void MultipleIfsSamePropertyAcrossGroups_GeneratesWithoutDuplicateIfProperties()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.MultipleIfsSamePropertyAcrossGroups",
+		  "type": "object",
+		  "properties": {
+		    "Status": {
+		      "enum": ["Active", "Inactive", "Pending"]
+		    },
+		    "JobListingId": {
+		      "type": ["null", "string"],
+		      "format": "uuid"
+		    },
+		    "OrgId": {
+		      "type": ["null", "string"],
+		      "format": "uuid"
+		    }
+		  },
+		  "required": ["Status"],
+		  "allOf": [
+		    {
+		      "if": {
+		        "properties": {
+		          "Status": {
+		            "enum": ["Active", "Pending"]
+		          }
+		        },
+		        "required": ["Status"]
+		      },
+		      "then": {
+		        "required": ["JobListingId"]
+		      }
+		    },
+		    {
+		      "if": {
+		        "properties": {
+		          "Status": {
+		            "const": "Inactive"
+		          }
+		        },
+		        "required": ["Status"]
+		      },
+		      "then": {
+		        "required": ["OrgId"]
+		      }
+		    }
+		  ]
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_MultipleIfsSamePropertyAcrossGroups;
+
 		AssertEqual(expected, actual);
 	}
 

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
@@ -50,21 +50,21 @@ public class SourceGeneratorTests
 	}
 
 	[Test]
-	public void SecondaryTypeOfCamelCaseModel_UsesCamelCase()
+	public void NestedTypeOfCamelCaseModel_UsesCamelCase()
 	{
 		var expectedJson = """
 		{
 		  "$schema": "https://json-schema.org/draft/2020-12/schema",
-		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.SecondaryType",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.NestedType",
 		  "type": "object",
 		  "properties": {
-		    "candidateId": { "type": "string" },
-		    "sourceSystem": { "type": "string" }
+		    "externalId": { "type": "string" },
+		    "displayName": { "type": "string" }
 		  }
 		}
 		""";
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
-		var actual = GeneratedJsonSchemas.TestModels_SecondaryType;
+		var actual = GeneratedJsonSchemas.TestModels_NestedType;
 
 		AssertEqual(expected, actual);
 	}

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
@@ -23,6 +23,18 @@ public static class TestModels
 		public int Age { get; set; }
 	}
 
+	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
+	public class CamelCaseWithSecondaryType
+	{
+		public SecondaryType Secondary { get; set; } = new();
+	}
+
+	public class SecondaryType
+	{
+		public string CandidateId { get; set; } = string.Empty;
+		public string SourceSystem { get; set; } = string.Empty;
+	}
+
 	[GenerateJsonSchema]
 	public class PersonWithNullable
 	{
@@ -45,11 +57,26 @@ public static class TestModels
 		Pending
 	}
 
+	public enum ContentStyle
+	{
+		Confident,
+		Passionate,
+		Engaging,
+		Practical,
+		Humorous
+	}
+
 	[GenerateJsonSchema]
 	public class PersonWithEnum
 	{
 		public string Name { get; set; } = string.Empty;
 		public Status Status { get; set; }
+	}
+
+	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
+	public class ModelWithNullableEnumArray
+	{
+		public ContentStyle[]? Styles { get; set; }
 	}
 
 	[GenerateJsonSchema]
@@ -78,6 +105,14 @@ public static class TestModels
 		public int DiscountPercentage { get; set; }
 
 		public string? Description { get; set; }
+	}
+
+	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
+	public class ModelWithGuidArrayAndMinItems
+	{
+		[Required]
+		[MinItems(1)]
+		public Guid[] RecipientIds { get; set; } = [];
 	}
 
 	public class Address
@@ -150,6 +185,34 @@ public static class TestModels
 
 		[Required(ConditionGroup = 0)]
 		public string? SpecialField { get; set; }
+	}
+
+	[GenerateJsonSchema]
+	[If(nameof(Status), nameof(TestModels.Status.Active), "state-note")]
+	[If(nameof(Status), nameof(TestModels.Status.Pending), "state-note")]
+	public class MultipleIfsSamePropertyAndGroup
+	{
+		[Required]
+		public Status Status { get; set; }
+
+		[Required(ConditionGroup = "state-note")]
+		public string? Note { get; set; }
+	}
+
+	[GenerateJsonSchema]
+	[If(nameof(Status), nameof(TestModels.Status.Active), "job-required")]
+	[If(nameof(Status), nameof(TestModels.Status.Pending), "job-required")]
+	[If(nameof(Status), nameof(TestModels.Status.Inactive), "org-required")]
+	public class MultipleIfsSamePropertyAcrossGroups
+	{
+		[Required]
+		public Status Status { get; set; }
+
+		[Required(ConditionGroup = "job-required")]
+		public Guid? JobListingId { get; set; }
+
+		[Required(ConditionGroup = "org-required")]
+		public Guid? OrgId { get; set; }
 	}
 
 	[GenerateJsonSchema]
@@ -321,6 +384,13 @@ public static class TestModels
 		/// <summary>Force-non-nullable nullable int.</summary>
 		[Nullable(false)]
 		public int? ForcedNonNullable { get; set; }
+	}
+
+	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
+	public class ModelWithDuplicateSchemaPropertyNames
+	{
+		public int Foo { get; set; }
+		public int foo { get; set; }
 	}
 
 	[GenerateJsonSchema(StrictConditionals = true)]

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
@@ -24,15 +24,15 @@ public static class TestModels
 	}
 
 	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
-	public class CamelCaseWithSecondaryType
+	public class CamelCaseWithNestedType
 	{
-		public SecondaryType Secondary { get; set; } = new();
+		public NestedType Nested { get; set; } = new();
 	}
 
-	public class SecondaryType
+	public class NestedType
 	{
-		public string CandidateId { get; set; } = string.Empty;
-		public string SourceSystem { get; set; } = string.Empty;
+		public string ExternalId { get; set; } = string.Empty;
+		public string DisplayName { get; set; } = string.Empty;
 	}
 
 	[GenerateJsonSchema]

--- a/src/JsonSchema.Generation/AnalyzerReleases.Shipped.md
+++ b/src/JsonSchema.Generation/AnalyzerReleases.Shipped.md
@@ -1,3 +1,13 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
+## Release 7.3.5
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+JSGEN001 | JsonSchemaGeneration | Error | Open generic types are not supported
+JSGEN002 | JsonSchemaGeneration | Error | GeneratedJsonSchemas class must be partial
+JSGEN003 | JsonSchemaGeneration | Warning | Duplicate schema property name
+

--- a/src/JsonSchema.Generation/AnalyzerReleases.Unshipped.md
+++ b/src/JsonSchema.Generation/AnalyzerReleases.Unshipped.md
@@ -5,5 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-JSGEN001 | JsonSchemaGeneration | Error | Open generic types are not supported
-JSGEN002 | JsonSchemaGeneration | Error | GeneratedJsonSchemas class must be partial

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>7.3.4</Version>
-    <FileVersion>7.3.4</FileVersion>
+    <Version>7.3.5</Version>
+    <FileVersion>7.3.5</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>
@@ -64,6 +64,7 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\Resources\json-logo-256.png" Pack="true" PackagePath="\" />
     <None Include="..\..\OSMFEULA.txt" Pack="true" PackagePath="OSMFEULA.txt" />
+    <None Include="build\JsonSchema.Net.Generation.props" Pack="true" PackagePath="build\" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/JsonSchema.Generation/SourceGeneration/Diagnostics.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Diagnostics.cs
@@ -21,4 +21,12 @@ internal static class Diagnostics
 		category: _category,
 		defaultSeverity: DiagnosticSeverity.Error,
 		isEnabledByDefault: true);
+
+	public static readonly DiagnosticDescriptor DuplicateSchemaPropertyName = new(
+		id: "JSGEN003",
+		title: "Duplicate schema property name",
+		messageFormat: "Type '{0}' contains multiple members that map to schema property name '{1}'. Only the first member is emitted.",
+		category: _category,
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
 }

--- a/src/JsonSchema.Generation/SourceGeneration/Emitters/ConditionalSchemaEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Emitters/ConditionalSchemaEmitter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -48,18 +49,22 @@ internal static class ConditionalSchemaEmitter
 
 		if (conditional.Triggers.Count > 0)
 		{
+			var triggerGroups = conditional.Triggers
+				.GroupBy(t => t.PropertySchemaName)
+				.ToList();
+
 			sb.AppendLine();
 			sb.Append($"{indent}\t.Properties(");
 			sb.AppendLine();
 			
-			for (int i = 0; i < conditional.Triggers.Count; i++)
+			for (int i = 0; i < triggerGroups.Count; i++)
 			{
-				var trigger = conditional.Triggers[i];
-				sb.Append($"{indent}\t\t(\"{CodeEmitterHelpers.EscapeString(trigger.PropertySchemaName)}\", ");
-				EmitTriggerSchema(sb, trigger);
+				var triggerGroup = triggerGroups[i];
+				sb.Append($"{indent}\t\t(\"{CodeEmitterHelpers.EscapeString(triggerGroup.Key)}\", ");
+				EmitTriggerSchema(sb, triggerGroup.ToList());
 				sb.Append(")");
 				
-				if (i < conditional.Triggers.Count - 1)
+				if (i < triggerGroups.Count - 1)
 					sb.Append(",");
 				sb.AppendLine();
 			}
@@ -68,11 +73,11 @@ internal static class ConditionalSchemaEmitter
 			
 			sb.AppendLine();
 			sb.Append($"{indent}\t.Required(");
-			for (int i = 0; i < conditional.Triggers.Count; i++)
+			for (int i = 0; i < triggerGroups.Count; i++)
 			{
 				if (i > 0)
 					sb.Append(", ");
-				sb.Append($"\"{CodeEmitterHelpers.EscapeString(conditional.Triggers[i].PropertySchemaName)}\"");
+				sb.Append($"\"{CodeEmitterHelpers.EscapeString(triggerGroups[i].Key)}\"");
 			}
 			sb.Append(")");
 		}
@@ -81,24 +86,35 @@ internal static class ConditionalSchemaEmitter
 		sb.Append($"{indent})");
 	}
 
-	private static void EmitTriggerSchema(StringBuilder sb, ConditionalTrigger trigger)
+	private static void EmitTriggerSchema(StringBuilder sb, IReadOnlyList<ConditionalTrigger> triggers)
 	{
-		switch (trigger.Type)
+		sb.Append("new JsonSchemaBuilder()");
+
+		var equalityValues = triggers
+			.Where(t => t.Type is ConditionalTriggerType.Equality or ConditionalTriggerType.Enum)
+			.Select(t => t.ExpectedValue)
+			.Where(v => v != null)
+			.Distinct()
+			.ToList();
+
+		if (equalityValues.Count == 1)
+			sb.Append($".Const({equalityValues[0]})");
+		else if (equalityValues.Count > 1)
+			sb.Append($".Enum({string.Join(", ", equalityValues)})");
+
+		foreach (var trigger in triggers.Where(t => t.Type is ConditionalTriggerType.Minimum or ConditionalTriggerType.Maximum))
 		{
-			case ConditionalTriggerType.Equality:
-				sb.Append($"new JsonSchemaBuilder().Const({trigger.ExpectedValue})");
-				break;
-			case ConditionalTriggerType.Minimum:
-				var minKeyword = trigger.IsExclusive ? "ExclusiveMinimum" : "Minimum";
-				sb.Append($"new JsonSchemaBuilder().{minKeyword}({trigger.NumericValue})");
-				break;
-			case ConditionalTriggerType.Maximum:
-				var maxKeyword = trigger.IsExclusive ? "ExclusiveMaximum" : "Maximum";
-				sb.Append($"new JsonSchemaBuilder().{maxKeyword}({trigger.NumericValue})");
-				break;
-			case ConditionalTriggerType.Enum:
-				sb.Append($"new JsonSchemaBuilder().Const({trigger.ExpectedValue})");
-				break;
+			switch (trigger.Type)
+			{
+				case ConditionalTriggerType.Minimum:
+					var minKeyword = trigger.IsExclusive ? "ExclusiveMinimum" : "Minimum";
+					sb.Append($".{minKeyword}({trigger.NumericValue})");
+					break;
+				case ConditionalTriggerType.Maximum:
+					var maxKeyword = trigger.IsExclusive ? "ExclusiveMaximum" : "Maximum";
+					sb.Append($".{maxKeyword}({trigger.NumericValue})");
+					break;
+			}
 		}
 	}
 

--- a/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using Json.Schema.Generation.Serialization;
 using Json.Schema.Generation.SourceGeneration.Emitters;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -29,13 +30,24 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		var generationOptions = context.AnalyzerConfigOptionsProvider
 			.Select(static (provider, _) =>
 			{
-				provider.GlobalOptions.TryGetValue("build_property.DisableJsonSchemaSourceGeneration", out var value);
+				provider.GlobalOptions.TryGetValue("build_property.DisableJsonSchemaSourceGeneration", out var disabled);
 				provider.GlobalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace);
+				provider.GlobalOptions.TryGetValue("build_property.JsonSchemaDefaultPropertyNaming", out var namingRaw);
+				provider.GlobalOptions.TryGetValue("build_property.JsonSchemaDefaultPropertyOrder", out var orderRaw);
+
+				var defaultNaming = Enum.TryParse<NamingConvention>(namingRaw, ignoreCase: true, out var parsedNaming)
+					? parsedNaming
+					: NamingConvention.AsDeclared;
+				var defaultOrder = Enum.TryParse<PropertyOrder>(orderRaw, ignoreCase: true, out var parsedOrder)
+					? parsedOrder
+					: PropertyOrder.AsDeclared;
 
 				return new GenerationOptions
 				{
-					IsDisabled = value?.Equals("true", StringComparison.OrdinalIgnoreCase) == true,
-					RootNamespace = rootNamespace ?? string.Empty
+					IsDisabled = disabled?.Equals("true", StringComparison.OrdinalIgnoreCase) == true,
+					RootNamespace = rootNamespace ?? string.Empty,
+					DefaultPropertyNaming = defaultNaming,
+					DefaultPropertyOrder = defaultOrder
 				};
 			});
 
@@ -55,7 +67,7 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			var generationOptions = source.Right;
 			if (generationOptions.IsDisabled) return;
 
-			Execute(source.Left.Left, source.Left.Right, generationOptions.RootNamespace, spc);
+			Execute(source.Left.Left, source.Left.Right, generationOptions, spc);
 		});
 	}
 
@@ -69,7 +81,7 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		return new TypeToGenerate(typeSymbol, attributeData);
 	}
 
-	private static void Execute(Compilation compilation, ImmutableArray<TypeToGenerate?> types, string rootNamespace, SourceProductionContext context)
+	private static void Execute(Compilation compilation, ImmutableArray<TypeToGenerate?> types, GenerationOptions options, SourceProductionContext context)
 	{
 		if (types.IsDefaultOrEmpty) return;
 
@@ -80,11 +92,11 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		var allEncounteredTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
 		foreach (var type in validTypes)
 		{
-			var typeInfo = TypeAnalyzer.Analyze(compilation, type.TypeSymbol, type.AttributeData, context.ReportDiagnostic);
+			var typeInfo = TypeAnalyzer.Analyze(compilation, type.TypeSymbol, type.AttributeData, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
 			if (typeInfo != null) 
 			{
 				analyzedTypes.Add(typeInfo);
-				CollectAllTypes(compilation, typeInfo, allEncounteredTypes, context.ReportDiagnostic);
+				CollectAllTypes(compilation, typeInfo, allEncounteredTypes, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
 			}
 		}
 
@@ -100,15 +112,15 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 
 			if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
 			{
-				var typeInfo = TypeAnalyzer.Analyze(compilation, namedTypeSymbol, null, context.ReportDiagnostic);
+				var typeInfo = TypeAnalyzer.Analyze(compilation, namedTypeSymbol, null, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
 				if (typeInfo != null)
 					allTypeInfos.Add(typeInfo);
 			}
 		}
 
-		ResolvePropertyNameConflicts(allTypeInfos, rootNamespace);
+		ResolvePropertyNameConflicts(allTypeInfos, options.RootNamespace);
 
-		var targetNamespace = rootNamespace;
+		var targetNamespace = options.RootNamespace;
 		var classDeclaration = DetectGeneratedJsonSchemasClass(compilation, targetNamespace, context.ReportDiagnostic);
 		var generatedCode = SchemaCodeEmitter.EmitGeneratedClass(allTypeInfos, targetNamespace, classDeclaration, schemaHandlers);
 
@@ -165,17 +177,17 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			CollectSchemaHandlers(nested, results, systemType);
 	}
 
-	private static void CollectAllTypes(Compilation compilation, TypeInfo typeInfo, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic)
+	private static void CollectAllTypes(Compilation compilation, TypeInfo typeInfo, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, NamingConvention defaultPropertyNaming, PropertyOrder defaultPropertyOrder)
 	{
-		CollectTypeRecursive(compilation, typeInfo.TypeSymbol, allTypes, reportDiagnostic);
+		CollectTypeRecursive(compilation, typeInfo.TypeSymbol, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
 
 		foreach (var prop in typeInfo.Properties)
 		{
-			CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic);
+			CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
 		}
 	}
 
-	private static void CollectTypeRecursive(Compilation compilation, ITypeSymbol typeSymbol, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic)
+	private static void CollectTypeRecursive(Compilation compilation, ITypeSymbol typeSymbol, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, NamingConvention defaultPropertyNaming, PropertyOrder defaultPropertyOrder)
 	{
 		var unwrapped = CodeEmitterHelpers.UnwrapNullable(typeSymbol);
 		var typeKind = SchemaCodeEmitter.DetermineTypeKind(unwrapped);
@@ -189,7 +201,7 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		{
 			var elementType = CodeEmitterHelpers.GetElementType(unwrapped);
 			if (elementType != null)
-				CollectTypeRecursive(compilation, elementType, allTypes, reportDiagnostic);
+				CollectTypeRecursive(compilation, elementType, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
 			return;
 		}
 
@@ -198,12 +210,12 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			if (allTypes.Add(namedType))
 			{
 				// Analyze the type to collect its properties' types
-				var tempTypeInfo = TypeAnalyzer.Analyze(compilation, namedType, null, reportDiagnostic);
+				var tempTypeInfo = TypeAnalyzer.Analyze(compilation, namedType, null, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
 				if (tempTypeInfo != null)
 				{
 					foreach (var prop in tempTypeInfo.Properties)
 					{
-						CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic);
+						CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
 					}
 				}
 			}
@@ -347,5 +359,7 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 	{
 		public required bool IsDisabled { get; init; }
 		public required string RootNamespace { get; init; }
+		public required NamingConvention DefaultPropertyNaming { get; init; }
+		public required PropertyOrder DefaultPropertyOrder { get; init; }
 	}
 }

--- a/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
@@ -90,13 +90,15 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 
 		var analyzedTypes = new List<TypeInfo>();
 		var allEncounteredTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+		var discoveredTypeOptions = new Dictionary<ITypeSymbol, (NamingConvention Naming, PropertyOrder Order)>(SymbolEqualityComparer.Default);
 		foreach (var type in validTypes)
 		{
 			var typeInfo = TypeAnalyzer.Analyze(compilation, type.TypeSymbol, type.AttributeData, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
 			if (typeInfo != null) 
 			{
 				analyzedTypes.Add(typeInfo);
-				CollectAllTypes(compilation, typeInfo, allEncounteredTypes, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
+				RegisterTypeOptions(discoveredTypeOptions, typeInfo.TypeSymbol, typeInfo.PropertyNaming, typeInfo.PropertyOrder);
+				CollectAllTypes(compilation, typeInfo, allEncounteredTypes, context.ReportDiagnostic, discoveredTypeOptions, typeInfo.PropertyNaming, typeInfo.PropertyOrder);
 			}
 		}
 
@@ -112,7 +114,15 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 
 			if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
 			{
-				var typeInfo = TypeAnalyzer.Analyze(compilation, namedTypeSymbol, null, context.ReportDiagnostic, options.DefaultPropertyNaming, options.DefaultPropertyOrder);
+				var naming = options.DefaultPropertyNaming;
+				var order = options.DefaultPropertyOrder;
+				if (discoveredTypeOptions.TryGetValue(namedTypeSymbol, out var discovered))
+				{
+					naming = discovered.Naming;
+					order = discovered.Order;
+				}
+
+				var typeInfo = TypeAnalyzer.Analyze(compilation, namedTypeSymbol, null, context.ReportDiagnostic, naming, order);
 				if (typeInfo != null)
 					allTypeInfos.Add(typeInfo);
 			}
@@ -177,17 +187,17 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 			CollectSchemaHandlers(nested, results, systemType);
 	}
 
-	private static void CollectAllTypes(Compilation compilation, TypeInfo typeInfo, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, NamingConvention defaultPropertyNaming, PropertyOrder defaultPropertyOrder)
+	private static void CollectAllTypes(Compilation compilation, TypeInfo typeInfo, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, Dictionary<ITypeSymbol, (NamingConvention Naming, PropertyOrder Order)> discoveredTypeOptions, NamingConvention naming, PropertyOrder order)
 	{
-		CollectTypeRecursive(compilation, typeInfo.TypeSymbol, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
+		CollectTypeRecursive(compilation, typeInfo.TypeSymbol, allTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
 
 		foreach (var prop in typeInfo.Properties)
 		{
-			CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
+			CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
 		}
 	}
 
-	private static void CollectTypeRecursive(Compilation compilation, ITypeSymbol typeSymbol, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, NamingConvention defaultPropertyNaming, PropertyOrder defaultPropertyOrder)
+	private static void CollectTypeRecursive(Compilation compilation, ITypeSymbol typeSymbol, HashSet<ITypeSymbol> allTypes, Action<Diagnostic> reportDiagnostic, Dictionary<ITypeSymbol, (NamingConvention Naming, PropertyOrder Order)> discoveredTypeOptions, NamingConvention naming, PropertyOrder order)
 	{
 		var unwrapped = CodeEmitterHelpers.UnwrapNullable(typeSymbol);
 		var typeKind = SchemaCodeEmitter.DetermineTypeKind(unwrapped);
@@ -201,25 +211,34 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		{
 			var elementType = CodeEmitterHelpers.GetElementType(unwrapped);
 			if (elementType != null)
-				CollectTypeRecursive(compilation, elementType, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
+				CollectTypeRecursive(compilation, elementType, allTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
 			return;
 		}
 
 		if (typeKind == TypeKind.Object && unwrapped is INamedTypeSymbol namedType)
 		{
+			RegisterTypeOptions(discoveredTypeOptions, namedType, naming, order);
+
 			if (allTypes.Add(namedType))
 			{
 				// Analyze the type to collect its properties' types
-				var tempTypeInfo = TypeAnalyzer.Analyze(compilation, namedType, null, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
+				var tempTypeInfo = TypeAnalyzer.Analyze(compilation, namedType, null, reportDiagnostic, naming, order);
 				if (tempTypeInfo != null)
 				{
 					foreach (var prop in tempTypeInfo.Properties)
 					{
-						CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, defaultPropertyNaming, defaultPropertyOrder);
+						CollectTypeRecursive(compilation, prop.Type, allTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
 					}
 				}
 			}
 		}
+	}
+
+	private static void RegisterTypeOptions(Dictionary<ITypeSymbol, (NamingConvention Naming, PropertyOrder Order)> discoveredTypeOptions, ITypeSymbol typeSymbol, NamingConvention naming, PropertyOrder order)
+	{
+		if (discoveredTypeOptions.ContainsKey(typeSymbol)) return;
+
+		discoveredTypeOptions[typeSymbol] = (naming, order);
 	}
 
 	private static ClassDeclarationInfo DetectGeneratedJsonSchemasClass(

--- a/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
@@ -55,6 +55,32 @@ internal static class SchemaCodeEmitter
 
 			return;
 		}
+
+		if (typeKind == TypeKind.Array)
+		{
+			sb.AppendLine();
+			if (isNullable)
+				sb.Append($"{indent}.Type(SchemaValueType.Array, SchemaValueType.Null)");
+			else
+				sb.Append($"{indent}.Type(SchemaValueType.Array)");
+
+			var elementType = CodeEmitterHelpers.GetElementType(unwrapped);
+			if (elementType != null)
+			{
+				sb.AppendLine();
+				sb.Append($"{indent}.Items(");
+				sb.Append("new JsonSchemaBuilder()");
+
+				EmitSchemaForType(sb, elementType, false, indent + "\t", context);
+
+				if (itemAttributes is { Count: > 0 })
+					EmitAttributes(sb, itemAttributes, indent + "\t");
+
+				sb.Append(")");
+			}
+
+			return;
+		}
 		
 		if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
 		{
@@ -223,6 +249,7 @@ internal static class SchemaCodeEmitter
 	{
 		sb.AppendLine("\tpublic static JsonSchemaBuilder BuildForType(this JsonSchemaBuilder builder, Type type)");
 		sb.AppendLine("\t{");
+		sb.AppendLine("\t\tvar isNullable = Nullable.GetUnderlyingType(type) != null;");
 		sb.AppendLine("\t\tvar unwrapped = Nullable.GetUnderlyingType(type) ?? type;");
 
 		foreach (var handler in schemaHandlers)
@@ -265,14 +292,14 @@ internal static class SchemaCodeEmitter
 			sb.AppendLine($"\t\t\tvar t when t == typeof({typeName}) => builder.Ref(\"{schemaId}\"),");
 		}
 
-		sb.AppendLine("\t\t	var t when t == typeof(bool) => builder.Type(SchemaValueType.Boolean),");
-		sb.AppendLine("\t\t	var t when t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) || t == typeof(uint) || t == typeof(long) || t == typeof(ulong) => builder.Type(SchemaValueType.Integer),");
-		sb.AppendLine("\t\t	var t when t == typeof(float) || t == typeof(double) || t == typeof(decimal) => builder.Type(SchemaValueType.Number),");
-		sb.AppendLine("\t\t	var t when t == typeof(string) => builder.Type(SchemaValueType.String),");
-		sb.AppendLine("\t\t	var t when t == typeof(DateTime) || t == typeof(DateTimeOffset) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.DateTime),");
-		sb.AppendLine("\t\t	var t when t == typeof(Guid) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uuid),");
-		sb.AppendLine("\t\t	var t when t == typeof(Uri) => builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uri),");
-		sb.AppendLine("\t\t	_ => builder");
+		sb.AppendLine("\t\t\tvar t when t == typeof(bool) => isNullable ? builder.Type(SchemaValueType.Boolean, SchemaValueType.Null) : builder.Type(SchemaValueType.Boolean),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) || t == typeof(uint) || t == typeof(long) || t == typeof(ulong) => isNullable ? builder.Type(SchemaValueType.Integer, SchemaValueType.Null) : builder.Type(SchemaValueType.Integer),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(float) || t == typeof(double) || t == typeof(decimal) => isNullable ? builder.Type(SchemaValueType.Number, SchemaValueType.Null) : builder.Type(SchemaValueType.Number),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(string) => builder.Type(SchemaValueType.String),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(DateTime) || t == typeof(DateTimeOffset) => isNullable ? builder.Type(SchemaValueType.String, SchemaValueType.Null).Format(global::Json.Schema.Formats.DateTime) : builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.DateTime),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(Guid) => isNullable ? builder.Type(SchemaValueType.String, SchemaValueType.Null).Format(global::Json.Schema.Formats.Uuid) : builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uuid),");
+		sb.AppendLine("\t\t\tvar t when t == typeof(Uri) => isNullable ? builder.Type(SchemaValueType.String, SchemaValueType.Null).Format(global::Json.Schema.Formats.Uri) : builder.Type(SchemaValueType.String).Format(global::Json.Schema.Formats.Uri),");
+		sb.AppendLine("\t\t\t_ => builder");
 		sb.AppendLine("\t\t};");
 		sb.AppendLine("\t}");
 		sb.AppendLine();

--- a/src/JsonSchema.Generation/SourceGeneration/TypeAnalyzer.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/TypeAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Json.Schema.Generation.SourceGeneration;
 
 internal static class TypeAnalyzer
 {
-	public static TypeInfo? Analyze(Compilation compilation, INamedTypeSymbol typeSymbol, AttributeData? attributeData, Action<Diagnostic> reportDiagnostic)
+	public static TypeInfo? Analyze(Compilation compilation, INamedTypeSymbol typeSymbol, AttributeData? attributeData, Action<Diagnostic> reportDiagnostic, NamingConvention defaultPropertyNaming = NamingConvention.AsDeclared, PropertyOrder defaultPropertyOrder = PropertyOrder.AsDeclared)
 	{
 		if (typeSymbol is { IsGenericType: true, IsUnboundGenericType: false })
 		{
@@ -27,8 +27,8 @@ internal static class TypeAnalyzer
 			}
 		}
 
-		var propertyNaming = NamingConvention.AsDeclared;
-		var propertyOrder = PropertyOrder.AsDeclared;
+		var propertyNaming = defaultPropertyNaming;
+		var propertyOrder = defaultPropertyOrder;
 		var strictConditionals = false;
 
 		if (attributeData != null)
@@ -136,6 +136,7 @@ internal static class TypeAnalyzer
 	private static void AnalyzeObjectType(Compilation compilation, TypeInfo typeInfo, Action<Diagnostic> reportDiagnostic)
 	{
 		var typeSymbol = typeInfo.TypeSymbol;
+		var encounteredSchemaNames = new HashSet<string>(StringComparer.Ordinal);
 
 		var members = typeSymbol.GetMembers()
 			.Where(m => m is { IsStatic: false, Kind: SymbolKind.Property or SymbolKind.Field })
@@ -182,6 +183,15 @@ internal static class TypeAnalyzer
 			else continue;
 
 			var schemaName = GetPropertySchemaName(member, typeInfo.PropertyNaming);
+			if (!encounteredSchemaNames.Add(schemaName))
+			{
+				reportDiagnostic(Diagnostic.Create(
+					Diagnostics.DuplicateSchemaPropertyName,
+					member.Locations.FirstOrDefault(),
+					typeSymbol.ToDisplayString(),
+					schemaName));
+				continue;
+			}
 
 			var isRequired = false;
 			var requiredAttrs = member.GetAttributes().Where(a => a.AttributeClass?.Name == "RequiredAttribute").ToList();

--- a/src/JsonSchema.Generation/build/JsonSchema.Net.Generation.props
+++ b/src/JsonSchema.Generation/build/JsonSchema.Net.Generation.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="DisableJsonSchemaSourceGeneration" />
+    <CompilerVisibleProperty Include="JsonSchemaDefaultPropertyNaming" />
+    <CompilerVisibleProperty Include="JsonSchemaDefaultPropertyOrder" />
+  </ItemGroup>
+</Project>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-api.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-api.md
@@ -4,9 +4,13 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.055"
 ---
-# [1.1.0](https://github.com/gregsdennis/json-everything/pull/1013) {#release-schemaapi-1.0.3}
+# [1.1.1](https://github.com/gregsdennis/json-everything/pull/1023) {#release-schemaapi-1.1.1}
 
-Updated nuget packages & EULA.
+Add debug logging for full validation results on failure.
+
+# [1.1.0](https://github.com/gregsdennis/json-everything/pull/1013) {#release-schemaapi-1.1.0}
+
+Added Minimal API support.
 
 # [1.0.3](https://github.com/gregsdennis/json-everything/pull/1013) {#release-schemaapi-1.0.3}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,6 +4,21 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
+# [7.3.5](https://github.com/gregsdennis/json-everything/pull/1023) {#release-schemagen-7.3.5}
+
+[#1018](https://github.com/gregsdennis/json-everything/issues/1018)
+
+- Fixes
+  - Runtime type initialization failure in source-generated code
+  - Multiple `[If]` attributes that use the same property
+  - Array types support
+  - Better nullability tracking
+  - Better support for external types
+- Added project attributes (.csproj) that allow setting generation defaults for
+  - enabling/disabling source generation
+  - property naming (casing)
+  - property order
+
 # [7.3.4](https://github.com/gregsdennis/json-everything/commits/d9ed49cf134e4b22282da90e2da0d2348c06a9b1) {#release-schemagen-7.3.4}
 
 [#1018](https://github.com/gregsdennis/json-everything/issues/1018)


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

#### JsonSchema.Net.Generation

- Fixes
  - Runtime type initialization failure in source-generated code
  - Multiple `[If]` attributes that use the same property
  - Array types support
  - Better nullability tracking
  - Better support for external types
- Added project attributes (.csproj) that allow setting generation defaults for
  - enabling/disabling source generation
  - property naming (casing)
  - property order

#### JsonSchema.Net.Api

Add debug logging for full validation results.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #1018     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
