### PR TITLE
fix(playground): light mode cursor invisible due to missing color-scheme

### DIFF
--- a/json-everything.net/Shared/Header.razor
+++ b/json-everything.net/Shared/Header.razor
@@ -100,7 +100,7 @@
 	private async Task ApplyTheme()
 	{
 		await JSRuntime.InvokeVoidAsync("eval", _isDarkMode 
-			? "document.documentElement.removeAttribute('data-bs-theme')" 
-			: "document.documentElement.setAttribute('data-bs-theme', 'light')");
+			? "document.documentElement.removeAttribute('data-bs-theme'); document.documentElement.style.colorScheme='dark'" 
+			: "document.documentElement.setAttribute('data-bs-theme', 'light'); document.documentElement.style.colorScheme='light'");
 	}
 }

--- a/json-everything.net/wwwroot/css/app.css
+++ b/json-everything.net/wwwroot/css/app.css
@@ -1,5 +1,9 @@
 ﻿@import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
 
+html {
+	color-scheme: light dark;
+}
+
 html,
 body,
 #app,

--- a/json-everything.net/wwwroot/index.html
+++ b/json-everything.net/wwwroot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="color-scheme: dark">
 
 <head>
 	<meta charset="utf-8" />


### PR DESCRIPTION
The text cursor (I-beam) is white in light mode, making it invisible against the white background. Bootstrap 5.1 doesn't set `color-scheme` on the document element, so the browser defaults to dark-mode native controls regardless of the `data-bs-theme` attribute.

Three changes:
- Added `color-scheme: light dark` on `html` in `app.css` to declare both modes are supported
- Updated `ApplyTheme()` in `Header.razor` to set `document.documentElement.style.colorScheme` alongside the existing `data-bs-theme` toggle
- Set `style="color-scheme: dark"` on the `<html>` tag in `index.html` so the loading screen also renders correctly before Blazor initializes

Fixes #983
