### PR TITLE
fix: resolve $id base URI before building sibling subschemas

### DIFF
--- a/src/JsonSchema.Tests/IdOrderingTests.cs
+++ b/src/JsonSchema.Tests/IdOrderingTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Json.Schema.Tests;
+
+/// <summary>
+/// Regression tests for a schema-registration collision that occurred when `$id` appeared
+/// after subschema-producing keywords (e.g. `$defs` / `properties`) in document order.
+/// This happens whenever a schema is serialized in canonical / alphabetical key order, which
+/// sorts `$defs` before `$id`. Two or more subschemas built before `$id` inherited the
+/// placeholder base URI and were then mis-detected as embedded resources, throwing
+/// "Overwriting registered schemas is not permitted." JSON object key order is not
+/// significant, so `$id` must establish the resource base URI regardless of its position.
+/// </summary>
+public class IdOrderingTests
+{
+	[Test]
+	public void DefsBeforeId_DoesNotThrowAndResolvesInternalRefs()
+	{
+		const string schemaText = @"{
+  ""$defs"": { ""a"": { ""type"": ""string"" }, ""b"": { ""type"": ""integer"" } },
+  ""$id"": ""https://example.com/id-after-defs.json"",
+  ""$schema"": ""https://json-schema.org/draft/2020-12/schema"",
+  ""type"": ""object"",
+  ""properties"": { ""x"": { ""$ref"": ""#/$defs/a"" }, ""y"": { ""$ref"": ""#/$defs/b"" } }
+}";
+
+		var options = new BuildOptions { SchemaRegistry = new SchemaRegistry() };
+		JsonSchema schema = null!;
+		Assert.DoesNotThrow(() => schema = JsonSchema.FromText(schemaText, options));
+
+		// The internal `#/$defs/...` refs resolve against the base URI that `$id` establishes;
+		// if that base were wrong (the pre-fix placeholder) they would not resolve correctly.
+		var valid = schema.Evaluate(JsonDocument.Parse(@"{ ""x"": ""hello"", ""y"": 5 }").RootElement);
+		Assert.That(valid.IsValid, Is.True);
+
+		var invalid = schema.Evaluate(JsonDocument.Parse(@"{ ""x"": 5, ""y"": ""nope"" }").RootElement);
+		Assert.That(invalid.IsValid, Is.False);
+	}
+
+	[Test]
+	public void PropertiesBeforeId_DoesNotThrow()
+	{
+		// No `$defs` and no `$ref`: two subschemas under `properties` built before a late
+		// `$id` are by themselves enough to trigger the registration collision.
+		const string schemaText = @"{
+  ""properties"": { ""a"": { ""type"": ""string"" }, ""b"": { ""type"": ""number"" } },
+  ""$id"": ""https://example.com/props-before-id.json"",
+  ""type"": ""object""
+}";
+
+		var options = new BuildOptions { SchemaRegistry = new SchemaRegistry() };
+		Assert.DoesNotThrow(() => JsonSchema.FromText(schemaText, options));
+	}
+
+	[Test]
+	public void IdPositionDoesNotChangeEvaluation()
+	{
+		// `$id` before vs after the subschema keywords must build and evaluate equivalently.
+		const string idFirst = @"{
+  ""$id"": ""https://example.com/order-a.json"",
+  ""$defs"": { ""s"": { ""type"": ""string"" } },
+  ""type"": ""object"",
+  ""properties"": { ""x"": { ""$ref"": ""#/$defs/s"" } }
+}";
+		const string idLast = @"{
+  ""$defs"": { ""s"": { ""type"": ""string"" } },
+  ""properties"": { ""x"": { ""$ref"": ""#/$defs/s"" } },
+  ""type"": ""object"",
+  ""$id"": ""https://example.com/order-b.json""
+}";
+
+		var a = JsonSchema.FromText(idFirst, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+		var b = JsonSchema.FromText(idLast, new BuildOptions { SchemaRegistry = new SchemaRegistry() });
+
+		var good = JsonDocument.Parse(@"{ ""x"": ""ok"" }").RootElement;
+		Assert.That(a.Evaluate(good).IsValid, Is.True);
+		Assert.That(b.Evaluate(good).IsValid, Is.True);
+
+		var bad = JsonDocument.Parse(@"{ ""x"": 1 }").RootElement;
+		Assert.That(a.Evaluate(bad).IsValid, Is.False);
+		Assert.That(b.Evaluate(bad).IsValid, Is.False);
+	}
+}

--- a/src/JsonSchema/JsonSchema.cs
+++ b/src/JsonSchema/JsonSchema.cs
@@ -199,6 +199,32 @@ public class JsonSchema : IBaseDocument
 		var onlyHandleRef = context.LocalSchema.TryGetProperty("$ref", out _) &&
 		                    context.Dialect.RefIgnoresSiblingKeywords;
 
+		// JSON object key order is not significant: a `$id` keyword sets this resource's base
+		// URI for the whole object, regardless of where it appears among its sibling keywords.
+		// Establish it before any subschemas are built. Previously a `$id` that appeared after
+		// subschema-producing keywords (for example when a schema is serialized in canonical /
+		// alphabetical key order, which sorts `$defs` before `$id`) left those subschemas built
+		// against the parent/placeholder base URI; they were then mis-detected as embedded
+		// resources below and collided on registration ("Overwriting registered schemas is not
+		// permitted.").
+		if (!onlyHandleRef)
+		{
+			var scanDialect = context.Dialect;
+			foreach (var property in context.LocalSchema.EnumerateObject())
+			{
+				var scanHandler = scanDialect.GetHandler(property.Name);
+				if (scanHandler is SchemaKeyword)
+					scanDialect = context.Options.DialectRegistry.Get((Uri)scanHandler.ValidateKeywordValue(property.Value)!, context.Options.SchemaRegistry, context.Options.VocabularyRegistry, scanDialect);
+				else if (scanHandler is IdKeyword)
+				{
+#pragma warning disable CS0618 // Type or member is obsolete
+					context.PathFromResourceRoot = JsonPointer.Empty;
+#pragma warning restore CS0618 // Type or member is obsolete
+					context.BaseUri = context.BaseUri.Resolve((Uri)scanHandler.ValidateKeywordValue(property.Value)!);
+				}
+			}
+		}
+
 		var keywordData = new List<KeywordData>();
 		foreach (var property in context.LocalSchema.EnumerateObject())
 		{
@@ -222,13 +248,11 @@ public class JsonSchema : IBaseDocument
 				var uri = (Uri)data.Value!;
 				context.Dialect = context.Options.DialectRegistry.Get(uri, context.Options.SchemaRegistry, context.Options.VocabularyRegistry, context.Dialect);
 			}
-			else if (handler is IdKeyword && !onlyHandleRef)
-			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				context.PathFromResourceRoot = JsonPointer.Empty;
-				context.BaseUri = context.BaseUri.Resolve((Uri)data.Value!);
-			}
+			// `$id` base-URI resolution is performed in the pre-pass above, before any
+			// subschemas are built, so it does not depend on the position of `$id` relative
+			// to its sibling subschema keywords.
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var keywordContext = context with
 			{
 				PathFromResourceRoot = context.PathFromResourceRoot.Combine(context.RelativePath).Combine(keyword)
@@ -238,8 +262,8 @@ public class JsonSchema : IBaseDocument
 			foreach (var subschema in data.Subschemas)
 			{
 				subschema.PathFromResourceRoot = keywordContext.PathFromResourceRoot.Combine(subschema.RelativePath);
-#pragma warning restore CS0618 // Type or member is obsolete
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			keywordData.Add(data);
 		}


### PR DESCRIPTION
Fixes #1044.

## Problem

`JsonSchema.FromText` throws `"Overwriting registered schemas is not permitted."` for **valid** Draft 2020-12 schemas when `$id` appears after subschema-producing keywords (e.g. `$defs`, `properties`) — which happens whenever a schema is serialized in canonical / alphabetical key order (sorting `$defs` before `$id`). Any **two or more subschemas before a late `$id`** reproduce it (minimal repro in #1044).

## Root cause

`BuildNode` applies a schema's `$id` to `context.BaseUri` only when the `$id` property is reached in document order, and `BuildImpl` seeds `context.BaseUri` with a generated placeholder. Subschemas built before a late `$id` therefore inherit the placeholder base URI. After `$id` changes the base, the post-loop embedded-resource detection (`subschema.BaseUri != context.BaseUri`) misclassifies every such subschema as an embedded resource and registers each as a separate root document at the same placeholder URI — the second collides in `SchemaRegistry.RegisterSchema`.

## Fix

Establish `$id` (tracking the dialect locally via `$schema`) in a pre-pass **before** building subschemas, so the resource base URI is correct regardless of `$id`'s position — per the spec, JSON object key order is not significant. `$id` is detected exactly as before (same dialect evolution); only the *timing* of the base-URI assignment changes, so dialect behavior is unchanged.

## Commits (per CONTRIBUTING)

1. **Failing test** — `IdOrderingTests` demonstrating the bug (this build should fail).
2. **Fix** — the `BuildNode` pre-pass (this build should pass).

The full `JsonSchema.Tests` suite, including the official JSON-Schema-Test-Suite, passes with the fix: **14,379 passed, 0 failed** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
