### PR TITLE
logic - array coercion

### DIFF
--- a/src/JsonLogic.Tests/GithubTests.cs
+++ b/src/JsonLogic.Tests/GithubTests.cs
@@ -268,4 +268,17 @@ public class GithubTests
 
 		JsonAssert.IsFalse(result);
 	}
+
+	[Test]
+	public void Issue1019_ArrayCoercion()
+	{
+		var rule = JsonNode.Parse("""{"==":[{"var":"features.group1"}, "feat1"]}""");
+		var data = JsonNode.Parse("""{"features":{"group1":["feat1"]}}""");
+
+		var result = Apply(rule, data);
+
+		TestConsole.WriteLine(result.AsJsonString());
+
+		JsonAssert.IsTrue(result);
+	}
 }

--- a/src/JsonLogic/JsonNodeExtensions.cs
+++ b/src/JsonLogic/JsonNodeExtensions.cs
@@ -132,8 +132,6 @@ public static class JsonNodeExtensions
 	/// </remarks>
 	public static bool LooseEquals(this JsonNode? a, JsonNode? b)
 	{
-		static string CoerceArrayToString(JsonArray array) => string.Join(",", array.Select(e => e.AsJsonString()));
-
 		if (a is null && b is null) return true;
 		if (a is null || b is null) return false;
 
@@ -143,7 +141,7 @@ public static class JsonNodeExtensions
 		if (a is JsonArray && b is JsonArray) return a.IsEquivalentTo(b);
 		if (a is JsonArray aArr)
 		{
-			var aStr = CoerceArrayToString(aArr);
+			var aStr = Stringify(aArr);
 			var bVal = (JsonValue)b;
 			if (bVal.TryGetValue(out string? bStr)) return aStr == bStr;
 			var bNum = bVal.GetNumber();
@@ -152,7 +150,7 @@ public static class JsonNodeExtensions
 		}
 		if (b is JsonArray bArr)
 		{
-			var bStr = CoerceArrayToString(bArr);
+			var bStr = Stringify(bArr);
 			var aVal = (JsonValue)a;
 			if (aVal.TryGetValue(out string? aStr)) return bStr == aStr;
 			var aNum = aVal.GetNumber();


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Fixes JSON Logic array -> string coercion for loose-equals.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #1019     <!-- Use if these changes completely resolve the issue -->

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
