### PR TITLE
Schema/applicator errors 2

### DIFF
--- a/src/JsonPointer.Tests/RelativeJsonPointerParseTests.cs
+++ b/src/JsonPointer.Tests/RelativeJsonPointerParseTests.cs
@@ -50,6 +50,7 @@ public class RelativeJsonPointerParseTests
 			yield return new TestCaseData("/end");
 			yield return new TestCaseData("-1/end");
 			yield return new TestCaseData("end");
+			yield return new TestCaseData("١/foo");
 		}
 	}
 

--- a/src/JsonPointer/JsonPointer.csproj
+++ b/src/JsonPointer/JsonPointer.csproj
@@ -16,8 +16,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>JsonPointer.Net</PackageId>
-    <Version>7.0.1</Version>
-    <FileVersion>7.0.1</FileVersion>
+    <Version>7.0.2</Version>
+    <FileVersion>7.0.2</FileVersion>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <Authors>Greg Dennis</Authors>
     <Description>JSON Pointer built on the System.Text.Json namespace</Description>

--- a/src/JsonPointer/RelativeJsonPointer.cs
+++ b/src/JsonPointer/RelativeJsonPointer.cs
@@ -191,7 +191,11 @@ public readonly struct RelativeJsonPointer : IEquatable<RelativeJsonPointer>
 			return false;
 		}
 
-		var parentSteps = span[..i].AsUint();
+		if (! span[..i].TryAsUint(out var parentSteps))
+		{
+			relativePointer = default;
+			return false;
+		}
 
 		if (i == span.Length)
 		{
@@ -207,7 +211,13 @@ public readonly struct RelativeJsonPointer : IEquatable<RelativeJsonPointer>
 			var start = i;
 			while (i < span.Length && char.IsDigit(span[i])) i++;
 
-			indexManipulation = sign * span[start..i].AsInt();
+			if (!span[start..i].TryAsInt(out var index))
+			{
+				relativePointer = default;
+				return false;
+			}
+
+			indexManipulation = sign * index;
 
 			if (i == span.Length)
 			{

--- a/src/JsonPointer/UtilityExtensions.cs
+++ b/src/JsonPointer/UtilityExtensions.cs
@@ -7,19 +7,51 @@ internal static class UtilityExtensions
 {
 	public static int AsInt(this ReadOnlySpan<char> value)
 	{
+		try
+		{
 #if NET8_0_OR_GREATER
-		return int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+			return int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
 #else
-		return int.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
+			return int.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
+#endif
+		}
+		catch (FormatException e)
+		{
+			throw new PointerParseException("An invalid integer format was found", e);
+		}
+	}
+
+	public static bool TryAsInt(this ReadOnlySpan<char> value, out int i)
+	{
+#if NET8_0_OR_GREATER
+		return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out i);
+#else
+		return int.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out i);
 #endif
 	}
 
 	public static uint AsUint(this ReadOnlySpan<char> value)
 	{
+		try
+		{
 #if NET8_0_OR_GREATER
-		return uint.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+			return uint.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
 #else
-		return uint.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
+			return uint.Parse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture);
+#endif
+		}
+		catch (FormatException e)
+		{
+			throw new PointerParseException("An invalid integer format was found", e);
+		}
+	}
+
+	public static bool TryAsUint(this ReadOnlySpan<char> value, out uint i)
+	{
+#if NET8_0_OR_GREATER
+		return uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out i);
+#else
+		return uint.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out i);
 #endif
 	}
 }

--- a/src/JsonSchema.Tests/FormatTests.cs
+++ b/src/JsonSchema.Tests/FormatTests.cs
@@ -124,4 +124,31 @@ public class FormatTests
 		TestConsole.WriteLine(JsonSerializer.Serialize(results, TestEnvironment.TestOutputSerializerOptions));
 		Assert.That(results.IsValid, Is.EqualTo(isValid));
 	}
+
+	// Regression tests for RFC 3986 syntactic-only URI validation (issue #1043)
+	// file://../../path has authority=".." (valid reg-name) and path="/../path" — syntactically valid
+	[TestCase("\"file://../../oblx-service-template\"", true)]
+	// Absolute URIs require a scheme
+	[TestCase("\"//foo.bar/?baz=qux#quux\"", false)]
+	[TestCase("\"/abc\"", false)]
+	// Non-numeric port is a structural violation
+	[TestCase("\"http://example.com:abc/path\"", false)]
+	// Non-ASCII must be percent-encoded in URIs
+	[TestCase("\"https://example.org/foobar\\u00AE.txt\"", false)]
+	// IPv4-looking hosts that fail strict parsing are still valid as reg-names
+	[TestCase("\"http://999.999.999.999/\"", true)]
+	[TestCase("\"http://087.10.0.1/\"", true)]
+	public void UriFormatSyntacticValidation(string jsonText, bool isValid)
+	{
+		var json = JsonDocument.Parse(jsonText).RootElement;
+		JsonSchema schema = new JsonSchemaBuilder().Format("uri");
+
+		var results = schema.Evaluate(json, new EvaluationOptions
+		{
+			OutputFormat = OutputFormat.Hierarchical,
+			RequireFormatValidation = true
+		});
+
+		Assert.That(results.IsValid, Is.EqualTo(isValid));
+	}
 }

--- a/src/JsonSchema.Tests/OutputTests.cs
+++ b/src/JsonSchema.Tests/OutputTests.cs
@@ -105,7 +105,7 @@ public class OutputTests
 				  "schemaLocation": "https://json-everything.test/schema#",
 				  "instanceLocation": "",
 				  "errors": {
-				    "properties": "Some properties did not match the required schema"
+				    "properties": "Some properties did not match the required schema: [\"fails\"]"
 				  }
 				},
 			    {
@@ -164,7 +164,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"fails\"]"
 			  },
 			  "details": [
 			    {
@@ -198,7 +198,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"fails\"]"
 			  },
 			  "droppedAnnotations": {
 			    "properties": [
@@ -291,7 +291,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"multi\"]"
 			  },
 			  "details": [
 			    {
@@ -357,7 +357,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"fails\"]"
 			  },
 			  "details": [
 			    {
@@ -387,7 +387,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"fails\"]"
 			  },
 			  "details": [
 			    {
@@ -444,7 +444,7 @@ public class OutputTests
 			  "schemaLocation": "https://json-everything.test/schema#",
 			  "instanceLocation": "",
 			  "errors": {
-			    "properties": "Some properties did not match the required schema"
+			    "properties": "Some properties did not match the required schema: [\"refs\"]"
 			  },
 			  "details": [
 			    {

--- a/src/JsonSchema.Tests/OutputTests.cs
+++ b/src/JsonSchema.Tests/OutputTests.cs
@@ -407,6 +407,33 @@ public class OutputTests
 	}
 
 	[Test]
+	public void Hierarchical_Multi_Failure_Minimum_ExcludeApplicators()
+	{
+		var result = Validate("{\"fails\":3}", OutputFormat.Hierarchical, false);
+		var expected = """
+			{
+			  "valid": false,
+			  "evaluationPath": "",
+			  "schemaLocation": "https://json-everything.test/schema#",
+			  "instanceLocation": "",
+			  "details": [
+			    {
+			      "valid": false,
+			      "evaluationPath": "/properties/fails",
+			      "schemaLocation": "https://json-everything.test/schema#/properties/fails",
+			      "instanceLocation": "/fails",
+			      "errors": {
+			        "": "All values fail against the false schema"
+			      }
+			    }
+			  ]
+			}
+			""";
+
+		result.AssertInvalid(expected);
+	}
+
+	[Test]
 	public void RelativeAndAbsoluteLocations()
 	{
 		var result = Validate("{\"refs\":8.8}", OutputFormat.Hierarchical);
@@ -444,11 +471,12 @@ public class OutputTests
 		result.AssertInvalid(expected);
 	}
 
-	private static EvaluationResults Validate(string json, OutputFormat format)
+	private static EvaluationResults Validate(string json, OutputFormat format, bool includeApplicatorErrors = true)
 	{
 		var instance = JsonDocument.Parse(json).RootElement;
 		var options = EvaluationOptions.From(EvaluationOptions.Default);
 		options.OutputFormat = format;
+		options.IncludeApplicatorErrors = includeApplicatorErrors;
 
 		var result = _schema.Evaluate(instance, options);
 		return result;

--- a/src/JsonSchema.Tests/Suite/Validation.cs
+++ b/src/JsonSchema.Tests/Suite/Validation.cs
@@ -20,12 +20,44 @@ public class Validation
 	private const string _externalTestCasesPath = @"../../../../../../JSON-Schema-Test-Suite/tests";
 	private const string _externalRemoteSchemasPath = @"../../../../../../JSON-Schema-Test-Suite/remotes";
 
-	// Tests to explicitly ignore: [fileName, collectionDescription]
-	private static readonly HashSet<(string, string)> _ignoredTests =
+	// Tests to explicitly ignore: [fileName, collectionDescription, testCaseDescription ("*" for all)]
+	private static readonly HashSet<(string, string, string)> _ignoredTests =
 	[
-		("hostname", "validation of A-label (punycode) host names"),
-		("idn-hostname", "validation of internationalized host names"),
-		("idn-hostname", "validation of separators in internationalized host names")
+		("idn-email", "validation of an internationalized e-mail addresses", "a local part with a lone UTF-16 surrogate is invalid"),
+		("hostname", "validation of A-label (punycode) host names", "a valid host name (example.test in Hangul)"),
+		("hostname", "validation of A-label (punycode) host names", "Arabic-Indic digits not mixed with Extended Arabic-Indic digits"),
+		("hostname", "validation of A-label (punycode) host names", "Exceptions that are PVALID, left-to-right chars"),
+		("hostname", "validation of A-label (punycode) host names", "Exceptions that are PVALID, right-to-left chars"),
+		("hostname", "validation of A-label (punycode) host names", "Extended Arabic-Indic digits not mixed with Arabic-Indic digits"),
+		("hostname", "validation of A-label (punycode) host names", "Greek KERAIA followed by Greek"),
+		("hostname", "validation of A-label (punycode) host names", "Hebrew GERESH preceded by Hebrew"),
+		("hostname", "validation of A-label (punycode) host names", "Hebrew GERSHAYIM preceded by Hebrew"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Han"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Hiragana"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Katakana"),
+		("hostname", "validation of A-label (punycode) host names", "MIDDLE DOT with surrounding 'l's"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH JOINER preceded by Virama"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH NON-JOINER preceded by Virama"),
+		("idn-hostname", "validation of internationalized host names", "a name longer than 253 characters is invalid"),
+		("idn-hostname", "validation of internationalized host names", "a U-label whose A-label form is longer than 63 octets is invalid"),
+		("idn-hostname", "validation of internationalized host names", "Bidi domain name with a digit-first label is invalid"),
+		("idn-hostname", "validation of internationalized host names", "contains illegal char U+302E Hangul single dot tone mark"),
+		("idn-hostname", "validation of internationalized host names", "Exceptions that are DISALLOWED, left-to-right chars"),
+		("idn-hostname", "validation of internationalized host names", "Exceptions that are DISALLOWED, right-to-left chars"),
+		("idn-hostname", "validation of internationalized host names", "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han"),
+		("idn-hostname", "validation of internationalized host names", "KATAKANA MIDDLE DOT with no other characters"),
+		("idn-hostname", "validation of internationalized host names", "label starting with a digit before a right-to-left letter is invalid"),
+		("idn-hostname", "validation of internationalized host names", "left-to-right label containing a right-to-left letter is invalid"),
+		("idn-hostname", "validation of internationalized host names", "right-to-left label mixing both digit types is invalid"),
+		("idn-hostname", "validation of internationalized host names", "valid Chinese Punycode"),
+		("idn-hostname", "validation of internationalized host names", "zero width non-joiner must pass at every occurrence"),
+		("idn-hostname", "validation of separators in internationalized host names", "fullwidth full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "halfwidth ideographic full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "ideographic full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (fullwidth full stop)"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (halfwidth ideographic full stop)"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (ideographic full stop)"),
 	];
 
 	private static readonly string[] _supportedProposals =
@@ -80,8 +112,6 @@ public class Validation
 			{
 				collection.IsOptional = fileName.Contains("optional");
 				
-				if (_ignoredTests.Contains((shortFileName, collection.Description))) continue;
-
 				foreach (var test in collection.Tests)
 				{
 					var dialect = draftFolder switch
@@ -99,6 +129,9 @@ public class Validation
 						Dialect = dialect,
 						SchemaRegistry = new()
 					};
+					if (_ignoredTests.Contains((shortFileName, collection.Description, test.Description))) continue;
+					if (_ignoredTests.Contains((shortFileName, collection.Description, "*"))) continue;
+
 					var optional = collection.IsOptional ? "(optional) / " : null;
 					var name = $"{draftFolder} / {optional}{shortFileName} / {collection.Description} / {test.Description}";
 					var evaluationOptionsCopy = EvaluationOptions.From(evaluationOptions);
@@ -165,7 +198,7 @@ public class Validation
 		TestConsole.WriteLine();
 		TestConsole.WriteLine(JsonSerializer.Serialize(collection.Schema, TestEnvironment.TestOutputSerializerOptions));
 		TestConsole.WriteLine();
-		TestConsole.WriteLine(JsonSerializer.Serialize(test.Data, TestEnvironment.TestOutputSerializerOptions));
+		//TestConsole.WriteLine(JsonSerializer.Serialize(test.Data, TestEnvironment.TestOutputSerializerOptions));
 		TestConsole.WriteLine();
 
 		JsonSchema schema;

--- a/src/JsonSchema.Tests/Suite/ValidationOptimized.cs
+++ b/src/JsonSchema.Tests/Suite/ValidationOptimized.cs
@@ -16,16 +16,48 @@ public class ValidationOptimized
 	private const string _remoteSchemasPath = @"../../../../../ref-repos/JSON-Schema-Test-Suite/remotes";
 
 	private const bool _useExternal = false;
-	private const bool _runDraftNext = false;
+	private const bool _runDraftNext = true;
 	private const string _externalTestCasesPath = @"../../../../../../JSON-Schema-Test-Suite/tests";
 	private const string _externalRemoteSchemasPath = @"../../../../../../JSON-Schema-Test-Suite/remotes";
 
-	// Tests to explicitly ignore: [fileName, collectionDescription]
-	private static readonly HashSet<(string, string)> _ignoredTests =
+	// Tests to explicitly ignore: [fileName, collectionDescription, testCaseDescription ("*" for all)]
+	private static readonly HashSet<(string, string, string)> _ignoredTests =
 	[
-		("hostname", "validation of A-label (punycode) host names"),
-		("idn-hostname", "validation of internationalized host names"),
-		("idn-hostname", "validation of separators in internationalized host names")
+		("idn-email", "validation of an internationalized e-mail addresses", "a local part with a lone UTF-16 surrogate is invalid"),
+		("hostname", "validation of A-label (punycode) host names", "a valid host name (example.test in Hangul)"),
+		("hostname", "validation of A-label (punycode) host names", "Arabic-Indic digits not mixed with Extended Arabic-Indic digits"),
+		("hostname", "validation of A-label (punycode) host names", "Exceptions that are PVALID, left-to-right chars"),
+		("hostname", "validation of A-label (punycode) host names", "Exceptions that are PVALID, right-to-left chars"),
+		("hostname", "validation of A-label (punycode) host names", "Extended Arabic-Indic digits not mixed with Arabic-Indic digits"),
+		("hostname", "validation of A-label (punycode) host names", "Greek KERAIA followed by Greek"),
+		("hostname", "validation of A-label (punycode) host names", "Hebrew GERESH preceded by Hebrew"),
+		("hostname", "validation of A-label (punycode) host names", "Hebrew GERSHAYIM preceded by Hebrew"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Han"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Hiragana"),
+		("hostname", "validation of A-label (punycode) host names", "KATAKANA MIDDLE DOT with Katakana"),
+		("hostname", "validation of A-label (punycode) host names", "MIDDLE DOT with surrounding 'l's"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH JOINER preceded by Virama"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp"),
+		("hostname", "validation of A-label (punycode) host names", "ZERO WIDTH NON-JOINER preceded by Virama"),
+		("idn-hostname", "validation of internationalized host names", "a name longer than 253 characters is invalid"),
+		("idn-hostname", "validation of internationalized host names", "a U-label whose A-label form is longer than 63 octets is invalid"),
+		("idn-hostname", "validation of internationalized host names", "Bidi domain name with a digit-first label is invalid"),
+		("idn-hostname", "validation of internationalized host names", "contains illegal char U+302E Hangul single dot tone mark"),
+		("idn-hostname", "validation of internationalized host names", "Exceptions that are DISALLOWED, left-to-right chars"),
+		("idn-hostname", "validation of internationalized host names", "Exceptions that are DISALLOWED, right-to-left chars"),
+		("idn-hostname", "validation of internationalized host names", "KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han"),
+		("idn-hostname", "validation of internationalized host names", "KATAKANA MIDDLE DOT with no other characters"),
+		("idn-hostname", "validation of internationalized host names", "label starting with a digit before a right-to-left letter is invalid"),
+		("idn-hostname", "validation of internationalized host names", "left-to-right label containing a right-to-left letter is invalid"),
+		("idn-hostname", "validation of internationalized host names", "right-to-left label mixing both digit types is invalid"),
+		("idn-hostname", "validation of internationalized host names", "valid Chinese Punycode"),
+		("idn-hostname", "validation of internationalized host names", "zero width non-joiner must pass at every occurrence"),
+		("idn-hostname", "validation of separators in internationalized host names", "fullwidth full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "halfwidth ideographic full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "ideographic full stop as label separator"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (fullwidth full stop)"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (halfwidth ideographic full stop)"),
+		("idn-hostname", "validation of separators in internationalized host names", "label too long if separator ignored (ideographic full stop)"),
 	];
 
 	public static IEnumerable<TestCaseData> TestCases()
@@ -67,8 +99,6 @@ public class ValidationOptimized
 			{
 				collection.IsOptional = fileName.Contains("optional");
 
-				if (_ignoredTests.Contains((shortFileName, collection.Description))) continue;
-
 				foreach (var test in collection.Tests)
 				{
 					var dialect = draftFolder switch
@@ -86,6 +116,9 @@ public class ValidationOptimized
 						Dialect = dialect,
 						SchemaRegistry = new()
 					};
+					if (_ignoredTests.Contains((shortFileName, collection.Description, test.Description))) continue;
+					if (_ignoredTests.Contains((shortFileName, collection.Description, "*"))) continue;
+
 					var optional = collection.IsOptional ? "(optional) / " : null;
 					var name = $"{draftFolder} / {optional}{shortFileName} / {collection.Description} / {test.Description}";
 					var evaluationOptionsCopy = EvaluationOptions.From(evaluationOptions);

--- a/src/JsonSchema.Tests/Suite/ValidationOptimized.cs
+++ b/src/JsonSchema.Tests/Suite/ValidationOptimized.cs
@@ -16,7 +16,7 @@ public class ValidationOptimized
 	private const string _remoteSchemasPath = @"../../../../../ref-repos/JSON-Schema-Test-Suite/remotes";
 
 	private const bool _useExternal = false;
-	private const bool _runDraftNext = true;
+	private const bool _runDraftNext = false;
 	private const string _externalTestCasesPath = @"../../../../../../JSON-Schema-Test-Suite/tests";
 	private const string _externalRemoteSchemasPath = @"../../../../../../JSON-Schema-Test-Suite/remotes";
 

--- a/src/JsonSchema/ErrorMessages.Keywords.cs
+++ b/src/JsonSchema/ErrorMessages.Keywords.cs
@@ -16,6 +16,28 @@ public static partial class ErrorMessages
 	}
 
 	/// <summary>
+	/// Gets or sets the error message for <see cref="Keywords.Draft06.AdditionalItemsKeyword"/>.
+	/// </summary>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[failed]] - the indexes of the items that did not match the schema
+	/// </remarks>
+	public static string? AdditionalItems { get; set; }
+
+	/// <summary>
+	/// Gets the error message for <see cref="Keywords.Draft06.AdditionalItemsKeyword"/> for a specific culture.
+	/// </summary>
+	/// <param name="culture">The culture to retrieve.</param>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[failed]] - the indexes of the items that did not match the schema
+	/// </remarks>
+	public static string GetAdditionalItems(CultureInfo? culture)
+	{
+		return AdditionalItems ?? Get(culture);
+	}
+
+	/// <summary>
 	/// Gets or sets the error message for <see cref="AdditionalPropertiesKeyword"/>.
 	/// </summary>
 	/// <remarks>
@@ -689,7 +711,7 @@ public static partial class ErrorMessages
 	/// <param name="culture">The culture to retrieve.</param>
 	/// <remarks>
 	///	Available tokens are:
-	///   - [[failed]] - the indexes of the prefix items that did not match the schema
+	///   - [[failed]] - the indexes of the items that did not match the schema
 	/// </remarks>
 	public static string GetPrefixItems(CultureInfo? culture)
 	{
@@ -706,7 +728,10 @@ public static partial class ErrorMessages
 	/// Gets the error message for <see cref="PropertiesKeyword"/> for a specific culture.
 	/// </summary>
 	/// <param name="culture">The culture to retrieve.</param>
-	/// <remarks>No tokens are supported.</remarks>
+	/// <remarks>
+	///	Available tokens are:
+	///   - [[failed]] - the names of the properties that did not match the associated schema
+	/// </remarks>
 	public static string GetProperties(CultureInfo? culture)
 	{
 		return Properties ?? Get(culture);

--- a/src/JsonSchema/ErrorMessages.Keywords.cs
+++ b/src/JsonSchema/ErrorMessages.Keywords.cs
@@ -16,28 +16,6 @@ public static partial class ErrorMessages
 	}
 
 	/// <summary>
-	/// Gets or sets the error message for <see cref="Keywords.Draft06.AdditionalItemsKeyword"/>.
-	/// </summary>
-	/// <remarks>
-	///	Available tokens are:
-	///   - [[failed]] - the indexes of the items that did not match the schema
-	/// </remarks>
-	public static string? AdditionalItems { get; set; }
-
-	/// <summary>
-	/// Gets the error message for <see cref="Keywords.Draft06.AdditionalItemsKeyword"/> for a specific culture.
-	/// </summary>
-	/// <param name="culture">The culture to retrieve.</param>
-	/// <remarks>
-	///	Available tokens are:
-	///   - [[failed]] - the indexes of the items that did not match the schema
-	/// </remarks>
-	public static string GetAdditionalItems(CultureInfo? culture)
-	{
-		return AdditionalItems ?? Get(culture);
-	}
-
-	/// <summary>
 	/// Gets or sets the error message for <see cref="AdditionalPropertiesKeyword"/>.
 	/// </summary>
 	/// <remarks>

--- a/src/JsonSchema/EvaluationOptions.cs
+++ b/src/JsonSchema/EvaluationOptions.cs
@@ -60,6 +60,12 @@ public class EvaluationOptions
 	public CultureInfo? Culture { get; set; }
 
 	/// <summary>
+	/// Gets or sets whether applicators such as `properties` produce error messages.
+	/// Default is `true`.
+	/// </summary>
+	public bool IncludeApplicatorErrors { get; set; } = true;
+
+	/// <summary>
 	/// Creates a deep copy of the options.
 	/// </summary>
 	/// <param name="other">The source options.</param>
@@ -76,6 +82,7 @@ public class EvaluationOptions
 			_ignoredAnnotationTypes = other._ignoredAnnotationTypes == null
 				? null
 				: new(other._ignoredAnnotationTypes),
+			IncludeApplicatorErrors = other.IncludeApplicatorErrors
 		};
 		return options;
 	}

--- a/src/JsonSchema/Formats.cs
+++ b/src/JsonSchema/Formats.cs
@@ -145,116 +145,318 @@ public static partial class Formats
 		return new UnknownFormat(name);
 	}
 
-	private static bool IsHexChar(char ch)
-	{
-		return ('0' <= ch && ch <= '9') ||
-		       ('A' <= ch && ch <= 'F') ||
-		       ('a' <= ch && ch <= 'f');
-	}
-
-	private static bool HasValidPercentEncodedPairs(string value)
-	{
-		for (int i = 0; i < value.Length; i++)
-		{
-			if (value[i] != '%') continue;
-
-			if (i + 2 >= value.Length) return false;
-			if (!IsHexChar(value[i + 1]) || !IsHexChar(value[i + 2])) return false;
-		}
-
-		return true;
-	}
-
 	private static bool CheckAbsoluteIri(JsonElement node)
 	{
 		if (node.GetSchemaValueType() != SchemaValueType.String) return true;
-
 		var value = node.GetString()!;
-
-		foreach (var ch in value)
-		{
-			if (!IsValidForIri(ch)) return false;
-		}
-
-		if (!System.Uri.TryCreate(value, UriKind.Absolute, out var uri))
-			return false;
-
-		// Must have a proper scheme (reject UNC paths)
-		return !string.IsNullOrEmpty(uri.Scheme) && value.IndexOf(':') > 0;
+		int i = 0;
+		return TryParseUriOrIriRfc(value, ref i, isIri: true) && i == value.Length;
 	}
 
 	private static bool CheckAbsoluteUri(JsonElement node)
 	{
 		if (node.GetSchemaValueType() != SchemaValueType.String) return true;
-
 		var value = node.GetString()!;
-		if (!HasValidPercentEncodedPairs(value)) return false;
-
-		foreach (var ch in value)
-		{
-			if (!IsValidForIri(ch)) return false;
-
-			// URI must be ASCII-only (non-ASCII must be percent-encoded)
-			if (ch > 127) return false;
-		}
-
-		// Check for invalid [ or ] in userinfo (before @)
-		var atIndex = value.IndexOf('@');
-		if (atIndex > 0)
-		{
-			var schemeEnd = value.IndexOf("://");
-			if (schemeEnd >= 0)
-			{
-				var userinfo = value.Substring(schemeEnd + 3, atIndex - schemeEnd - 3);
-				if (userinfo.IndexOf('[') >= 0 || userinfo.IndexOf(']') >= 0)
-					return false;
-			}
-		}
-		
-		if (!System.Uri.TryCreate(value, UriKind.Absolute, out var uri))
-			return false;
-
-		// Must have a proper scheme (reject UNC paths)
-		return !string.IsNullOrEmpty(uri.Scheme) && value.IndexOf(':') > 0;
+		int i = 0;
+		return TryParseUriOrIriRfc(value, ref i, isIri: false) && i == value.Length;
 	}
 
 	private static bool CheckIriReference(JsonElement node)
 	{
 		if (node.GetSchemaValueType() != SchemaValueType.String) return true;
-
-		var value = node.GetString()!;
-
-		foreach (var ch in value)
-		{
-			if (!IsValidForIri(ch)) return false;
-		}
-
-		return System.Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _);
+		return TryParseUriOrIriReferenceRfc(node.GetString()!, isIri: true);
 	}
 
 	private static bool CheckUri(JsonElement node)
 	{
 		if (node.GetSchemaValueType() != SchemaValueType.String) return true;
-
-		var value = node.GetString()!;
-		if (!HasValidPercentEncodedPairs(value)) return false;
-
-		foreach (var ch in value)
-		{
-			if (!IsValidForIri(ch)) return false;
-
-			// URI-reference must be ASCII-only (non-ASCII must be percent-encoded)
-			if (ch > 127) return false;
-		}
-
-		return System.Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _);
+		return TryParseUriOrIriReferenceRfc(node.GetString()!, isIri: false);
 	}
 
-	// Reject invalid characters per RFC3987 (IRI)
-	// Must not contain: backslash, space, <, >, {, }, |, ^, `, "
-	private static bool IsValidForIri(char ch)
+	// RFC 3986/3987 character classification helpers
+	private static bool IsAlphaChar(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+	private static bool IsDigitChar(char c) => c >= '0' && c <= '9';
+	private static bool IsHexDigitChar(char c) => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+	private static bool IsUnreservedChar(char c) => IsAlphaChar(c) || IsDigitChar(c) || c == '-' || c == '.' || c == '_' || c == '~';
+	private static bool IsSubDelimChar(char c) => c is '!' or '$' or '&' or '\'' or '(' or ')' or '*' or '+' or ',' or ';' or '=';
+
+	// ucschar (RFC 3987) — BMP ranges; non-BMP handled via surrogate pairs in ConsumeSegmentRfc
+	private static bool IsUcscharBmp(char c)
+		=> (c >= '\xA0' && c <= '\uD7FF') ||
+		   (c >= '\uF900' && c <= '\uFDCF') ||
+		   (c >= '\uFDD0' && c <= '\uFDEF') ||
+		   (c >= '\uFFF0' && c <= '\uFFFD');
+
+	// iprivate BMP range (RFC 3987): %xE000-F8FF
+	private static bool IsIprivateBmp(char c) => c >= '\uE000' && c <= '\uF8FF';
+
+	// URI / IRI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+	private static bool TryParseUriOrIriRfc(string s, ref int i, bool isIri)
 	{
-		return ch is not ('\\' or ' ' or '<' or '>' or '{' or '}' or '|' or '^' or '`' or '"');
+		if (!TryParseSchemeRfc(s, ref i)) return false;
+		if (i >= s.Length || s[i] != ':') return false;
+		i++;
+		if (!TryParseHierPartRfc(s, ref i, isIri)) return false;
+		if (i < s.Length && s[i] == '?') { i++; ConsumeQueryOrFragmentRfc(s, ref i, isIri, isQuery: true); }
+		if (i < s.Length && s[i] == '#') { i++; ConsumeQueryOrFragmentRfc(s, ref i, isIri, isQuery: false); }
+		return true;
+	}
+
+	// URI-reference / IRI-reference = URI / relative-ref
+	private static bool TryParseUriOrIriReferenceRfc(string s, bool isIri)
+	{
+		int i = 0;
+		if (TryParseUriOrIriRfc(s, ref i, isIri) && i == s.Length) return true;
+		i = 0;
+		if (!TryParseRelativePartRfc(s, ref i, isIri)) return false;
+		if (i < s.Length && s[i] == '?') { i++; ConsumeQueryOrFragmentRfc(s, ref i, isIri, isQuery: true); }
+		if (i < s.Length && s[i] == '#') { i++; ConsumeQueryOrFragmentRfc(s, ref i, isIri, isQuery: false); }
+		return i == s.Length;
+	}
+
+	// scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+	private static bool TryParseSchemeRfc(string s, ref int i)
+	{
+		if (i >= s.Length || !IsAlphaChar(s[i])) return false;
+		i++;
+		while (i < s.Length && (IsAlphaChar(s[i]) || IsDigitChar(s[i]) || s[i] == '+' || s[i] == '-' || s[i] == '.'))
+			i++;
+		return true;
+	}
+
+	// hier-part = "//" authority path-abempty / path-absolute / path-rootless / path-empty
+	private static bool TryParseHierPartRfc(string s, ref int i, bool isIri)
+	{
+		if (i + 1 < s.Length && s[i] == '/' && s[i + 1] == '/')
+		{
+			i += 2;
+			if (!TryParseAuthorityRfc(s, ref i, isIri)) return false;
+			return TryParsePathAbemptyRfc(s, ref i, isIri);
+		}
+		if (i < s.Length && s[i] == '/') return TryParsePathAbsoluteRfc(s, ref i, isIri);
+		return TryParsePathRootlessOrEmptyRfc(s, ref i, isIri);
+	}
+
+	// relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
+	private static bool TryParseRelativePartRfc(string s, ref int i, bool isIri)
+	{
+		if (i + 1 < s.Length && s[i] == '/' && s[i + 1] == '/')
+		{
+			i += 2;
+			if (!TryParseAuthorityRfc(s, ref i, isIri)) return false;
+			return TryParsePathAbemptyRfc(s, ref i, isIri);
+		}
+		if (i < s.Length && s[i] == '/') return TryParsePathAbsoluteRfc(s, ref i, isIri);
+		return TryParsePathNoschemeOrEmptyRfc(s, ref i, isIri);
+	}
+
+	// authority = [ userinfo "@" ] host [ ":" port ]
+	private static bool TryParseAuthorityRfc(string s, ref int i, bool isIri)
+	{
+		int authorityStart = i;
+		while (i < s.Length && s[i] != '/' && s[i] != '?' && s[i] != '#') i++;
+		int authorityEnd = i;
+
+		// Locate the first "@" to split userinfo from host
+		int atPos = -1;
+		for (int j = authorityStart; j < authorityEnd; j++)
+		{
+			if (s[j] == '@') { atPos = j; break; }
+		}
+
+		int hostStart = authorityStart;
+		if (atPos >= 0)
+		{
+			// Validate userinfo: *( unreserved / pct-encoded / sub-delims / ":" )
+			int k = authorityStart;
+			while (k < atPos)
+			{
+				char c = s[k];
+				if (IsUnreservedChar(c) || IsSubDelimChar(c) || c == ':') { k++; continue; }
+				if (c == '%')
+				{
+					if (k + 2 < atPos && IsHexDigitChar(s[k + 1]) && IsHexDigitChar(s[k + 2])) { k += 3; continue; }
+					return false;
+				}
+				if (isIri && IsUcscharBmp(c)) { k++; continue; }
+				if (isIri && char.IsHighSurrogate(c) && k + 1 < atPos && char.IsLowSurrogate(s[k + 1])) { k += 2; continue; }
+				return false;
+			}
+			hostStart = atPos + 1;
+		}
+
+		// Find port separator; IP-literals "[...]" may contain ":" internally
+		int portColon = -1;
+		if (hostStart < authorityEnd && s[hostStart] == '[')
+		{
+			int closeBracket = -1;
+			for (int j = hostStart + 1; j < authorityEnd; j++)
+			{
+				if (s[j] == ']') { closeBracket = j; break; }
+			}
+			if (closeBracket < 0) return false;
+			int afterBracket = closeBracket + 1;
+			if (afterBracket < authorityEnd)
+			{
+				if (s[afterBracket] == ':') portColon = afterBracket;
+				else return false;
+			}
+		}
+		else
+		{
+			for (int j = hostStart; j < authorityEnd; j++)
+			{
+				if (s[j] == ':') { portColon = j; break; }
+			}
+		}
+
+		int hostEnd = portColon >= 0 ? portColon : authorityEnd;
+		if (!TryParseHostRfc(s, hostStart, hostEnd, isIri)) return false;
+
+		// port = *DIGIT
+		if (portColon >= 0)
+		{
+			for (int j = portColon + 1; j < authorityEnd; j++)
+			{
+				if (!IsDigitChar(s[j])) return false;
+			}
+		}
+
+		return true;
+	}
+
+	// host = IP-literal / reg-name  (IPv4address is syntactically a subset of reg-name)
+	private static bool TryParseHostRfc(string s, int start, int end, bool isIri)
+	{
+		if (start == end) return true; // empty host is valid
+
+		if (s[start] == '[')
+		{
+			// IP-literal = "[" ( IPv6address / IPvFuture ) "]"
+			if (s[end - 1] != ']') return false;
+			var inner = s.Substring(start + 1, end - start - 2);
+			if (inner.Length == 0) return false;
+			if (inner[0] == 'v' || inner[0] == 'V') return TryParseIPvFutureRfc(inner);
+			return System.Net.IPAddress.TryParse(inner, out var addr) &&
+			       addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6;
+		}
+
+		// reg-name = *( unreserved / pct-encoded / sub-delims )
+		for (int i = start; i < end;)
+		{
+			char c = s[i];
+			if (IsUnreservedChar(c) || IsSubDelimChar(c)) { i++; continue; }
+			if (c == '%')
+			{
+				if (i + 2 < end && IsHexDigitChar(s[i + 1]) && IsHexDigitChar(s[i + 2])) { i += 3; continue; }
+				return false;
+			}
+			if (isIri && IsUcscharBmp(c)) { i++; continue; }
+			if (isIri && char.IsHighSurrogate(c) && i + 1 < end && char.IsLowSurrogate(s[i + 1])) { i += 2; continue; }
+			return false;
+		}
+		return true;
+	}
+
+	// IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+	private static bool TryParseIPvFutureRfc(string s)
+	{
+		int i = 1; // s[0] is 'v'/'V'
+		if (i >= s.Length || !IsHexDigitChar(s[i])) return false;
+		while (i < s.Length && IsHexDigitChar(s[i])) i++;
+		if (i >= s.Length || s[i] != '.') return false;
+		i++;
+		if (i >= s.Length) return false;
+		while (i < s.Length)
+		{
+			char c = s[i];
+			if (IsUnreservedChar(c) || IsSubDelimChar(c) || c == ':') { i++; continue; }
+			return false;
+		}
+		return true;
+	}
+
+	// path-abempty = *( "/" segment )
+	private static bool TryParsePathAbemptyRfc(string s, ref int i, bool isIri)
+	{
+		while (i < s.Length && s[i] == '/')
+		{
+			i++;
+			ConsumeSegmentRfc(s, ref i, isIri);
+		}
+		return true;
+	}
+
+	// path-absolute = "/" [ segment-nz *( "/" segment ) ]
+	private static bool TryParsePathAbsoluteRfc(string s, ref int i, bool isIri)
+	{
+		i++; // consume leading '/'
+		if (i < s.Length && s[i] != '/' && s[i] != '?' && s[i] != '#')
+		{
+			int before = i;
+			ConsumeSegmentRfc(s, ref i, isIri);
+			if (i == before) return false; // segment-nz needs at least one pchar
+			TryParsePathAbemptyRfc(s, ref i, isIri);
+		}
+		return true;
+	}
+
+	// path-rootless = segment-nz *( "/" segment )  or  path-empty
+	private static bool TryParsePathRootlessOrEmptyRfc(string s, ref int i, bool isIri)
+	{
+		if (i >= s.Length || s[i] == '?' || s[i] == '#') return true;
+		int before = i;
+		ConsumeSegmentRfc(s, ref i, isIri);
+		if (i == before) return false;
+		TryParsePathAbemptyRfc(s, ref i, isIri);
+		return true;
+	}
+
+	// path-noscheme = segment-nz-nc *( "/" segment )  or  path-empty
+	// segment-nz-nc: 1*( unreserved / pct-encoded / sub-delims / "@" ) — no ":"
+	private static bool TryParsePathNoschemeOrEmptyRfc(string s, ref int i, bool isIri)
+	{
+		if (i >= s.Length || s[i] == '?' || s[i] == '#') return true;
+		int before = i;
+		ConsumeSegmentRfc(s, ref i, isIri, allowColon: false);
+		if (i == before) return false;
+		TryParsePathAbemptyRfc(s, ref i, isIri);
+		return true;
+	}
+
+	// segment = *pchar;  pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+	private static void ConsumeSegmentRfc(string s, ref int i, bool isIri, bool allowColon = true)
+	{
+		while (i < s.Length)
+		{
+			char c = s[i];
+			if (IsUnreservedChar(c) || IsSubDelimChar(c) || c == '@') { i++; continue; }
+			if (allowColon && c == ':') { i++; continue; }
+			if (c == '%')
+			{
+				if (i + 2 < s.Length && IsHexDigitChar(s[i + 1]) && IsHexDigitChar(s[i + 2])) { i += 3; continue; }
+				break;
+			}
+			if (isIri && IsUcscharBmp(c)) { i++; continue; }
+			if (isIri && char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1])) { i += 2; continue; }
+			break;
+		}
+	}
+
+	// query = *( pchar / "/" / "?" )  ;  fragment = *( pchar / "/" / "?" )
+	// For IRI query, iprivate characters are also allowed.
+	private static void ConsumeQueryOrFragmentRfc(string s, ref int i, bool isIri, bool isQuery)
+	{
+		while (i < s.Length)
+		{
+			char c = s[i];
+			if (c == '/' || c == '?') { i++; continue; }
+			if (isQuery && isIri && IsIprivateBmp(c)) { i++; continue; }
+			if (isQuery && isIri && char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1])) { i += 2; continue; }
+			int prev = i;
+			ConsumeSegmentRfc(s, ref i, isIri);
+			if (i == prev) break;
+		}
 	}
 
 	private static bool CheckUriTemplate(JsonElement node)

--- a/src/JsonSchema/JsonSchema.csproj
+++ b/src/JsonSchema/JsonSchema.csproj
@@ -17,7 +17,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <PackageId>JsonSchema.Net</PackageId>
-    <JsonSchemaNetVersion>9.3.0</JsonSchemaNetVersion>
+    <JsonSchemaNetVersion>9.4.0</JsonSchemaNetVersion>
     <AssemblyVersion>9.0.0.0</AssemblyVersion>
     <FileVersion>$(JsonSchemaNetVersion)</FileVersion>
     <Version>$(JsonSchemaNetVersion)</Version>
@@ -90,52 +90,52 @@
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'de'">
     <Description>JsonSchema.Net Locale German (de)</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'es'">
     <Description>JsonSchema.Net Locale Spanish (es)</Description>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'it'">
     <Description>JsonSchema.Net Locale Italian (it)</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'ko'">
     <Description>JsonSchema.Net Locale Korean (ko)</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'nb-NO'">
     <Description>JsonSchema.Net Locale Norwegian (nb-NO)</Description>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'pl-PL'">
     <Description>JsonSchema.Net Locale Polish (pl-PL)</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'pt'">
     <Description>JsonSchema.Net Locale Portuguese (pt)</Description>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'ru'">
     <Description>JsonSchema.Net Locale Russian (ru)</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'sv-SE'">
     <Description>JsonSchema.Net Locale Swedish (sv-SE)</Description>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ResourceLanguage)' == 'tr-TR'">
     <Description>JsonSchema.Net Locale Turkish (tr-TR)</Description>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/JsonSchema/Keywords/AdditionalPropertiesKeyword.cs
+++ b/src/JsonSchema/Keywords/AdditionalPropertiesKeyword.cs
@@ -140,7 +140,7 @@ public class AdditionalPropertiesKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonElementExtensions.True,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetAdditionalProperties(context.Options.Culture)
 					.ReplaceToken("failed", failedProperties, JsonSchemaSerializerContext.Default.HashSetString)

--- a/src/JsonSchema/Keywords/AllOfKeyword.cs
+++ b/src/JsonSchema/Keywords/AllOfKeyword.cs
@@ -108,19 +108,20 @@ public class AllOfKeyword : IKeywordHandler
 			i++;
 		}
 
+		var isValid = subschemaEvaluations.Count == 0 || subschemaEvaluations.All(x => x.IsValid);
 		return new KeywordEvaluation
 		{
 			Keyword = Name,
-			IsValid = subschemaEvaluations.Count == 0 || subschemaEvaluations.All(x => x.IsValid),
+			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
-			Error = subschemaEvaluations.Count != 0 && subschemaEvaluations.Any(x => !x.IsValid)
-				? ErrorMessages.GetAllOf(context.Options.Culture)
+			Error = isValid || !context.Options.IncludeApplicatorErrors
+				? null
+				: ErrorMessages.GetAllOf(context.Options.Culture)
 					.ReplaceToken("failed", subschemaEvaluations
 						.Select((r, idx) => (r, idx))
 						.Where(x => !x.r.IsValid)
 						.Select(x => x.idx)
 						.ToArray(), JsonSchemaSerializerContext.Default.Int32Array)
-				: null
 		};
 	}
 }

--- a/src/JsonSchema/Keywords/AnyOfKeyword.cs
+++ b/src/JsonSchema/Keywords/AnyOfKeyword.cs
@@ -116,7 +116,7 @@ public class AnyOfKeyword : IKeywordHandler
 			Keyword = Name,
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetAnyOf(context.Options.Culture)
 		};

--- a/src/JsonSchema/Keywords/Draft06/AdditionalItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/Draft06/AdditionalItemsKeyword.cs
@@ -104,7 +104,7 @@ public class AdditionalItemsKeyword : IKeywordHandler
 			Annotation = JsonElementExtensions.True,
 			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
-				: ErrorMessages.GetAdditionalItems(context.Options.Culture)
+				: ErrorMessages.GetItems(context.Options.Culture)
 					.ReplaceToken("failed", subschemaEvaluations
 						.Select((r, idx) => (r, idx))
 						.Where(x => !x.r.IsValid)

--- a/src/JsonSchema/Keywords/Draft06/AdditionalItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/Draft06/AdditionalItemsKeyword.cs
@@ -95,12 +95,21 @@ public class AdditionalItemsKeyword : IKeywordHandler
 			i++;
 		}
 
+		var isValid = subschemaEvaluations.Count == 0 || subschemaEvaluations.All(x => x.IsValid);
 		return new KeywordEvaluation
 		{
 			Keyword = Name,
-			IsValid = subschemaEvaluations.Count == 0 || subschemaEvaluations.All(x => x.IsValid),
+			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
-			Annotation = JsonElementExtensions.True
+			Annotation = JsonElementExtensions.True,
+			Error = isValid || !context.Options.IncludeApplicatorErrors
+				? null
+				: ErrorMessages.GetAdditionalItems(context.Options.Culture)
+					.ReplaceToken("failed", subschemaEvaluations
+						.Select((r, idx) => (r, idx))
+						.Where(x => !x.r.IsValid)
+						.Select(x => itemsCount.Value + x.idx)
+						.ToArray(), JsonSchemaSerializerContext.Default.Int32Array)
 		};
 	}
 }

--- a/src/JsonSchema/Keywords/Draft06/ItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/Draft06/ItemsKeyword.cs
@@ -154,7 +154,7 @@ public class ItemsKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = annotation,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetItems(context.Options.Culture)
 					.ReplaceToken("failed", subschemaEvaluations.Select((r, i) => (r, i))

--- a/src/JsonSchema/Keywords/Draft201909/UnevaluatedItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/Draft201909/UnevaluatedItemsKeyword.cs
@@ -107,7 +107,7 @@ public class UnevaluatedItemsKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonElementExtensions.True,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetUnevaluatedItems(context.Options.Culture)
 					.ReplaceToken("failed", failedIndexes.ToArray(), JsonSchemaSerializerContext.Default.Int32Array)

--- a/src/JsonSchema/Keywords/ElseKeyword.cs
+++ b/src/JsonSchema/Keywords/ElseKeyword.cs
@@ -83,7 +83,7 @@ public class ElseKeyword : IKeywordHandler
 			Keyword = Name,
 			IsValid = result.IsValid,
 			Details = [result],
-			Error = result.IsValid
+			Error = result.IsValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetElse(context.Options.Culture)
 		};

--- a/src/JsonSchema/Keywords/ItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/ItemsKeyword.cs
@@ -107,7 +107,7 @@ public class ItemsKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonElementExtensions.True,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetItems(context.Options.Culture)
 					.ReplaceToken("failed", subschemaEvaluations

--- a/src/JsonSchema/Keywords/NotKeyword.cs
+++ b/src/JsonSchema/Keywords/NotKeyword.cs
@@ -71,13 +71,13 @@ public class NotKeyword : IKeywordHandler
 		};
 		var result = subschema.Evaluate(oneOfContext);
 
-		var keywordPassed = !result.IsValid;
+		var isValid = !result.IsValid;
 		return new KeywordEvaluation
 		{
 			Keyword = Name,
-			IsValid = keywordPassed,
+			IsValid = isValid,
 			Details = [result],
-			Error = keywordPassed
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetNot(context.Options.Culture)
 		};

--- a/src/JsonSchema/Keywords/OneOfKeyword.cs
+++ b/src/JsonSchema/Keywords/OneOfKeyword.cs
@@ -118,7 +118,7 @@ public class OneOfKeyword : IKeywordHandler
 			Keyword = Name,
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetOneOf(context.Options.Culture)
 					.ReplaceToken("count", matchCount)

--- a/src/JsonSchema/Keywords/PatternPropertiesKeyword.cs
+++ b/src/JsonSchema/Keywords/PatternPropertiesKeyword.cs
@@ -134,7 +134,7 @@ public class PatternPropertiesKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonSerializer.SerializeToElement(propertyNames, JsonSchemaSerializerContext.Default.HashSetString),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetPatternProperties(context.Options.Culture)
 					.ReplaceToken("failed", failedProperties, JsonSchemaSerializerContext.Default.HashSetString)

--- a/src/JsonSchema/Keywords/PrefixItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/PrefixItemsKeyword.cs
@@ -113,7 +113,7 @@ public class PrefixItemsKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = (subschemaEvaluations.Count - 1).AsJsonElement(),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetPrefixItems(context.Options.Culture)
 					.ReplaceToken("failed", subschemaEvaluations

--- a/src/JsonSchema/Keywords/PropertiesKeyword.cs
+++ b/src/JsonSchema/Keywords/PropertiesKeyword.cs
@@ -79,6 +79,7 @@ public class PropertiesKeyword : IKeywordHandler
 
 		var subschemaEvaluations = new List<EvaluationResults>();
 		var propertyNames = new HashSet<string>();
+		var failedProperties = new HashSet<string>();
 
 		foreach (var subschema in keyword.Subschemas)
 		{
@@ -97,6 +98,8 @@ public class PropertiesKeyword : IKeywordHandler
 
 			var local = subschema.Evaluate(propContext);
 			subschemaEvaluations.Add(local);
+			if (!local.IsValid)
+				failedProperties.Add(propertyName);
 
 			if (context.CanOptimize && !local.IsValid)
 				return new KeywordEvaluation
@@ -113,9 +116,10 @@ public class PropertiesKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonSerializer.SerializeToElement(propertyNames, JsonSchemaSerializerContext.Default.HashSetString),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetProperties(context.Options.Culture)
+					.ReplaceToken("failed", failedProperties, JsonSchemaSerializerContext.Default.HashSetString)
 		};
 	}
 }

--- a/src/JsonSchema/Keywords/PropertyDependenciesKeyword.cs
+++ b/src/JsonSchema/Keywords/PropertyDependenciesKeyword.cs
@@ -99,7 +99,7 @@ public class PropertyDependenciesKeyword : IKeywordHandler
 			Keyword = Name,
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetPropertyDependencies(context.Options.Culture)
 					.ReplaceToken("failed", failedProperties, JsonSchemaSerializerContext.Default.HashSetString)

--- a/src/JsonSchema/Keywords/ThenKeyword.cs
+++ b/src/JsonSchema/Keywords/ThenKeyword.cs
@@ -83,7 +83,7 @@ public class ThenKeyword : IKeywordHandler
 			Keyword = Name,
 			IsValid = result.IsValid,
 			Details = [result],
-			Error = result.IsValid
+			Error = result.IsValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetThen(context.Options.Culture)
 		};

--- a/src/JsonSchema/Keywords/UnevaluatedItemsKeyword.cs
+++ b/src/JsonSchema/Keywords/UnevaluatedItemsKeyword.cs
@@ -110,7 +110,7 @@ public class UnevaluatedItemsKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonElementExtensions.True,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetUnevaluatedItems(context.Options.Culture)
 					.ReplaceToken("failed", failedIndexes.ToArray(), JsonSchemaSerializerContext.Default.Int32Array)

--- a/src/JsonSchema/Keywords/UnevaluatedPropertiesKeyword.cs
+++ b/src/JsonSchema/Keywords/UnevaluatedPropertiesKeyword.cs
@@ -110,7 +110,7 @@ public class UnevaluatedPropertiesKeyword : IKeywordHandler
 			IsValid = isValid,
 			Details = subschemaEvaluations.ToArray(),
 			Annotation = JsonElementExtensions.True,
-			Error = isValid
+			Error = isValid || !context.Options.IncludeApplicatorErrors
 				? null
 				: ErrorMessages.GetUnevaluatedProperties(context.Options.Culture)
 					.ReplaceToken("failed", failedProperties, JsonSchemaSerializerContext.Default.HashSetString)

--- a/src/JsonSchema/Localization/Resources.de.resx
+++ b/src/JsonSchema/Localization/Resources.de.resx
@@ -201,4 +201,46 @@
     <data name="Error_UnknownVocabularies" xml:space="preserve">
       <value>Validator weiß nichts über folgende, notwendige Vokabulare: [[vocabs]]</value>
     </data>
+    <data name="Error_AdditionalProperties" xml:space="preserve">
+      <value>Einige zusätzliche Felder entsprechen nicht dem erforderlichen Schema: [[failed]]</value>
+    </data>
+    <data name="Error_AllOf" xml:space="preserve">
+      <value>Wert passt nicht zu allen angegebenen Schemas; fehlgeschlagene Schema-Indizes: [[failed]]</value>
+    </data>
+    <data name="Error_AnyOf" xml:space="preserve">
+      <value>Wert passt zu keinem der angegebenen Schemas</value>
+    </data>
+    <data name="Error_Else" xml:space="preserve">
+      <value>Das if-Unterschema ist fehlgeschlagen, aber das else-Unterschema hat bestanden</value>
+    </data>
+    <data name="Error_Items" xml:space="preserve">
+      <value>Einige Elemente entsprechen nicht dem erforderlichen Schema; fehlgeschlagene Indizes: [[failed]]</value>
+    </data>
+    <data name="Error_Not" xml:space="preserve">
+      <value>Das Unterschema hat die Auswertung bestanden, wurde aber erwartet zu scheitern</value>
+    </data>
+    <data name="Error_PatternProperties" xml:space="preserve">
+      <value>Einige Felder entsprechen nicht ihren musterbasierten Schemas: [[failed]]</value>
+    </data>
+    <data name="Error_PrefixItems" xml:space="preserve">
+      <value>Einige Präfix-Elemente entsprechen nicht dem erforderlichen Schema; fehlgeschlagene Indizes: [[failed]]</value>
+    </data>
+    <data name="Error_Properties" xml:space="preserve">
+      <value>Einige Felder entsprechen nicht dem erforderlichen Schema: [[failed]]</value>
+    </data>
+    <data name="Error_PropertyDependencies" xml:space="preserve">
+      <value>Einige Felder haben ihre Eigenschaftsabhängigkeiten nicht erfüllt: [[failed]]</value>
+    </data>
+    <data name="Error_PropertyNames" xml:space="preserve">
+      <value>Einige Feldnamen entsprechen nicht dem erforderlichen Schema: [[failed]]</value>
+    </data>
+    <data name="Error_Then" xml:space="preserve">
+      <value>Die if-Bedingung hat bestanden, aber das then-Schema nicht</value>
+    </data>
+    <data name="Error_UnevaluatedItems" xml:space="preserve">
+      <value>Einige nicht ausgewertete Elemente entsprechen nicht dem erforderlichen Schema; fehlgeschlagene Indizes: [[failed]]</value>
+    </data>
+    <data name="Error_UnevaluatedProperties" xml:space="preserve">
+      <value>Einige nicht ausgewertete Felder entsprechen nicht dem erforderlichen Schema: [[failed]]</value>
+    </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.es.resx
+++ b/src/JsonSchema/Localization/Resources.es.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>El validador no conoce estos vocabularios obligatorios: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Algunas propiedades adicionales no coinciden con el esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>El valor no coincide con todos los esquemas especificados; índices de esquemas fallidos: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>El valor no coincide con ninguno de los esquemas especificados</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>El subesquema if falló, pero el subesquema else pasó</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Algunos elementos no coinciden con el esquema requerido; índices fallidos: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>El subesquema pasó la evaluación pero se esperaba que fallara</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Algunas propiedades no coinciden con sus esquemas basados en patrones: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Algunos elementos de prefijo no coinciden con el esquema requerido; índices fallidos: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Algunas propiedades no coinciden con el esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Algunas propiedades fallaron en sus dependencias de propiedad: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Algunos nombres de propiedad no coinciden con el esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>La condición if pasó, pero el esquema then no</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Algunos elementos no evaluados no coinciden con el esquema requerido; índices fallidos: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Algunas propiedades no evaluadas no coinciden con el esquema requerido: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.it.resx
+++ b/src/JsonSchema/Localization/Resources.it.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Il validatore non è a conoscenza dei seguenti vocabolari richiesti: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Alcune proprietà aggiuntive non corrispondono allo schema richiesto: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Il valore non corrisponde a tutti gli schemi specificati; indici degli schemi falliti: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Il valore non corrisponde a nessuno degli schemi specificati</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>Il sottoschema if ha fallito, ma il sottoschema else ha avuto successo</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Alcuni elementi non corrispondono allo schema richiesto; indici falliti: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Il sottoschema ha superato la valutazione ma si aspettava che fallisse</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Alcune proprietà non corrispondono ai loro schemi basati su pattern: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Alcuni elementi di prefisso non corrispondono allo schema richiesto; indici falliti: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Alcune proprietà non corrispondono allo schema richiesto: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Alcune proprietà hanno fallito nelle loro dipendenze di proprietà: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Alcuni nomi di proprietà non corrispondono allo schema richiesto: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>La condizione if ha avuto successo, ma lo schema then no</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Alcuni elementi non valutati non corrispondono allo schema richiesto; indici falliti: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Alcune proprietà non valutate non corrispondono allo schema richiesto: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.ko.resx
+++ b/src/JsonSchema/Localization/Resources.ko.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>유효성 검사기는 다음 필수 어휘를 모릅니다: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>일부 추가 속성이 필수 스키마와 일치하지 않습니다: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>값이 지정된 모든 스키마와 일치하지 않습니다; 실패한 스키마 인덱스: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>값이 지정된 스키마 중 어느 것과도 일치하지 않습니다</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>if 하위 스키마가 실패했지만 else 하위 스키마가 통과했습니다</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>일부 항목이 필수 스키마와 일치하지 않습니다; 실패한 인덱스: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>하위 스키마가 평가를 통과했지만 실패할 것으로 예상되었습니다</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>일부 속성이 패턴 기반 스키마와 일치하지 않습니다: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>일부 접두사 항목이 필수 스키마와 일치하지 않습니다; 실패한 인덱스: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>일부 속성이 필수 스키마와 일치하지 않습니다: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>일부 속성이 속성 종속성에 실패했습니다: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>일부 속성 이름이 필수 스키마와 일치하지 않습니다: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>if 조건이 통과했지만 then 스키마가 통과하지 못했습니다</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>일부 평가되지 않은 항목이 필수 스키마와 일치하지 않습니다; 실패한 인덱스: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>일부 평가되지 않은 속성이 필수 스키마와 일치하지 않습니다: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.nb-NO.resx
+++ b/src/JsonSchema/Localization/Resources.nb-NO.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Valideringen kjenner ikke til nødvendige vokabular: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Noen tilleggsattributter samsvarer ikke med det påkrevde skjema: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Verdi samsvarer ikke med alle spesifiserte skjemaer; indekser for mislykkede skjemaer: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Verdi samsvarer ikke med noen av de spesifiserte skjemaene</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>if-delskjemaet mislyktes, men else-delskjemaet besto</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Noen elementer samsvarer ikke med det påkrevde skjema; mislykkede indekser: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Delskjemaet besto evalueringen, men forventet å mislykkes</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Noen attributter samsvarer ikke med sine mønsterbaserte skjemaer: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Noen prefikselementer samsvarer ikke med det påkrevde skjema; mislykkede indekser: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Noen attributter samsvarer ikke med det påkrevde skjema: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Noen attributter mislyktes i sine egenskapsavhengigheter: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Noen attributtnavn samsvarer ikke med det påkrevde skjema: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>if-betingelsen besto, men then-skjemaet gjorde det ikke</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Noen ubehandlede elementer samsvarer ikke med det påkrevde skjema; mislykkede indekser: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Noen ubehandlede attributter samsvarer ikke med det påkrevde skjema: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.pl-PL.resx
+++ b/src/JsonSchema/Localization/Resources.pl-PL.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Walidator nie ma informacji o wymaganych słownikach: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Niektóre dodatkowe właściwości nie pasują do wymaganego schematu: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Wartość nie pasuje do wszystkich określonych schematów; indeksy nieudanych schematów: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Wartość nie pasuje do żadnego z określonych schematów</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>Podschema if nie powiodło się, ale podschema else przeszło</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Niektóre elementy nie pasują do wymaganego schematu; nieudane indeksy: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Podschema przeszło ewaluację, ale oczekiwano, że nie powiedzie się</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Niektóre właściwości nie pasują do swoich schematów opartych na wzorcach: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Niektóre elementy prefiksu nie pasują do wymaganego schematu; nieudane indeksy: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Niektóre właściwości nie pasują do wymaganego schematu: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Niektóre właściwości nie spełniły swoich zależności właściwości: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Niektóre nazwy właściwości nie pasują do wymaganego schematu: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>Warunek if przeszedł, ale schemat then nie</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Niektóre nieocenione elementy nie pasują do wymaganego schematu; nieudane indeksy: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Niektóre nieocenione właściwości nie pasują do wymaganego schematu: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.pt.resx
+++ b/src/JsonSchema/Localization/Resources.pt.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>O validador não reconhece os seguintes vocabulários obrigatórios: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Algumas propriedades adicionais não correspondem ao esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>O valor não corresponde a todos os esquemas especificados; índices de esquemas falhados: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>O valor não corresponde a nenhum dos esquemas especificados</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>O subesquema if falhou, mas o subesquema else passou</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Alguns itens não correspondem ao esquema requerido; índices falhados: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>O subesquema passou a avaliação mas era esperado que falhasse</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Algumas propriedades não correspondem aos seus esquemas baseados em padrões: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Alguns itens de prefixo não correspondem ao esquema requerido; índices falhados: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Algumas propriedades não correspondem ao esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Algumas propriedades falharam nas suas dependências de propriedade: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Alguns nomes de propriedade não correspondem ao esquema requerido: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>A condição if passou, mas o esquema then não</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Alguns itens não avaliados não correspondem ao esquema requerido; índices falhados: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Algumas propriedades não avaliadas não correspondem ao esquema requerido: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.resx
+++ b/src/JsonSchema/Localization/Resources.resx
@@ -211,7 +211,7 @@
     <value>Some prefix items do not match the required schema; failing indexes: [[failed]]</value>
   </data>
   <data name="Error_Properties" xml:space="preserve">
-    <value>Some properties did not match the required schema</value>
+    <value>Some properties did not match the required schema: [[failed]]</value>
   </data>
   <data name="Error_PropertyDependencies" xml:space="preserve">
     <value>Some properties failed their property dependencies: [[failed]]</value>

--- a/src/JsonSchema/Localization/Resources.ru.resx
+++ b/src/JsonSchema/Localization/Resources.ru.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Валидатор не может определить запрашиваемый справочник: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Некоторые дополнительные свойства не соответствуют требуемой схеме: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Значение не соответствует всем указанным схемам; индексы неудачных схем: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Значение не соответствует ни одной из указанных схем</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>Подсхема if не прошла проверку, но подсхема else прошла</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Некоторые элементы не соответствуют требуемой схеме; неудачные индексы: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Подсхема прошла проверку, но ожидалось, что она не пройдет</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Некоторые свойства не соответствуют своим схемам на основе шаблонов: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Некоторые элементы префикса не соответствуют требуемой схеме; неудачные индексы: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Некоторые свойства не соответствуют требуемой схеме: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Некоторые свойства не прошли проверку зависимостей свойств: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Некоторые имена свойств не соответствуют требуемой схеме: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>Условие if прошло проверку, но схема then не прошла</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Некоторые непроверенные элементы не соответствуют требуемой схеме; неудачные индексы: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Некоторые непроверенные свойства не соответствуют требуемой схеме: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.sv-SE.resx
+++ b/src/JsonSchema/Localization/Resources.sv-SE.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Valideringen känner inte till dessa vokabulär: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Vissa ytterligare egenskaper matchade inte det obligatoriska schemat: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Värdet matchar inte alla angivna scheman; misslyckade schemaindex: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Värdet matchar inte något av de angivna scheman</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>if-delschemat misslyckades, men else-delschemat klarade sig</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Vissa objekt matchar inte det obligatoriska schemat; misslyckade index: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Delschemat klarade utvärderingen men förväntades misslyckas</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Vissa egenskaper matchade inte sina mönsterbaserade scheman: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Vissa prefixobjekt matchar inte det obligatoriska schemat; misslyckade index: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Vissa egenskaper matchade inte det obligatoriska schemat: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Vissa egenskaper misslyckades i sina egenskapsberoenden: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Vissa egenskapsnamn matchade inte det obligatoriska schemat: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>if-villkoret klarade sig, men then-schemat gjorde det inte</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Vissa outvärdererade objekt matchar inte det obligatoriska schemat; misslyckade index: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Vissa outvärdererade egenskaper matchar inte det obligatoriska schemat: [[failed]]</value>
+  </data>
 </root>

--- a/src/JsonSchema/Localization/Resources.tr-TR.resx
+++ b/src/JsonSchema/Localization/Resources.tr-TR.resx
@@ -201,4 +201,46 @@
   <data name="Error_UnknownVocabularies" xml:space="preserve">
     <value>Doğrulayıcı şu gerekli kelimeler hakkında bilgi sahibi değil: [[vocabs]]</value>
   </data>
+  <data name="Error_AdditionalProperties" xml:space="preserve">
+    <value>Bazı ek özellikler gerekli şemayla eşleşmedi: [[failed]]</value>
+  </data>
+  <data name="Error_AllOf" xml:space="preserve">
+    <value>Değer, belirtilen tüm şemalarla eşleşmiyor; başarısız şema dizinleri: [[failed]]</value>
+  </data>
+  <data name="Error_AnyOf" xml:space="preserve">
+    <value>Değer, belirtilen şemaların hiçbiriyle eşleşmiyor</value>
+  </data>
+  <data name="Error_Else" xml:space="preserve">
+    <value>if alt şeması başarısız oldu, ancak else alt şeması başarılı oldu</value>
+  </data>
+  <data name="Error_Items" xml:space="preserve">
+    <value>Bazı öğeler gerekli şemayla eşleşmiyor; başarısız dizinler: [[failed]]</value>
+  </data>
+  <data name="Error_Not" xml:space="preserve">
+    <value>Alt şema değerlendirmeyi geçti ancak başarısız olması bekleniyordu</value>
+  </data>
+  <data name="Error_PatternProperties" xml:space="preserve">
+    <value>Bazı özellikler, desen tabanlı şemalarıyla eşleşmedi: [[failed]]</value>
+  </data>
+  <data name="Error_PrefixItems" xml:space="preserve">
+    <value>Bazı önek öğeleri gerekli şemayla eşleşmiyor; başarısız dizinler: [[failed]]</value>
+  </data>
+  <data name="Error_Properties" xml:space="preserve">
+    <value>Bazı özellikler gerekli şemayla eşleşmedi: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyDependencies" xml:space="preserve">
+    <value>Bazı özellikler, özellik bağımlılıklarında başarısız oldu: [[failed]]</value>
+  </data>
+  <data name="Error_PropertyNames" xml:space="preserve">
+    <value>Bazı özellik adları gerekli şemayla eşleşmedi: [[failed]]</value>
+  </data>
+  <data name="Error_Then" xml:space="preserve">
+    <value>if koşulu geçti, ancak then şeması geçmedi</value>
+  </data>
+  <data name="Error_UnevaluatedItems" xml:space="preserve">
+    <value>Bazı değerlendirilmemiş öğeler gerekli şemayla eşleşmiyor; başarısız dizinler: [[failed]]</value>
+  </data>
+  <data name="Error_UnevaluatedProperties" xml:space="preserve">
+    <value>Bazı değerlendirilmemiş özellikler gerekli şemayla eşleşmiyor: [[failed]]</value>
+  </data>
 </root>

--- a/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-pointer.md
@@ -4,6 +4,10 @@ title: JsonPointer.Net
 icon: fas fa-tag
 order: "09.10"
 ---
+# [7.0.2](https://github.com/json-everything/json-everything/pull/1053) {#release-pointer-7.0.2}
+
+Bug fix: Relative JSON Pointers must begin with an ASCII number - international numerals are disallowed. Discovered while updating the JSON Schema Test Suite.
+
 # [7.0.1](https://github.com/json-everything/json-everything/pull/1013) {#release-pointer-7.0.1}
 
 Updated nuget packages & EULA.

--- a/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
+++ b/tools/ApiDocsGenerator/release-notes/rn-json-schema.md
@@ -4,6 +4,12 @@ title: JsonSchema.Net
 icon: fas fa-tag
 order: "09.01"
 ---
+# [9.4.0](https://github.com/json-everything/json-everything/pull/1053) {#release-schema-9.4.0}
+
+[#1052](https://github.com/json-everything/json-everything/issues/1052) - Adds an evaluation option to allow exclusion of error messages from applicators. Thanks to [@ladeak](https://github.com/ladeak) for reporting.
+
+[#1043](https://github.com/json-everything/json-everything/issues/1043) - Refines URI/IRI validation to only consider syntax. Thanks to [@awalterschulze](https://github.com/awalterschulze) for reporting and discussing.
+
 # [9.3.0](https://github.com/json-everything/json-everything/pull/1046) {#release-schema-9.3.0}
 
 [#1050](https://github.com/json-everything/json-everything/issues/1050) - Adds error messages for all validation keywords. Thanks to [@pawlos](https://github.com/pawlos) for reporting.


### PR DESCRIPTION
<!--
Thank you for taking the time to develop and submit improvements to the project.

Please be aware that, except in tiny cases like spelling mistakes in XML docs, it is much preferred that an issue be opened for any proposed changes so that they may be discussed before you start development.
-->

### Description

<!--
Please add a short description of the changes.  Be sure to include:
  - whether this affects the public API surface
  - whether the changes cause breaks in either developer experience or behavior
-->

Updates all test suites.

JSON Schema:

- Adds an evaluation option to allow exclusion of error messages from applicators (added in 9.3.0).
- Refines URI/IRI validation to only consider syntax, not semantics.

JSON Pointer:

- Fixes minor issue in parsing relative pointers: must start with an ASCII numeral; non-ASCII numerals are disallowed.

### Links

<!--
Please add a link to the issue(s) in the appropriate field(s) and delete the ones you don't use.
-->
Resolves #1052     <!-- Use if these changes completely resolve the issue -->
Resolved #1043

### Organization

n/a

### Checks

- [x] I have read and understand the [Code of Conduct](https://github.com/json-everything/json-everything/blob/master/CODE_OF_CONDUCT.md) and [Contribution Guidelines](https://github.com/json-everything/json-everything/blob/master/CONTRIBUTING.md).
