### PR TITLE
Fix swapped path names in copy/move patch error messages

### DIFF
--- a/src/JsonPatch.Tests/GithubTests.cs
+++ b/src/JsonPatch.Tests/GithubTests.cs
@@ -347,4 +347,18 @@ public class GithubTests
 		Assert.That(patchResult.IsSuccess, Is.False);
 		Assert.That(patchResult.Error, Is.EqualTo("Target path `/a/b` could not be reached."));
 	}
+
+	[TestCase("copy", "/missing", "/target", "Source path `/missing` could not be reached.")]
+	[TestCase("copy", "/foo", "/missing/target", "Target path `/missing/target` could not be reached.")]
+	[TestCase("move", "/missing", "/target", "Source path `/missing` could not be reached.")]
+	[TestCase("move", "/foo", "/missing/target", "Target path `/missing/target` could not be reached.")]
+	public void Issue862_CopyAndMoveErrorsNameTheUnreachablePath(string op, string from, string path, string expected)
+	{
+		var patchStr = "[{ \"op\": \"" + op + "\", \"from\": \"" + from + "\", \"path\": \"" + path + "\" }]";
+		var patch = JsonSerializer.Deserialize<JsonPatch>(patchStr, TestEnvironment.SerializerOptions)!;
+
+		var actual = patch.Apply(JsonNode.Parse("{\"foo\":\"bar\"}"));
+
+		Assert.That(actual.Error, Is.EqualTo(expected));
+	}
 }

--- a/src/JsonPatch/CopyOperationHandler.cs
+++ b/src/JsonPatch/CopyOperationHandler.cs
@@ -16,13 +16,13 @@ internal class CopyOperationHandler : IPatchOperationHandler
 		if (!operation.From.EvaluateAndGetParent(context.Source, out _) ||
 			!operation.From.TryEvaluate(context.Source, out var data))
 		{
-			context.Message = $"Source path `{operation.Path}` could not be reached.";
+			context.Message = $"Source path `{operation.From}` could not be reached.";
 			return;
 		}
 
 		if (!operation.Path.EvaluateAndGetParent(context.Source, out var target))
 		{
-			context.Message = $"Target path `{operation.From}` could not be reached.";
+			context.Message = $"Target path `{operation.Path}` could not be reached.";
 			return;
 		}
 
@@ -53,6 +53,6 @@ internal class CopyOperationHandler : IPatchOperationHandler
 			return;
 		}
 
-		context.Message = $"Target path `{operation.From}` could not be reached.";
+		context.Message = $"Target path `{operation.Path}` could not be reached.";
 	}
 }

--- a/src/JsonPatch/JsonPatch.csproj
+++ b/src/JsonPatch/JsonPatch.csproj
@@ -15,8 +15,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPatch.Net</PackageId>
-    <Version>5.0.2</Version>
-    <FileVersion>5.0.2</FileVersion>
+    <Version>5.0.3</Version>
+    <FileVersion>5.0.3</FileVersion>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Patch built on the System.Text.Json namespace</Description>

--- a/src/JsonPatch/MoveOperationHandler.cs
+++ b/src/JsonPatch/MoveOperationHandler.cs
@@ -22,13 +22,13 @@ internal class MoveOperationHandler : IPatchOperationHandler
 		if (!operation.From.EvaluateAndGetParent(context.Source, out var source) ||
 			!operation.From.TryEvaluate(context.Source, out var data))
 		{
-			context.Message = $"Source path `{operation.Path}` could not be reached.";
+			context.Message = $"Source path `{operation.From}` could not be reached.";
 			return;
 		}
 
 		if (!operation.Path.EvaluateAndGetParent(context.Source, out var target))
 		{
-			context.Message = $"Target path `{operation.From}` could not be reached.";
+			context.Message = $"Target path `{operation.Path}` could not be reached.";
 			return;
 		}
 

--- a/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-patch.md
@@ -4,6 +4,10 @@ title: JsonPatch.Net
 icon: fas fa-tag
 order: "09.09"
 ---
+# [5.0.3](https://github.com/json-everything/json-everything/pull/1048) {#release-patch-5.0.3}
+
+[#862](https://github.com/json-everything/json-everything/issues/862) - [@LindqvistMartin](https://github.com/LindqvistMartin) fixed the swapped source and target paths in the `copy` and `move` operation error messages.  Thanks to [@pekaaw](https://github.com/pekaaw) for reporting.
+
 # [5.0.2](https://github.com/json-everything/json-everything/pull/1013) {#release-patch-5.0.2}
 
 Updated nuget packages & EULA.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

The copy and move handlers name the wrong path in their "could not be reached" errors: source and target are swapped. #862 reports copy; the reporter notes the same swap in move, so this fixes both. No API change, just the `PatchResult.Error` text.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #862

### Organization

<!-- 
Are you submitting this change on behalf of an organization?  If so, who?
-->
- [ ] Organization: ___
- [x] Independent

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
