### PR TITLE
Misc updates

### DIFF
--- a/src/JsonLogic.Tests/IfTests.cs
+++ b/src/JsonLogic.Tests/IfTests.cs
@@ -22,6 +22,14 @@ public class IfTests
 	}
 
 	[Test]
+	public void IfNullReturnsFalseResult()
+	{
+		var rule = JsonLogic.If(null!, 1, 2);
+
+		JsonAssert.AreEquivalent(2, rule.Apply());
+	}
+
+	[Test]
 	public void IfStandardReturnsSecondTrueResult()
 	{
 		var rule = JsonLogic.If(false, 1, true, 2, 3);

--- a/src/JsonLogic/ILogicLogger.cs
+++ b/src/JsonLogic/ILogicLogger.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text.Json.Nodes;
+
+namespace Json.Logic;
+
+/// <summary>
+/// Defines a logger that writes structured log entries represented as JSON nodes.
+/// </summary>
+/// <remarks>Implementations of this interface can be used to record log information in a structured format,
+/// enabling easier parsing and analysis of log data. The interface is intended for scenarios where log content is best
+/// represented as JSON, such as for telemetry or diagnostics in distributed systems.</remarks>
+public interface ILogicLogger
+{
+	/// <summary>
+	/// Writes the specified JSON content followed by a line terminator.
+	/// </summary>
+	/// <param name="content">The JSON content to write. Can be null, in which case no content is written but a line terminator is still
+	/// appended.</param>
+	void WriteLine(JsonNode? content);
+}
+
+/// <summary>
+/// Provides commonly used implementations of the ILogicLogger interface for application logic logging.
+/// </summary>
+/// <remarks>This static class offers ready-to-use logger instances, including a console logger for outputting log
+/// messages to the console and a null logger that ignores all log messages. These loggers can be used to simplify
+/// logging setup in applications or for testing purposes.</remarks>
+public static class LogicLoggers
+{
+	/// <summary>
+	/// Gets a logger instance that writes log messages to the console.
+	/// </summary>
+	public static ILogicLogger ConsoleLogger { get; } = new ConsoleLogger();
+	/// <summary>
+	/// Gets a logger instance that performs no logging operations.  This is the default logger.
+	/// </summary>
+	/// <remarks>This property provides a no-op implementation of the logger interface. It can be used in scenarios
+	/// where logging is optional or should be suppressed, such as in testing or when a logger is required but no actual
+	/// logging is desired.</remarks>
+	public static ILogicLogger NullLogger { get; } = new NullLogger();
+}
+
+internal class NullLogger : ILogicLogger
+{
+	public void WriteLine(JsonNode? content)
+	{
+	}
+}
+
+internal class ConsoleLogger : ILogicLogger
+{
+	public void WriteLine(JsonNode? content)
+	{
+		Console.WriteLine(content);
+	}
+}

--- a/src/JsonLogic/JsonLogic.csproj
+++ b/src/JsonLogic/JsonLogic.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>6.0.2</Version>
-    <FileVersion>6.0.2</FileVersion>
+    <Version>6.1.0</Version>
+    <FileVersion>6.1.0</FileVersion>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JsonLogic built on the System.Text.Json namespace</Description>

--- a/src/JsonLogic/Rules/IfRule.cs
+++ b/src/JsonLogic/Rules/IfRule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -79,10 +80,9 @@ public class IfRule : Rule, IRule
 
 					currentTrueResult = Components[elseIndex++];
 				}
-				break;
-		}
 
-		throw new NotImplementedException("Something went wrong. This shouldn't happen.");
+				return Components[elseIndex].Apply(data, contextData);
+		}
 	}
 
 	JsonNode? IRule.Apply(JsonNode? args, EvaluationContext context)
@@ -123,10 +123,8 @@ public class IfRule : Rule, IRule
 
 					currentTrueResult = array[elseIndex++];
 				}
-				break;
+				return JsonLogic.Apply(array[elseIndex], context);
 		}
-
-		throw new NotImplementedException("Something went wrong. This shouldn't happen.");
 	}
 }
 

--- a/src/JsonLogic/Rules/LogRule.cs
+++ b/src/JsonLogic/Rules/LogRule.cs
@@ -13,6 +13,17 @@ namespace Json.Logic.Rules;
 [JsonConverter(typeof(LogRuleJsonConverter))]
 public class LogRule : Rule, IRule
 {
+	/// <summary>
+	/// Gets or sets the logger used for logic operations.
+	/// </summary>
+	/// <remarks>If not explicitly set, the property returns a default console logger. Assigning a custom logger
+	/// allows integration with different logging frameworks or custom logging behavior.</remarks>
+	public static ILogicLogger Logger
+	{
+		get => field ?? LogicLoggers.ConsoleLogger;
+		set;
+	}
+
 	internal Rule Log { get; }
 
 	internal LogRule(Rule log)
@@ -37,7 +48,7 @@ public class LogRule : Rule, IRule
 	{
 		var log = Log.Apply(data, contextData);
 
-		Console.WriteLine(log);
+		Logger.WriteLine(log);
 
 		return log;
 	}
@@ -46,7 +57,7 @@ public class LogRule : Rule, IRule
 	{
 		var log = JsonLogic.Apply(args, context);
 
-		Console.WriteLine(log);
+		Logger.WriteLine(log);
 
 		return log;
 	}
@@ -58,7 +69,7 @@ internal class LogRuleJsonConverter : WeaklyTypedJsonConverter<LogRule>
 	{
 		var parameters = reader.TokenType == JsonTokenType.StartArray
 			? options.ReadArray(ref reader, JsonLogicSerializerContext.Default.Rule)
-			: new[] { options.Read(ref reader, JsonLogicSerializerContext.Default.Rule)! };
+			: [options.Read(ref reader, JsonLogicSerializerContext.Default.Rule)!];
 
 		return new LogRule(parameters!.Length == 0
 			? new LiteralRule("")

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/CustomEmitterAttributes.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/CustomEmitterAttributes.cs
@@ -38,15 +38,18 @@ public class CustomFormatAttribute : Attribute, IAttributeHandler<CustomFormatAt
 [SchemaHandler(typeof(TestModels.Optional<>))]
 public static class OptionalSchemaHandler
 {
-	public static JsonSchemaBuilder Apply(JsonSchemaBuilder builder, Type type)
+	public static JsonSchemaBuilder Apply(this JsonSchemaBuilder builder, Type type)
 	{
-		if (!type.IsGenericType) return builder;
-		if (type.IsGenericTypeDefinition) return builder;
+		var innerType = type.GetGenericArguments()[0];
+		if (innerType.IsGenericType && innerType.GetGenericTypeDefinition() == typeof(Nullable<>))
+			return builder.BuildForType(innerType);
 
-		var genericArguments = type.GetGenericArguments();
-		if (genericArguments.Length != 1) return builder;
+		builder.AnyOf(
+			new JsonSchemaBuilder().BuildForType(innerType),
+			new JsonSchemaBuilder().Type(SchemaValueType.Null)
+		);
 
-		return builder.BuildForType(genericArguments[0]);
+		return builder;
 	}
 }
 

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using static Json.Schema.Generation.Tests.AssertionExtensions;
+// ReSharper disable UnusedVariable
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Json.Schema.Generation.Tests.SourceGeneration;

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/SourceGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using static Json.Schema.Generation.Tests.AssertionExtensions;
@@ -456,7 +457,12 @@ public class SourceGeneratorTests
 		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalWrapper",
 		  "type": "object",
 		  "properties": {
-		    "Age": { "type": "integer" }
+		    "Age": { 
+		      "anyOf":[
+		        {"type":"integer"},
+		        {"type":"null"}
+		      ]
+		    }
 		  }
 		}
 		""";
@@ -475,7 +481,12 @@ public class SourceGeneratorTests
 		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalObjectWrapper",
 		  "type": "object",
 		  "properties": {
-		    "Person": { "$ref": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.SimplePerson" }
+		    "Person": {
+		      "anyOf":[
+		        {"$ref":"global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.SimplePerson"},
+		        {"type":"null"}
+		      ]
+		    }
 		  }
 		}
 		""";
@@ -486,17 +497,175 @@ public class SourceGeneratorTests
 	}
 
 	[Test]
+	public void ModelWithOptionalCollections_ContinuesWithGenerated()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalCollections",
+		  "type": "object",
+		  "properties": {
+		    "ValueA": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.IEnumerable<int>"},
+		        {"type":"null"}
+		      ]
+		    },
+		    "ValueB": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.IEnumerable<int>"},
+		        {"type":"null"}
+		      ]
+		    }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithOptionalCollections;
+		var enumerableParameter = GeneratedJsonSchemas.IEnumerableOfInt32;
+		var arrayParameter = GeneratedJsonSchemas.Int32Array;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void ModelWithOptionalDictionary_ContinuesWithGenerated()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalDictionary",
+		  "type": "object",
+		  "properties": {
+		    "Data": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.Dictionary<string, int>"},
+		        {"type":"null"}
+		      ]
+		    }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithOptionalDictionary;
+		var dictionaryParameter = GeneratedJsonSchemas.DictionaryOfStringAndInt32;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void ModelWithOptionalAdditionalCollections_ContinuesWithGenerated()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalAdditionalCollections",
+		  "type": "object",
+		  "properties": {
+		    "ValueA": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.IEnumerable<int>"},
+		        {"type":"null"}
+		      ]
+		    },
+		    "ValueB": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.IEnumerable<int>"},
+		        {"type":"null"}
+		      ]
+		    },
+		    "ValueC": {
+		      "anyOf":[
+		        {"$ref":"global::System.Collections.Generic.IEnumerable<int>"},
+		        {"type":"null"}
+		      ]
+		    }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithOptionalAdditionalCollections;
+		var hashSetParameter = GeneratedJsonSchemas.HashSetOfInt32;
+		var queueParameter = GeneratedJsonSchemas.QueueOfInt32;
+		var readOnlyCollectionParameter = GeneratedJsonSchemas.IReadOnlyCollectionOfInt32;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void ModelWithOptionalUngeneratedType_ContinuesWithGenerated()
+	{
+		var expectedJson = """
+		{
+		  "$schema": "https://json-schema.org/draft/2020-12/schema",
+		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.ModelWithOptionalUngeneratedType",
+		  "type": "object",
+		  "properties": {
+		    "Ungenerated": {
+		      "anyOf":[
+		        {"$ref":"global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.UngeneratedType"},
+		        {"type":"null"}
+		      ]
+		    }
+		  }
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = GeneratedJsonSchemas.TestModels_ModelWithOptionalUngeneratedType;
+		var parameter = GeneratedJsonSchemas.TestModels_UngeneratedType;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
 	public void BuildForType_UsesSchemaHandlerForOpenGenericType()
 	{
 		var expectedJson = """
 		{
-		  "type": "string"
+		  "anyOf":[
+		    {"type":"string"},
+		    {"type":"null"}
+		  ]
 		}
 		""";
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
 		var actual = new JsonSchemaBuilder()
 			.BuildForType(typeof(TestModels.Optional<string>))
 			.Build();
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void BuildForType_Array_UsesGeneratedSchema()
+	{
+		var expectedJson = """
+		{
+		  "$ref": "global::System.Collections.Generic.IEnumerable<int>"
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = new JsonSchemaBuilder()
+			.BuildForType(typeof(int[]))
+			.Build();
+		var parameter = GeneratedJsonSchemas.IEnumerableOfInt32;
+
+		AssertEqual(expected, actual);
+	}
+
+	[Test]
+	public void BuildForType_Dictionary_UsesGeneratedSchema()
+	{
+		var expectedJson = """
+		{
+		  "$ref": "global::System.Collections.Generic.Dictionary<string, int>"
+		}
+		""";
+		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var actual = new JsonSchemaBuilder()
+			.BuildForType(typeof(Dictionary<string, int>))
+			.Build();
+		var parameter = GeneratedJsonSchemas.DictionaryOfStringAndInt32;
 
 		AssertEqual(expected, actual);
 	}
@@ -604,7 +773,10 @@ public class SourceGeneratorTests
 		{
 		  "$schema": "https://json-schema.org/draft/2020-12/schema",
 		  "$id": "global::Json.Schema.Generation.Tests.SourceGeneration.TestModels.Optional<int>",
-		  "type": "integer"
+		  "anyOf":[
+		    {"type":"integer"},
+		    {"type":"null"}
+		  ]
 		}
 		""";
 		var expected = JsonSchema.FromText(expectedJson, new BuildOptions { SchemaRegistry = new SchemaRegistry() });

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
@@ -357,6 +357,38 @@ public static class TestModels
 	}
 
 	[GenerateJsonSchema]
+	public class ModelWithOptionalCollections
+	{
+		public Optional<IEnumerable<int>> ValueA { get; set; } = new();
+		public Optional<int[]> ValueB { get; set; } = new();
+	}
+
+	[GenerateJsonSchema]
+	public class ModelWithOptionalUngeneratedType
+	{
+		public Optional<UngeneratedType> Ungenerated { get; set; } = new();
+	}
+
+	[GenerateJsonSchema]
+	public class ModelWithOptionalDictionary
+	{
+		public Optional<Dictionary<string, int>> Data { get; set; } = new();
+	}
+
+	[GenerateJsonSchema]
+	public class ModelWithOptionalAdditionalCollections
+	{
+		public Optional<HashSet<int>> ValueA { get; set; } = new();
+		public Optional<Queue<int>> ValueB { get; set; } = new();
+		public Optional<IReadOnlyCollection<int>> ValueC { get; set; } = new();
+	}
+
+	public class UngeneratedType
+	{
+		public string Foo { get; set; } = null!;
+	}
+
+	[GenerateJsonSchema]
 	public class ModelWithBuiltInJsonTypes
 	{
 		public JsonDocument Document { get; set; } = null!;

--- a/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
+++ b/src/JsonSchema.Generation.Tests/SourceGeneration/TestModels.cs
@@ -449,12 +449,15 @@ public static class TestModels
 		public int? ForcedNonNullable { get; set; }
 	}
 
+#pragma warning disable JSGEN003
 	[GenerateJsonSchema(PropertyNaming = NamingConvention.CamelCase)]
 	public class ModelWithDuplicateSchemaPropertyNames
 	{
 		public int Foo { get; set; }
+		// ReSharper disable once InconsistentNaming
 		public int foo { get; set; }
 	}
+#pragma warning restore JSGEN003
 
 	[GenerateJsonSchema(StrictConditionals = true)]
 	[If(nameof(IsActive), true, 0)]

--- a/src/JsonSchema.Generation/JsonSchema.Generation.csproj
+++ b/src/JsonSchema.Generation/JsonSchema.Generation.csproj
@@ -15,8 +15,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>7.3.6</Version>
-    <FileVersion>7.3.6</FileVersion>
+    <Version>7.3.7</Version>
+    <FileVersion>7.3.7</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>Extends JsonSchema.Net to provide schema generation functionality</Description>

--- a/src/JsonSchema.Generation/SourceGeneration/Emitters/CodeEmitterHelpers.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/Emitters/CodeEmitterHelpers.cs
@@ -52,16 +52,14 @@ internal static class CodeEmitterHelpers
 
 	public static bool IsCollectionType(ITypeSymbol typeSymbol)
 	{
-		if (typeSymbol is not INamedTypeSymbol { IsGenericType: true } namedType) return false;
+		if (typeSymbol is not INamedTypeSymbol namedType) return false;
+		if (namedType.SpecialType == SpecialType.System_String) return false;
+		if (IsDictionaryType(namedType)) return false;
 
-		var typeString = namedType.ConstructedFrom.ToDisplayString();
-		return typeString is
-			"System.Collections.Generic.List<T>" or
-			"System.Collections.Generic.IList<T>" or
-			"System.Collections.Generic.ICollection<T>" or
-			"System.Collections.Generic.IEnumerable<T>" or
-			"System.Collections.Generic.IReadOnlyList<T>" or
-			"System.Collections.Generic.IReadOnlyCollection<T>";
+		if (TryGetEnumerableElementType(namedType, out _))
+			return true;
+
+		return false;
 	}
 
 	public static bool IsDictionaryType(ITypeSymbol typeSymbol)
@@ -112,29 +110,55 @@ internal static class CodeEmitterHelpers
 
 	public static ITypeSymbol? GetElementType(ITypeSymbol typeSymbol)
 	{
+		var fullyQualifiedTypeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		if (fullyQualifiedTypeName == "global::System.Text.Json.Nodes.JsonArray")
+			return null;
+
 		switch (typeSymbol)
 		{
 			case IArrayTypeSymbol arrayType:
 				return arrayType.ElementType;
-			case INamedTypeSymbol { IsGenericType: true } namedType:
+			case INamedTypeSymbol namedType:
 			{
-				var typeString = namedType.ConstructedFrom.ToDisplayString();
-				if (typeString is
-				    "System.Collections.Generic.List<T>" or
-				    "System.Collections.Generic.IList<T>" or
-				    "System.Collections.Generic.ICollection<T>" or
-				    "System.Collections.Generic.IEnumerable<T>" or
-				    "System.Collections.Generic.IReadOnlyList<T>" or
-				    "System.Collections.Generic.IReadOnlyCollection<T>")
-				{
-					return namedType.TypeArguments[0];
-				}
+				if (namedType.SpecialType == SpecialType.System_String) break;
+				if (IsDictionaryType(namedType)) break;
+
+				if (TryGetEnumerableElementType(namedType, out var elementType))
+					return elementType;
 
 				break;
 			}
 		}
 
 		return null;
+	}
+
+	private static bool TryGetEnumerableElementType(INamedTypeSymbol typeSymbol, out ITypeSymbol? elementType)
+	{
+		elementType = null;
+
+		if (typeSymbol is { IsGenericType: true } && IsGenericIEnumerable(typeSymbol.ConstructedFrom))
+		{
+			elementType = typeSymbol.TypeArguments[0];
+			return true;
+		}
+
+		foreach (var iface in typeSymbol.AllInterfaces)
+		{
+			if (!iface.IsGenericType) continue;
+			if (!IsGenericIEnumerable(iface.ConstructedFrom)) continue;
+
+			elementType = iface.TypeArguments[0];
+			return true;
+		}
+
+		return false;
+	}
+
+	private static bool IsGenericIEnumerable(INamedTypeSymbol typeSymbol)
+	{
+		return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace(" ", string.Empty)
+			== "global::System.Collections.Generic.IEnumerable<T>";
 	}
 
 	public static bool ShouldIncludeEnumMember(IFieldSymbol field)

--- a/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/JsonSchemaSourceGenerator.cs
@@ -116,6 +116,14 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		{
 			if (analyzedTypes.Any(t => SymbolEqualityComparer.Default.Equals(t.TypeSymbol, typeSymbol))) continue;
 
+			if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
+			{
+				if (allTypeInfos.Any(t => SymbolEqualityComparer.Default.Equals(t.TypeSymbol, arrayTypeSymbol))) continue;
+
+				allTypeInfos.Add(AnalyzeArrayType(arrayTypeSymbol, options.DefaultPropertyNaming, options.DefaultPropertyOrder));
+				continue;
+			}
+
 			if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
 			{
 				var naming = options.DefaultPropertyNaming;
@@ -228,6 +236,8 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 
 		if (typeKind == TypeKind.Array)
 		{
+			allTypes.Add(unwrapped);
+
 			var elementType = CodeEmitterHelpers.GetElementType(unwrapped);
 			if (elementType != null)
 				CollectTypeRecursive(compilation, elementType, allTypes, selfGeneratingAssemblies, generatedSchemaMembersByAssembly, foreignTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
@@ -236,6 +246,8 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 
 		if (typeKind == TypeKind.Dictionary)
 		{
+			allTypes.Add(unwrapped);
+
 			var keyType = CodeEmitterHelpers.GetDictionaryKeyType(unwrapped);
 			if (keyType != null)
 				CollectTypeRecursive(compilation, keyType, allTypes, selfGeneratingAssemblies, generatedSchemaMembersByAssembly, foreignTypes, reportDiagnostic, discoveredTypeOptions, naming, order);
@@ -288,6 +300,21 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		if (discoveredTypeOptions.ContainsKey(typeSymbol)) return;
 
 		discoveredTypeOptions[typeSymbol] = (naming, order);
+	}
+
+	private static TypeInfo AnalyzeArrayType(IArrayTypeSymbol typeSymbol, NamingConvention propertyNaming, PropertyOrder propertyOrder)
+	{
+		return new TypeInfo
+		{
+			TypeSymbol = typeSymbol,
+			FullyQualifiedName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+			SchemaPropertyName = GetSchemaPropertyName(typeSymbol),
+			PropertyNaming = propertyNaming,
+			PropertyOrder = propertyOrder,
+			StrictConditionals = false,
+			Kind = TypeKind.Array,
+			IsNullable = false
+		};
 	}
 
 	private static HashSet<IAssemblySymbol> FindSelfGeneratingAssemblies(Compilation compilation)
@@ -381,6 +408,11 @@ public class JsonSchemaSourceGenerator : IIncrementalGenerator
 		return typeSymbol.ContainingType != null
 			? $"{GetSchemaPropertyName(typeSymbol.ContainingType)}_{currentName}"
 			: currentName;
+	}
+
+	private static string GetSchemaPropertyName(IArrayTypeSymbol typeSymbol)
+	{
+		return $"{GetTypeArgumentPropertyName(typeSymbol.ElementType)}Array";
 	}
 
 	private static string GetTypeArgumentPropertyName(ITypeSymbol typeSymbol)

--- a/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/SchemaCodeEmitter.cs
@@ -272,7 +272,9 @@ internal static class SchemaCodeEmitter
 			EmitSchemaProperty(sb, type, typeIds, schemaHandlers);
 		}
 
-		EmitBuildForTypeMethod(sb, orderedTypes, schemaHandlers, foreignTypeEntries);
+		var shapeAliases = GetShapeAliases(orderedTypes);
+
+		EmitBuildForTypeMethod(sb, orderedTypes, schemaHandlers, foreignTypeEntries, shapeAliases);
 
 		EmitRegisterSchemasMethod(sb, orderedTypes);
 
@@ -294,7 +296,7 @@ internal static class SchemaCodeEmitter
 		return id;
 	}
 
-	private static void EmitBuildForTypeMethod(StringBuilder sb, List<TypeInfo> types, List<SchemaHandlerInfo> schemaHandlers, IReadOnlyList<(string TypeName, string SchemaId)> foreignTypeEntries)
+	private static void EmitBuildForTypeMethod(StringBuilder sb, List<TypeInfo> types, List<SchemaHandlerInfo> schemaHandlers, IReadOnlyList<(string TypeName, string SchemaId)> foreignTypeEntries, IReadOnlyList<(string TypeName, string SchemaId)> shapeAliases)
 	{
 		sb.AppendLine("\tpublic static JsonSchemaBuilder BuildForType(this JsonSchemaBuilder builder, Type type)");
 		sb.AppendLine("\t{");
@@ -334,6 +336,9 @@ internal static class SchemaCodeEmitter
 		sb.AppendLine("\t\treturn unwrapped switch");
 		sb.AppendLine("\t\t{");
 
+		foreach (var (typeName, schemaId) in shapeAliases)
+			sb.AppendLine($"\t\t\tvar t when t == typeof({typeName}) => builder.Ref(\"{schemaId}\"),");
+
 		foreach (var type in types)
 		{
 			var typeName = type.FullyQualifiedName;
@@ -358,6 +363,99 @@ internal static class SchemaCodeEmitter
 		sb.AppendLine("\t\t};");
 		sb.AppendLine("\t}");
 		sb.AppendLine();
+	}
+
+	private static List<(string TypeName, string SchemaId)> GetShapeAliases(List<TypeInfo> types)
+	{
+		var result = new List<(string TypeName, string SchemaId)>();
+
+		var arrayGroups = types
+			.Where(t => t.Kind == TypeKind.Array)
+			.Where(t => !string.IsNullOrEmpty(GetArrayShapeKey(t.TypeSymbol)))
+			.GroupBy(t => GetArrayShapeKey(t.TypeSymbol));
+
+		foreach (var group in arrayGroups)
+		{
+			var groupTypes = group.ToList();
+			if (groupTypes.Count <= 1) continue;
+
+			var canonical = groupTypes
+				.FirstOrDefault(t => IsPreferredCollectionShape(t.TypeSymbol))
+				?? groupTypes.OrderBy(t => t.FullyQualifiedName, StringComparer.Ordinal).First();
+
+			var canonicalId = GetSchemaId(canonical);
+
+			foreach (var type in groupTypes)
+			{
+				if (ReferenceEquals(type, canonical)) continue;
+				result.Add((type.FullyQualifiedName, canonicalId));
+			}
+		}
+
+		var dictionaryGroups = types
+			.Where(t => t.Kind == TypeKind.Dictionary)
+			.Where(t => !string.IsNullOrEmpty(GetDictionaryShapeKey(t.TypeSymbol)))
+			.GroupBy(t => GetDictionaryShapeKey(t.TypeSymbol));
+
+		foreach (var group in dictionaryGroups)
+		{
+			var groupTypes = group.ToList();
+			if (groupTypes.Count <= 1) continue;
+
+			var canonical = groupTypes
+				.FirstOrDefault(t => IsPreferredDictionaryShape(t.TypeSymbol))
+				?? groupTypes.OrderBy(t => t.FullyQualifiedName, StringComparer.Ordinal).First();
+
+			var canonicalId = GetSchemaId(canonical);
+
+			foreach (var type in groupTypes)
+			{
+				if (ReferenceEquals(type, canonical)) continue;
+				result.Add((type.FullyQualifiedName, canonicalId));
+			}
+		}
+
+		return result;
+	}
+
+	private static string GetArrayShapeKey(ITypeSymbol typeSymbol)
+	{
+		var elementType = CodeEmitterHelpers.GetElementType(typeSymbol);
+		if (elementType == null) return string.Empty;
+
+		var unwrappedElement = CodeEmitterHelpers.UnwrapNullable(elementType);
+		return unwrappedElement.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+	}
+
+	private static string GetDictionaryShapeKey(ITypeSymbol typeSymbol)
+	{
+		var keyType = CodeEmitterHelpers.GetDictionaryKeyType(typeSymbol);
+		var valueType = CodeEmitterHelpers.GetDictionaryValueType(typeSymbol);
+		if (keyType == null || valueType == null) return string.Empty;
+
+		var unwrappedKey = CodeEmitterHelpers.UnwrapNullable(keyType).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		var unwrappedValue = CodeEmitterHelpers.UnwrapNullable(valueType).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+		return $"{unwrappedKey}|{unwrappedValue}";
+	}
+
+	private static bool IsPreferredCollectionShape(ITypeSymbol typeSymbol)
+	{
+		if (typeSymbol is not INamedTypeSymbol namedType || !namedType.IsGenericType) return false;
+
+		var typeString = namedType.ConstructedFrom.ToDisplayString();
+		return typeString == "System.Collections.Generic.IEnumerable<T>";
+	}
+
+	private static bool IsPreferredDictionaryShape(ITypeSymbol typeSymbol)
+	{
+		if (typeSymbol is not INamedTypeSymbol namedType || !namedType.IsGenericType) return false;
+
+		var typeString = namedType.ConstructedFrom
+			.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+			.Replace(" ", string.Empty);
+
+		return typeString == "global::System.Collections.Generic.IDictionary<TKey,TValue>";
 	}
 
 	private static void EmitRegisterSchemasMethod(StringBuilder sb, List<TypeInfo> types)
@@ -432,9 +530,8 @@ internal static class SchemaCodeEmitter
 	private static TypeInfo? FindTypeBySymbol(List<TypeInfo> types, ITypeSymbol symbol)
 	{
 		var unwrapped = CodeEmitterHelpers.UnwrapNullable(symbol);
-		if (unwrapped is not INamedTypeSymbol named) return null;
 
-		return types.FirstOrDefault(t => SymbolEqualityComparer.Default.Equals(t.TypeSymbol, named));
+		return types.FirstOrDefault(t => SymbolEqualityComparer.Default.Equals(t.TypeSymbol, unwrapped));
 	}
 
 	private static string GetPropertyName(TypeInfo type) => type.ResolvedPropertyName ?? type.SchemaPropertyName;

--- a/src/JsonSchema.Generation/SourceGeneration/TypeAnalyzer.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/TypeAnalyzer.cs
@@ -119,30 +119,15 @@ internal static class TypeAnalyzer
 
 		if (unwrappedType.TypeKind == Microsoft.CodeAnalysis.TypeKind.Enum) return TypeKind.Enum;
 		if (unwrappedType is IArrayTypeSymbol) return TypeKind.Array;
-		if (unwrappedType is INamedTypeSymbol namedType && IsCollectionType(namedType)) return TypeKind.Array;
+		if (CodeEmitterHelpers.IsCollectionType(unwrappedType)) return TypeKind.Array;
 		if (CodeEmitterHelpers.IsDictionaryType(unwrappedType)) return TypeKind.Dictionary;
 
 		return TypeKind.Object;
 	}
 
-	private static bool IsCollectionType(INamedTypeSymbol typeSymbol)
-	{
-		if (!typeSymbol.IsGenericType)
-			return false;
-
-		var typeString = typeSymbol.ConstructedFrom.ToDisplayString();
-		return typeString is
-			"System.Collections.Generic.List<T>" or
-			"System.Collections.Generic.IList<T>" or
-			"System.Collections.Generic.ICollection<T>" or
-			"System.Collections.Generic.IEnumerable<T>" or
-			"System.Collections.Generic.IReadOnlyList<T>" or
-			"System.Collections.Generic.IReadOnlyCollection<T>";
-	}
-
 	private static void AnalyzeObjectType(Compilation compilation, TypeInfo typeInfo, Action<Diagnostic> reportDiagnostic)
 	{
-		var typeSymbol = typeInfo.TypeSymbol;
+		var typeSymbol = (INamedTypeSymbol)typeInfo.TypeSymbol;
 		var encounteredSchemaNames = new HashSet<string>(StringComparer.Ordinal);
 
 		var members = typeSymbol.GetMembers()

--- a/src/JsonSchema.Generation/SourceGeneration/TypeInfo.cs
+++ b/src/JsonSchema.Generation/SourceGeneration/TypeInfo.cs
@@ -6,7 +6,7 @@ namespace Json.Schema.Generation.SourceGeneration;
 
 internal sealed class TypeInfo
 {
-	public required INamedTypeSymbol TypeSymbol { get; init; }
+	public required ITypeSymbol TypeSymbol { get; init; }
 	public required string FullyQualifiedName { get; init; }
 	public required string SchemaPropertyName { get; init; }
 	public string? ResolvedPropertyName { get; set; }

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -101,7 +101,8 @@ public class JsonSchema : IBaseDocument
 	/// <exception cref="JsonException">Could not deserialize a portion of the schema.</exception>
 	public static JsonSchema FromText(string jsonText, BuildOptions? buildOptions = null, Uri? baseUri = null, JsonDocumentOptions? jsonOptions = null)
 	{
-		var element = JsonDocument.Parse(jsonText, jsonOptions ?? default).RootElement;
+		using var doc = JsonDocument.Parse(jsonText, jsonOptions ?? default);
+		var element = doc.RootElement.Clone();
 		return Build(element, buildOptions, baseUri);
 	}
 
@@ -208,7 +209,7 @@ public class JsonSchema : IBaseDocument
 			var data = new KeywordData(context)
 			{
 				EvaluationOrder = context.Dialect.GetEvaluationOrder(keyword) ?? 0,
-				RawValue = value.Clone(),
+				RawValue = value,
 				Handler = handler,
 				Value = handler is AnnotationKeyword
 					? keyword

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,7 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>JsonSchema.Net</PackageId>
-    <JsonSchemaNetVersion>9.2.0</JsonSchemaNetVersion>
+    <JsonSchemaNetVersion>9.2.1</JsonSchemaNetVersion>
     <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <FileVersion>$(JsonSchemaNetVersion)</FileVersion>
     <Version>$(JsonSchemaNetVersion)</Version>

--- a/src/JsonSchema/JsonSchemaBuilderExtensions.cs
+++ b/src/JsonSchema/JsonSchemaBuilderExtensions.cs
@@ -258,7 +258,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder DependentSchemas(this JsonSchemaBuilder builder, IReadOnlyDictionary<string, JsonSchemaBuilder> deps)
 	{
-		builder.Add("dependentRequired", deps);
+		builder.Add("dependentSchemas", deps);
 		return builder;
 	}
 
@@ -270,7 +270,7 @@ public static class JsonSchemaBuilderExtensions
 	/// <returns>The builder.</returns>
 	public static JsonSchemaBuilder DependentSchemas(this JsonSchemaBuilder builder, params (string name, JsonSchemaBuilder schema)[] deps)
 	{
-		builder.Add("dependentRequired", deps);
+		builder.Add("dependentSchemas", deps);
 		return builder;
 	}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-logic.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-logic.md
@@ -4,6 +4,12 @@ title: JsonLogic
 icon: fas fa-tag
 order: "09.11"
 ---
+# [6.1.0](https://github.com/gregsdennis/json-everything/pull/1039) {#release-logic-6.1.0}
+
+[#1036](https://github.com/gregsdennis/json-everything/issues/1036) - Nulls in condition for `if` rule throwing exception.  Thanks to [@toddbaert]https://github.com/toddbaert) for reporting this issue.
+
+[#1007](https://github.com/gregsdennis/json-everything/issues/1007) - Improved logging options for `log` rule through new `ILogicLogger` interface.
+
 # [6.0.2](https://github.com/gregsdennis/json-everything/pull/1027) {#release-logic-6.0.2}
 
 [#1019](https://github.com/gregsdennis/json-everything/issues/1019) - Fix array->string coercion for loose-equals.  Thanks to [@dkorunda-tp]https://github.com/dkorunda-tp) for reporting this issue.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema-generation.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net.Generation
 icon: fas fa-tag
 order: "09.05"
 ---
+# [7.3.7](https://github.com/gregsdennis/json-everything/pull/1039) {#release-schemagen-7.3.7}
+
+[#1038](https://github.com/gregsdennis/json-everything/issues/1038) - Source generation support improvements for collection types.
+
 # [7.3.6](https://github.com/gregsdennis/json-everything/pull/1025) {#release-schemagen-7.3.6}
 
 [#1024](https://github.com/gregsdennis/json-everything/issues/1024)

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,10 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [9.2.1](https://github.com/gregsdennis/json-everything/pull/1039) {#release-schema-9.2.1}
+
+[#1033](https://github.com/gregsdennis/json-everything/pull/1033) - Fixes the builder extension for `dependentSchemas`.  Thanks to [@BennieCopeland](https://github.com/BennieCopeland) for reporting.
+
 # [9.2.0](https://github.com/gregsdennis/json-everything/pull/1031) {#release-schema-9.2.0}
 
 - Update `ValidatingJsonConverter` to properly handle dictionary keys.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -8,6 +8,8 @@ order: "09.01"
 
 [#1033](https://github.com/gregsdennis/json-everything/pull/1033) - Fixes the builder extension for `dependentSchemas`.  Thanks to [@BennieCopeland](https://github.com/BennieCopeland) for reporting.
 
+[#1035](https://github.com/gregsdennis/json-everything/pull/1033) - [@LLDevLab](https://github.com/LLDevLab) found a minor memory leak when using `JsonSchema.FromText()`.
+
 # [9.2.0](https://github.com/gregsdennis/json-everything/pull/1031) {#release-schema-9.2.0}
 
 - Update `ValidatingJsonConverter` to properly handle dictionary keys.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

#### _JsonSchema.Net_

Fix `JsonSchemaBuilder` extension `.DependentSchemas()` to add the correct keyword.

Fix a minor memory leak when using `JsonSchema.FromText()`.

#### _JsonSchema.Net.Generation_

Improves support for schema source generation on collection types.

#### _JsonLogic_

Adds `ILogicLogger` for improved logging support through the `log` rule.

Fixes a bug with the `if` rule.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves https://github.com/json-everything/json-everything/issues/1035
Resolves https://github.com/json-everything/json-everything/issues/1038
Relates to https://github.com/json-everything/json-everything/issues/1007
Resolves https://github.com/json-everything/json-everything/issues/1036

### Organization

<!-- 
Are you submitting this change on behalf of an organization?  If so, who?
-->
- [ ] Organization: ___
- [ ] Independent

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
