### PR TITLE
enum-keyed dictionaries with schema'd enums doesn't work

### DIFF
--- a/src/JsonSchema.Tests/Serialization/DeserializationTests.cs
+++ b/src/JsonSchema.Tests/Serialization/DeserializationTests.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Drawing;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Json.More;
 using Json.Schema.Serialization;
 using NUnit.Framework;
 using TestHelpers;
@@ -53,6 +56,19 @@ public class DeserializationTests
 				("Y", new JsonSchemaBuilder().Type(SchemaValueType.Integer))
 			)
 			.AdditionalProperties(false);
+
+	public static readonly JsonSchema ValidatedEnumSchema =
+		new JsonSchemaBuilder()
+			.Enum("One", "Two", "Three");
+
+	[JsonSchema(typeof(DeserializationTests), nameof(ValidatedEnumSchema))]
+	[JsonConverter(typeof(EnumStringConverter<ValidatedEnum>))]
+	public enum ValidatedEnum
+	{
+		One,
+		Two,
+		Three
+	}
 
 	private static readonly JsonSerializerOptions _options = new()
 	{
@@ -408,6 +424,29 @@ public class DeserializationTests
 		{
 			Assert.That(result, Is.Not.Null, "Each concurrent deserialization should produce a non-null schema.");
 		}
+	}
+
+	[Test]
+	public void EnumKeyedDictionaryRoundTrip()
+	{
+		var dictionary = new Dictionary<ValidatedEnum, string>
+		{
+			[ValidatedEnum.One] = "1",
+			[ValidatedEnum.Two] = "2",
+			[ValidatedEnum.Three] = "3"
+		};
+		var options = new JsonSerializerOptions
+		{
+			TypeInfoResolverChain = { TestSerializerContext.Default },
+			WriteIndented = true,
+			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+			Converters = { new ValidatingJsonConverter { EvaluationOptions = { OutputFormat = OutputFormat.List } } }
+		};
+
+		var serialized = JsonSerializer.Serialize(dictionary, options);
+		var deserialized = JsonSerializer.Deserialize<Dictionary<ValidatedEnum, string>>(serialized, options);
+
+		Assert.That(deserialized, Is.EquivalentTo(dictionary));
 	}
 
 	/// <summary>

--- a/src/JsonSchema.Tests/TestSerializerContext.cs
+++ b/src/JsonSchema.Tests/TestSerializerContext.cs
@@ -10,6 +10,7 @@ namespace Json.Schema.Tests;
 [JsonSerializable(typeof(System.Drawing.Point))]
 [JsonSerializable(typeof(DeserializationTests.Foo))]
 [JsonSerializable(typeof(DeserializationTests.FooWithSchema))]
+[JsonSerializable(typeof(Dictionary<DeserializationTests.ValidatedEnum, string>))]
 [JsonSerializable(typeof(JsonSchema))]
 [JsonSerializable(typeof(EvaluationResults))]
 [JsonSerializable(typeof(GithubTests.Model791))]

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,7 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>JsonSchema.Net</PackageId>
-    <JsonSchemaNetVersion>9.1.5</JsonSchemaNetVersion>
+    <JsonSchemaNetVersion>9.2.0</JsonSchemaNetVersion>
     <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <FileVersion>$(JsonSchemaNetVersion)</FileVersion>
     <Version>$(JsonSchemaNetVersion)</Version>

--- a/src/JsonSchema/Serialization/JsonSchemaAttribute.cs
+++ b/src/JsonSchema/Serialization/JsonSchemaAttribute.cs
@@ -7,7 +7,7 @@ namespace Json.Schema.Serialization;
 /// <summary>
 /// Identifies a <see cref="JsonSchema"/> to use when deserializing a type.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Enum)]
 public class JsonSchemaAttribute : Attribute
 {
 	internal JsonSchema Schema { get; }

--- a/src/JsonSchema/Serialization/ValidatingJsonConverter.cs
+++ b/src/JsonSchema/Serialization/ValidatingJsonConverter.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Json.More;
 
@@ -191,6 +192,17 @@ public class ValidatingJsonConverter<T> : WeaklyTypedJsonConverter<T>, IValidati
 		};
 	}
 
+	/// <summary>Reads a dictionary key from a JSON property name.</summary>
+	/// <param name="reader">The <see cref="T:System.Text.Json.Utf8JsonReader" /> to read from.</param>
+	/// <param name="typeToConvert">The type to convert.</param>
+	/// <param name="options">The options to use when reading the value.</param>
+	/// <returns>The value that was converted.</returns>
+	public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		var newOptions = _optionsFactory(options);
+		return JsonSerializer.Deserialize<T>($"\"{reader.GetString()}\"", newOptions)!;
+	}
+
 	/// <summary>
 	/// Writes the JSON representation of the object.
 	/// </summary>
@@ -204,5 +216,20 @@ public class ValidatingJsonConverter<T> : WeaklyTypedJsonConverter<T>, IValidati
 		var newOptions = _optionsFactory(options);
 
 		newOptions.Write(writer, value, typeof(T));
+	}
+
+	/// <summary>Writes a dictionary key as a JSON property name.</summary>
+	/// <param name="writer">The <see cref="T:System.Text.Json.Utf8JsonWriter" /> to write to.</param>
+	/// <param name="value">The value to convert. The value of <see cref="P:System.Text.Json.Serialization.JsonConverter`1.HandleNull" /> determines if the converter handles <see langword="null" /> values.</param>
+	/// <param name="options">The options to use when writing the value.</param>
+	public override void WriteAsPropertyName(Utf8JsonWriter writer, [DisallowNull] T value, JsonSerializerOptions options)
+	{
+		var newOptions = _optionsFactory(options);
+		var serialized = JsonSerializer.SerializeToNode(value, newOptions);
+		if (serialized is not JsonValue jsonValue || !jsonValue.TryGetValue(out string? key))
+			throw new JsonException($"The value {value} cannot be used as a JSON key because it does not serialize to a string.");
+
+		writer.WritePropertyName(key);
+		
 	}
 }

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,11 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [9.2.0](https://github.com/gregsdennis/json-everything/pull/1031) {#release-schema-9.2.0}
+
+- Update `ValidatingJsonConverter` to properly handle dictionary keys.
+- Update `[JsonSchema]` attribute so that it can be applied to enums.
+
 # [9.1.5](https://github.com/gregsdennis/json-everything/pull/1028) {#release-schema-9.1.5}
 
 Adds `SchemaRegistry.CreateBundle()`.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

- Update validating converter to properly handle dictionary keys.
- Update `[JsonSchema]` attribute so that it can be applied to enums.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves [private]     <!-- Use if these changes completely resolve the issue -->

### Organization

<!-- 
Are you submitting this change on behalf of an organization?  If so, who?
-->
- [x] Organization: ZEIL
- [ ] Independent

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
